### PR TITLE
90f074f release note for v1.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,31 +239,31 @@ $ export GST_PLUGIN_PATH=<YourSdkFolderPath>/kinesis-video-native-build/download
 ```
 ###### 3.1 Run the following `gst-launch-1.0` command to start streaming from RTSP camera source.
 ```
-$ gst-launch-1.0 rtspsrc location=“rtsp://YourCameraRtspUrl” short-header=TRUE ! rtph264depay ! video/x-h264, format=avc,alignment=au ! kvssink stream-name=“YourStreamName” storage-size=512
+$ gst-launch-1.0 rtspsrc location=rtsp://YourCameraRtspUrl short-header=TRUE ! rtph264depay ! video/x-h264, format=avc,alignment=au ! kvssink stream-name=YourStreamName storage-size=512
 ```
 ###### 3.2 Run the following `gst-launch-1.0` command to start streaming from USB camera source in **Ubuntu**.
 
 ```
-$ gst-launch-1.0 v4l2src do-timestamp=TRUE device=/dev/video0 ! videoconvert ! video/x-raw,format=I420,width=640,height=480,framerate=30/1 ! x264enc  bframes=0 key-int-max=45 bitrate=500 ! video/x-h264,stream-format=avc,alignment=au ! kvssink stream-name="YourStreamName" storage-size=512
+$ gst-launch-1.0 v4l2src do-timestamp=TRUE device=/dev/video0 ! videoconvert ! video/x-raw,format=I420,width=640,height=480,framerate=30/1 ! x264enc  bframes=0 key-int-max=45 bitrate=500 ! video/x-h264,stream-format=avc,alignment=au ! kvssink stream-name=YourStreamName storage-size=512
 ```
 ###### 3.3 Run the following `gst-launch-1.0` command to start streaming from USB camera source which has h264 encoded stream already in **Ubuntu**.
 
 ```
-$ gst-launch-1.0 v4l2src do-timestamp=TRUE device=/dev/video0 ! h264parse ! video/x-h264,stream-format=avc,alignment=au ! kvssink stream-name="plugin" storage-size=512
+$ gst-launch-1.0 v4l2src do-timestamp=TRUE device=/dev/video0 ! h264parse ! video/x-h264,stream-format=avc,alignment=au ! kvssink stream-name=YourStreamName storage-size=512
 ```
 
 ###### 3.4 Run the following `gst-launch-1.0` command to start streaming from camera source in **Mac-OS**.
 
 ```
-$ gst-launch-1.0 autovideosrc ! videoconvert ! video/x-raw,format=I420,width=640,height=480,framerate=30/1 ! vtenc_h264_hw allow-frame-reordering=FALSE realtime=TRUE max-keyframe-interval=45 bitrate=500 ! h264parse ! video/x-h264,stream-format=avc,alignment=au,width=640,height=480,framerate=30/1 ! kvssink stream-name="YourStreamName" storage-size=512
+$ gst-launch-1.0 autovideosrc ! videoconvert ! video/x-raw,format=I420,width=640,height=480,framerate=30/1 ! vtenc_h264_hw allow-frame-reordering=FALSE realtime=TRUE max-keyframe-interval=45 bitrate=500 ! h264parse ! video/x-h264,stream-format=avc,alignment=au,width=640,height=480,framerate=30/1 ! kvssink stream-name=YourStreamName storage-size=512
 ```
 
 ###### 3.5 Run the following `gst-launch-1.0` command to start streaming from camera source in **Raspberry-PI**.
 
 ```
-$ gst-launch-1.0 v4l2src do-timestamp=TRUE device=/dev/video0 ! videoconvert ! video/x-raw,format=I420,width=640,height=480,framerate=30/1 ! omxh264enc control-rate=1 target-bitrate=5120000 periodicity-idr=45 inline-header=FALSE ! h264parse ! video/x-h264,stream-format=avc,alignment=au,width=640,height=480,framerate=30/1 ! kvssink stream-name="YourStreamName" frame-timestamp=KVS_SINK_TIMESTAMP_DTS_ONLY access-key="YourAccessKey" secret-key="YourSecretKey"
+$ gst-launch-1.0 v4l2src do-timestamp=TRUE device=/dev/video0 ! videoconvert ! video/x-raw,format=I420,width=640,height=480,framerate=30/1 ! omxh264enc control-rate=1 target-bitrate=5120000 periodicity-idr=45 inline-header=FALSE ! h264parse ! video/x-h264,stream-format=avc,alignment=au,width=640,height=480,framerate=30/1 ! kvssink stream-name=YourStreamName frame-timestamp=dts-only access-key=YourAccessKey secret-key=YourSecretKey
 ```
-Note:  Raspberry PI camera module requires `frame-timestamp=KVS_SINK_TIMESTAMP_DTS_ONLY` . If USB camera is used for streaming then this property is optional.
+Note:  Raspberry PI camera module requires `frame-timestamp=dts-only` . If USB camera is used for streaming then this property is optional.
 
 ##### 4. Run the demo application from Docker
 
@@ -424,31 +424,45 @@ make install
 
 ----
 ## Release notes
+#### Release 1.4.3 (20th June 2018)
+* Added prebuilt docker images for AmazonLinux and Raspbian Stretch
+* Updated install-script to accept commandline argument -j and pass the value to `make` to speed up building
+* Updated install-script to accept commandline argument -d to remove opensource library installation files after finishing
+* Updated CMakeLists.txt in kinesis-video-native-build to link up libraries properly
+
 #### Release 1.4.2 (14th June 2018)
 * Release first version of gstreamer plugin kvssink
 * Fix gstreamer demo issue when running on raspberry pi
+
 #### Release 1.4.1 (8th May 2018)
 * Update log4cplus download link in install-script
+
 #### Release 1.4.0 (25th April 2018)
 * Fix for crash caused by latest Mac tool chain issue
 * Fix for callbacks returning incorrect custom data in gstreamer sample app
 * Support for custom logger
 * Fix for multiple callbacks when triggering connection staleness
+
 #### Release 1.3.1 (5th April 2018)
 * Fixed video source negotiation error caused by camera with fractional fps
 * Docker suport for RTSP streaming
+
 #### Release 1.3.0 (15th March 2018)
 * Fixed producer intermittent termination issue for some edge cases involving re-streaming on error.
+
 #### Release 1.2.3 (1st March 2018)
 * Updated install-script to fix the local certificate trust issue for curl.
 * Added steps in README troubleshooting section for curl trust issues.
+
 #### Release 1.2.2 (March 2018)
 * Remove open-source dependencies from KinesisVideoProducerJNI native library. java-install-script can be used to build KinesisVideoProducerJNI native library fast.
 * README note improved.
+
 #### Release 1.2.1 (February 2018)
 * Bug fix for producer timestamp *video playback* in the console should be fixed if proper timestamp is provided to SDK. Current setting in sample app uses Gstreamer frame timecode and relative timestamp (used by SDK).
 * `install-script` is updated to automatically detect OS version and avoid dependency issue on Mac High Sierra and Ubuntu 17.10.
 * Known issue: Producer timestamp mode *video playback in console* will not work if GStreamer demoapp is configured to use frame timecode and absolute timestamp (used by SDK).
+
 #### Release 1.2.0 (February 2018)
 * Bug fixes and performance enhancement
 * Streaming error recovery improvements
@@ -461,6 +475,7 @@ make install
 ```
 AWS_ACCESS_KEY_ID=<MYACCESSKEYID> AWS_SECRET_ACCESS_KEY=<MYSECRETKEY> ./kinesis_video_gstreamer_sample_rtsp_app <rtspurl> <stream-name>
 ```
+
 #### Release 1.1.2 (January 2018)
 * Allowed devices to output h.264 streams directly
 * The user can also supply a streaming resolution through command line arguments.
@@ -468,16 +483,19 @@ AWS_ACCESS_KEY_ID=<MYACCESSKEYID> AWS_SECRET_ACCESS_KEY=<MYSECRETKEY> ./kinesis_
   * If no resolution is specified, the demo will try to use resolutions 1920x1080, 1280x720 and 640x480 in that order (highest resolution first)and will start streaming once the camera supported resolution is detected.
 * Known issues:
   * When streaming on raspberry pi. Some green artifacts might be observed on the preview screen. Reducing the resolution can fix the issue.
+
 #### Release 1.1.1 (December 2017)
 * Fix USB webcam support
 * Known issues:
     * If USB webcam doesn't support 720p, then gstreamer negotiation will fail. Trying lower resolution as mentioned in Troubleshooting may fix this issue.
+
 #### Release 1.1.0 (December 2017)
 * Addition of a received application ACK notification callback
 * Lifecycle management improvements
 * Exposed failure on progressive back-off/retry logic
 * Hardening/fixing various edge-cases
 * Fixing Raspberry PI frame dropping issue
+
 #### Release 1.0.0 (November 2017)
 * First release of the Amazon Kinesis Video Producer SDK for Cpp.
 * Known issues:

--- a/docker_native_scripts/Dockerfile
+++ b/docker_native_scripts/Dockerfile
@@ -30,9 +30,18 @@ RUN git clone https://github.com/awslabs/amazon-kinesis-video-streams-producer-s
 
 WORKDIR /opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/
 RUN  chmod a+x ./install-script
-RUN ./install-script a
+RUN chmod a+x ./gstreamer-plugin-install-script
+RUN ./install-script -a
+RUN cp libproducer.so /opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/lib/
+ENV KINESIS_VIDEO_STREAMS_PRODUCER_SDK_SOURCE_DIR=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/
+ENV SDK_SOURCE_DIR=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/
+RUN ./gstreamer-plugin-install-script
 RUN ./java-install-script
+RUN cp /opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-gstreamer-plugin/libgstkvssink.so /opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/lib/
 COPY start_rtsp_in_docker.sh /opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/
+ENV LD_LIBRARY_PATH=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/lib:$LD_LIBRARY_PATH
+ENV GST_PLUGIN_PATH=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/lib
+ENV PATH=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/bin:/opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build:$PATH
 RUN chmod a+x ./start_rtsp_in_docker.sh
 
 # comment the following step if you would like to customize the docker image build

--- a/docker_native_scripts/amazonlinux-docker/Dockerfile
+++ b/docker_native_scripts/amazonlinux-docker/Dockerfile
@@ -1,0 +1,79 @@
+# Build docker with
+# docker build -t kinesis-video-producer-sdk-cpp-amazon-linux .
+#
+FROM amazonlinux
+RUN yum update -y && \
+   yum upgrade -y && \
+   yum install -y autoconf && \
+   yum install -y automake && \
+   yum install -y bison && \
+   yum install -y bzip2 && \
+   yum install -y cmake && \
+   yum install -y curl && \
+   yum install -y diffutils && \
+   yum install -y flex  && \
+   yum install -y gcc-c++  && \
+   yum install -y git && \
+   yum install -y gmp-devel && \
+   yum install -y libffi && \
+   yum install -y libffi-devel && \
+   yum install -y  libmpc-devel && \
+   yum install -y libtool && \
+   yum install -y m4 && \
+   yum install -y mpfr-devel && \
+   yum install -y pkgconfig && \
+   yum install -y vim && \
+   yum install -y wget
+
+
+RUN wget https://cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz && \
+    tar -zxvf cmake-3.2.3-Linux-x86_64.tar.gz && \
+    rm cmake-3.2.3-Linux-x86_64.tar.gz
+ENV PATH=/cmake-3.2.3-Linux-x86_64/bin/:$PATH
+RUN wget https://ftp.gnu.org/gnu/gcc/gcc-7.2.0/gcc-7.2.0.tar.gz && \
+    tar -xvf gcc-7.2.0.tar.gz && \
+    cd gcc-7.2.0 && \
+    ./configure --disable-multilib --enable-languages=c,c++ && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf gcc-7.2.0*
+RUN /usr/local/bin/gcc "--version"
+WORKDIR /opt/
+
+RUN git clone https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp.git
+
+WORKDIR /opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/
+
+ENV CC=/usr/local/bin/gcc
+ENV CXX=/usr/local/bin/g++
+RUN chmod a+x ./install-script
+RUN chmod a+x ./gstreamer-plugin-install-script
+# =================  HTTPS Certificate =====================================================================
+RUN wget https://www.amazontrust.com/repository/SFSRootCAG2.pem
+RUN cp  SFSRootCAG2.pem /opt/amazon-kinesis-video-streams-producer-sdk-cpp
+# ================  Build producer sdk and gstreamer plugin ================================================
+#
+RUN chmod +x install-script
+RUN ./install-script -a -j 4 -d
+RUN cp libproducer.so /opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/lib/
+ENV KINESIS_VIDEO_STREAMS_PRODUCER_SDK_SOURCE_DIR=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/
+ENV SDK_SOURCE_DIR=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/
+RUN pwd
+RUN ./gstreamer-plugin-install-script
+
+#
+# Copy dynamic libraries into lib folder
+RUN cp /opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-gstreamer-plugin/libgstkvssink.so /opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/lib/
+
+# Copy all demo sample application binaries kinesis-video-native-build
+RUN cp /opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-gstreamer-plugin/kvs_producer_plugin* /opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/
+# Copy gst-launch-1.0 and gst-inspect-1.0 kinesis-video-native-build
+RUN cp /opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/bin/gst* /opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/
+
+# Set environment variables for plugin and libraries
+ENV LD_LIBRARY_PATH=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/lib:$LD_LIBRARY_PATH
+ENV GST_PLUGIN_PATH=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/lib
+ENV PATH=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/bin:/opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build:$PATH
+
+WORKDIR /opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/

--- a/docker_native_scripts/amazonlinux-docker/Instructions-for-prebuilt-Dockerimages.md
+++ b/docker_native_scripts/amazonlinux-docker/Instructions-for-prebuilt-Dockerimages.md
@@ -1,0 +1,72 @@
+# Using Docker images for Producer SDK (CPP and GStreamer plugin):
+
+Please follow the four steps below to get the Docker image for Producer SDK (includes CPP and GStreamer plugin) and start streaming to Kinesis Video.   
+
+#### Pre-requisite: 
+
+This requires docker is installed in your system. 
+
+Follow instructions to download and start Docker
+
+* [Docker download instructions](https://www.docker.com/community-edition#/download)
+* [Getting started with Docker](https://docs.docker.com/get-started/)
+
+
+Once you have docker installed, you can download the Kinesis Video Producer SDK (CPP and GStreamer plugin) from Amazon ECR (Elastic Container Service) using `docker pull` command.
+
+
+#### Step 1: 
+
+Authenticate your Docker client to the Amazon ECR registry that you intend to pull your image from. Authentication tokens must be obtained for each registry used, and the tokens are valid for 12 hours. For more information, see Registry Authentication.
+
+Example:
+    
+You can authenticate to Amazon ECR using the following two commands:
+
+1.  `aws ecr get-login --no-include-email --region us-west-2 --registry-ids 546150905175`
+
+you will see an **output** similar to the one below.
+
+2.  `docker login -u AWS -p <Password>   https://<YourAccountId>.dkr.ecr.us-west-2.amazonaws.com`
+
+Run the command as such in your command prompt. This will authorize the `docker pull` which you will be running next.
+
+
+#### Step 2: Pull Image
+
+##### 2.1 Steps for getting the Docker images built with AmazonLinux  
+	
+Run the following command to get the AmazonLinux Docker image to your local environment. E.g.
+
+`sudo docker pull 546150905175.dkr.ecr.us-west-2.amazonaws.com/kinesis-video-producer-cpp-amazon-linux:latest`
+`sudo docker pull 546150905175.dkr.ecr.us-west-2.amazonaws.com/kinesis-video-producer-sdk-cpp-raspberry-pi:latest`   
+
+you can verify the images in your local docker environment by running `docker images`.
+
+
+#### Step 3: Run the Docker Image (start the container)
+
+Run the following command to start the kinesis video sdk container 
+
+`sudo docker run -it --network="host" --device=/dev/video0 546150905175.dkr.ecr.us-west-2.amazonaws.com/kinesis-video-producer-cpp-amazon-linux:latest /bin/bash`
+
+
+#### Step 4: Run the GStreamer plugin
+
+Follow the next few steps to start Producer SDK GStreamer plugin element for sending video streams from webcamera to Kinesis Video:
+
+##### 4.1 Set these environment variable:
+
+`export LD_LIBRARY_PATH=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/lib:$LD_LIBRARY_PATH`
+
+`export PATH=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/bin:$PATH`
+
+`export GST_PLUGIN_PATH=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/lib:$GST_PLUGIN_PATH`
+
+
+##### 4.2 Start the streaming with `gst-launch-1.0` command.
+
+`gst-launch-1.0 v4l2src do-timestamp=TRUE device=/dev/video0 ! videoconvert ! video/x-raw,format=I420,width=640,height=480,framerate=30/1 ! x264enc bframes=0 key-int-max=45 bitrate=512 ! h264parse ! video/x-h264,stream-format=avc,alignment=au,width=640,height=480,framerate=30/1 ! kvssink stream-name="YOURSTREAMNAME" access-key=YOURACCESSKEY secret-key=YOURSECRETKEY` 
+     
+For additional examples refer [Readme](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/blob/master/README.md) in  https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp. 
+     

--- a/docker_native_scripts/amazonlinux-docker/README.md
+++ b/docker_native_scripts/amazonlinux-docker/README.md
@@ -1,0 +1,73 @@
+# Using Docker images for Producer SDK (CPP and GStreamer plugin):
+
+Please follow the four steps below to get the Docker image for Producer SDK (includes CPP and GStreamer plugin) and start streaming to Kinesis Video.
+
+#### Pre-requisite:
+
+This requires docker is installed in your system.
+
+Follow instructions to download and start Docker
+
+* [Docker download instructions](https://www.docker.com/community-edition#/download)
+* [Getting started with Docker](https://docs.docker.com/get-started/)
+
+
+Once you have docker installed, you can download the Kinesis Video Producer SDK (CPP and GStreamer plugin) from Amazon ECR (Elastic Container Service) using `docker pull` command.
+
+
+#### Step 1:
+
+Authenticate your Docker client to the Amazon ECR registry that you intend to pull your image from. Authentication tokens must be obtained for each registry used, and the tokens are valid for 12 hours. For more information, see Registry Authentication.
+
+Example:
+
+You can authenticate to Amazon ECR using the following two commands:
+
+1.  `aws ecr get-login --no-include-email --region us-west-2 --registry-ids 546150905175`
+
+you will see an **output** similar to the one below.
+
+2.  `docker login -u AWS -p <Password>   https://<YourAccountId>.dkr.ecr.us-west-2.amazonaws.com`
+
+Run the command as such in your command prompt. This will authorize the `docker pull` which you will be running next.
+
+
+#### Step 2: Pull Image
+
+##### 2.1 Steps for getting the Docker images built with AmazonLinux
+
+Run the following command to get the AmazonLinux Docker image to your local environment. E.g.
+
+`sudo docker pull 546150905175.dkr.ecr.us-west-2.amazonaws.com/kinesis-video-producer-cpp-amazon-linux:latest`
+
+you can verify the images in your local docker environment by running `docker images`.
+
+
+#### Step 3: Run the Docker Image (start the container)
+
+Run the following command to start the kinesis video sdk container
+
+`sudo docker run -it --network="host" --device=/dev/video0 546150905175.dkr.ecr.us-west-2.amazonaws.com/kinesis-video-producer-cpp-amazon-linux:latest /bin/bash`
+
+
+#### Step 4: Run the GStreamer plugin
+
+Follow the next few steps to start Producer SDK GStreamer plugin element for sending video streams from webcamera to Kinesis Video:
+
+##### 4.1 Set these environment variable:
+
+`export LD_LIBRARY_PATH=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/lib:$LD_LIBRARY_PATH`
+
+`export PATH=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/bin:$PATH`
+
+`export GST_PLUGIN_PATH=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/lib:$GST_PLUGIN_PATH`
+
+
+##### 4.2 Start the streaming with `gst-launch-1.0` command.
+
+`gst-launch-1.0 v4l2src do-timestamp=TRUE device=/dev/video0 ! videoconvert ! video/x-raw,format=I420,width=640,height=480,framerate=30/1 ! x264enc bframes=0 key-int-max=45 bitrate=512 ! h264parse ! video/x-h264,stream-format=avc,alignment=au,width=640,height=480,framerate=30/1,profile=baseline ! kvssink stream-name="YOURSTREAMNAME" access-key=YOURACCESSKEY secret-key=YOURSECRETKEY`
+
+For more information refer [AWS Doc](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/examples-gstreamer-plugin.html#examples-gstreamer-plugin-docker)
+
+For additional examples refer [Readme](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/blob/master/README.md) in  https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp.
+

--- a/docker_native_scripts/raspberry-pi-docker/Dockerfile
+++ b/docker_native_scripts/raspberry-pi-docker/Dockerfile
@@ -1,0 +1,53 @@
+FROM resin/rpi-raspbian:stretch
+
+RUN apt-get update && apt-get install -y \
+	git \
+	curl \
+	ca-certificates-java \
+	openjdk-8-jre \
+	openjdk-8-jdk \
+	pkg-config \
+	cmake \
+	vim \
+	binutils \
+	make \
+	openssh-server \
+	gcc \
+	g++ \
+	python \
+	bzip2
+
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-armhf/
+
+WORKDIR /opt/
+RUN curl -OL https://github.com/raspberrypi/firmware/archive/1.20180417.tar.gz
+RUN tar xvf 1.20180417.tar.gz
+RUN cp -r /opt/firmware-1.20180417/opt/vc ./
+RUN rm -rf firmware-1.20180417 1.20180417.tar.gz
+
+###################################################
+# create symlinks for libraries used by omxh264enc
+###################################################
+
+RUN     ln -s /opt/vc/lib/libopenmaxil.so /usr/lib/libopenmaxil.so && \
+        ln -s /opt/vc/lib/libbcm_host.so /usr/lib/libbcm_host.so && \
+        ln -s /opt/vc/lib/libvcos.so /usr/lib/libvcos.so &&  \
+        ln -s /opt/vc/lib/libvchiq_arm.so /usr/lib/libvchiq_arm.so && \
+        ln -s /opt/vc/lib/libbrcmGLESv2.so /usr/lib/libbrcmGLESv2.so && \
+        ln -s /opt/vc/lib/libbrcmEGL.so /usr/lib/libbrcmEGL.so && \
+        ln -s /opt/vc/lib/libGLESv2.so /usr/lib/libGLESv2.so && \
+        ln -s /opt/vc/lib/libEGL.so /usr/lib/libEGL.so
+
+WORKDIR /opt/
+RUN git clone https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp
+WORKDIR /opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/
+RUN chmod a+x install-script
+RUN ./install-script -a
+
+WORKDIR /opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/
+RUN chmod a+x ./gstreamer-plugin-install-script
+RUN ./gstreamer-plugin-install-script
+
+WORKDIR /opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/
+ENV PATH=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/bin:$PATH
+ENV GST_PLUGIN_PATH=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/lib:$GST_PLUGIN_PATH

--- a/docker_native_scripts/raspberry-pi-docker/README.md
+++ b/docker_native_scripts/raspberry-pi-docker/README.md
@@ -1,0 +1,73 @@
+# Using Docker images for Producer SDK (CPP and GStreamer plugin):
+
+Please follow the four steps below to get the Docker image for Producer SDK (includes CPP and GStreamer plugin) and start streaming to Kinesis Video.
+
+#### Pre-requisite:
+
+This requires docker is installed in your system.
+
+Follow instructions to download and start Docker
+
+* [Docker download instructions](https://www.docker.com/community-edition#/download)
+* [Getting started with Docker](https://docs.docker.com/get-started/)
+
+
+Once you have docker installed, you can download the Kinesis Video Producer SDK (CPP and GStreamer plugin) from Amazon ECR (Elastic Container Service) using `docker pull` command.
+
+
+#### Step 1:
+
+Authenticate your Docker client to the Amazon ECR registry that you intend to pull your image from. Authentication tokens must be obtained for each registry used, and the tokens are valid for 12 hours. For more information, see Registry Authentication.
+
+Example:
+
+You can authenticate to Amazon ECR using the following two commands:
+
+1.  `aws ecr get-login --no-include-email --region us-west-2 --registry-ids 546150905175`
+
+you will see an **output** similar to the one below.
+
+2.  `docker login -u AWS -p <Password>   https://<YourAccountId>.dkr.ecr.us-west-2.amazonaws.com`
+
+Run the command as such in your command prompt. This will authorize the `docker pull` which you will be running next.
+
+
+#### Step 2: Pull Image
+
+##### 2.1 Steps for getting the Docker images built with Raspbian Stretch
+
+Run the following command to get the AmazonLinux Docker image to your local environment. E.g.
+
+`sudo docker pull 546150905175.dkr.ecr.us-west-2.amazonaws.com/kinesis-video-producer-sdk-cpp-raspberry-pi:latest`
+
+you can verify the images in your local docker environment by running `docker images`.
+
+
+#### Step 3: Run the Docker Image (start the container)
+
+Run the following command to start the kinesis video sdk container
+
+`sudo docker run -it --device=/dev/video0 --device=/dev/vchiq -v /opt/vc:/opt/vc 546150905175.dkr.ecr.us-west-2.amazonaws.com/kinesis-video-producer-sdk-cpp-raspberry-pi:latest /bin/bash`
+
+
+#### Step 4: Run the GStreamer plugin
+
+Follow the next few steps to start Producer SDK GStreamer plugin element for sending video streams from webcamera to Kinesis Video:
+
+##### 4.1 Set these environment variable:
+
+`export LD_LIBRARY_PATH=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/lib:$LD_LIBRARY_PATH`
+
+`export PATH=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/bin:$PATH`
+
+`export GST_PLUGIN_PATH=/opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/lib:$GST_PLUGIN_PATH`
+
+
+##### 4.2 Start the streaming with `gst-launch-1.0` command.
+
+`gst-launch-1.0 v4l2src do-timestamp=TRUE device=/dev/video0 ! videoconvert ! video/x-raw,format=I420,width=640,height=480,framerate=30/1 ! omxh264enc control-rate=2 target-bitrate=512000 inline-header=FALSE periodicty-idr=20 ! h264parse ! video/x-h264,stream-format=avc,alignment=au,width=640,height=480,framerate=30/1,profile=baseline ! kvssink stream-name="YOURSTREAMNAME" access-key=YOURACCESSKEY secret-key=YOURSECRETKEY`
+
+For more information refer [AWS Doc](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/examples-gstreamer-plugin.html#examples-gstreamer-plugin-docker)
+
+For additional examples refer [Readme](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/blob/master/README.md) in  https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp.
+

--- a/kinesis-video-native-build/CMakeLists.txt
+++ b/kinesis-video-native-build/CMakeLists.txt
@@ -62,6 +62,52 @@ if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ldl -lrt -lpthread")
 endif()
 
+find_package(PkgConfig REQUIRED)
+pkg_check_modules (GLIB2        REQUIRED   glib-2.0)
+pkg_check_modules (CRYPTO       REQUIRED   libcrypto)
+pkg_check_modules (CURL         REQUIRED   libcurl)
+pkg_check_modules (GST          REQUIRED   gstreamer-1.0)
+pkg_check_modules (GST_APP      REQUIRED   gstreamer-app-1.0)
+pkg_check_modules (LOG4CPLUS    REQUIRED   log4cplus)
+pkg_check_modules (GOBJ2        REQUIRED   gobject-2.0)
+pkg_check_modules (SSL          REQUIRED   libssl)
+find_library(GTEST gtest REQUIRED HINTS ${KINESIS_VIDEO_OPEN_SOURCE_SRC}/local PATH_SUFFIXES lib)
+find_library(GTEST_MAIN gtest_main REQUIRED HINTS ${KINESIS_VIDEO_OPEN_SOURCE_SRC}/local PATH_SUFFIXES lib)
+
+set(OPEN_SRC_INCLUDE_DIRS
+        ${GLIB2_INCLUDE_DIRS}
+        ${CRYPTO_INCLUDE_DIRS}
+        ${CURL_INCLUDE_DIRS}
+        ${GST_APP_INCLUDE_DIRS}
+        ${GST_INCLUDE_DIRS}
+        ${LOG4CPLUS_INCLUDE_DIRS}
+        ${GOBJ2_INCLUDE_DIRS}
+        ${SSL_INLCUDE_DIRS})
+
+set(OPEN_SRC_LIBRARY_DIRS
+        ${GLIB2_LIBRARY_DIRS}
+        ${CRYPTO_LIBRARY_DIRS}
+        ${CURL_LIBRARY_DIRS}
+        ${GST_APP_LIBRARY_DIRS}
+        ${GST_LIBRARY_DIRS}
+        ${LOG4CPLUS_LIBRARY_DIRS}
+        ${GOBJ2_LIBRARY_DIRS}
+        ${SSL_LIBRARY_DIRS})
+
+set(PRODUCER_LIBRARIES
+        ${CRYPTO_LIBRARIES}
+        ${SSL_LIBRARIES}
+        ${CURL_LIBRARIES}
+        ${LOG4CPLUS_LIBRARIES}
+        ${GOBJ2_LIBRARIES})
+
+set(GST_DEMO_LIBRARIES
+        ${GLIB2_LIBRARIES}
+        pthread
+        ${GST_APP_LIBRARIES}
+        ${GST_LIBRARIES}
+        ${GOBJ2_LIBRARIES})
+
 set(PIC_SOURCE_FILES
         ${KINESIS_VIDEO_PIC_SRC}/src/client/include/com/amazonaws/kinesis/video/client/Include.h
         ${KINESIS_VIDEO_PIC_SRC}/src/client/src/AuthIntegration.cpp
@@ -259,34 +305,24 @@ include_directories(${KINESIS_VIDEO_PRODUCER_SRC}/src)
 include_directories(${KINESIS_VIDEO_PRODUCER_SRC}/opensource/jsoncpp)
 include_directories(${KINESIS_VIDEO_PRODUCER_SRC}/tst)
 include_directories(${KINESIS_VIDEO_PRODUCER_JNI_SRC}/src/include/)
-include_directories(${KINESIS_VIDEO_OPEN_SOURCE_SRC}/local/include/)
-include_directories(${KINESIS_VIDEO_OPEN_SOURCE_SRC}/local/include/gstreamer-1.0)
-include_directories(${KINESIS_VIDEO_OPEN_SOURCE_SRC}/local/include/glib-2.0)
-include_directories(${KINESIS_VIDEO_OPEN_SOURCE_SRC}/glib-2.54.2)
-include_directories(${KINESIS_VIDEO_OPEN_SOURCE_SRC}/local/lib/glib-2.0/include)
+include_directories(${OPEN_SRC_INCLUDE_DIRS})
 include_directories(/System/Library/Frameworks/JavaVM.framework/Versions/Current/Headers)
 include_directories(${JAVA_HOME}/include)
 include_directories(${JAVA_HOME}/include/${CMAKE_SYSTEM_NAME_LOWER_CASE})
 
-link_directories(${KINESIS_VIDEO_OPEN_SOURCE_SRC}/local/lib)
+link_directories(${OPEN_SRC_LIBRARY_DIRS})
 add_library(producer SHARED ${PRODUCER_SOURCE_FILES})
 add_library(KinesisVideoProducerJNI SHARED ${PRODUCER_SOURCE_FILES_JNI} ${PIC_SOURCE_FILES})
 add_executable(start ${TST_PRODUCER_SOURCE_FILES})
 add_executable(kinesis_video_gstreamer_sample_app ${GST_DEMO_APP})
 add_executable(kinesis_video_gstreamer_sample_rtsp_app ${RTSP_DEMO_APP})
 
-target_include_directories(kinesis_video_gstreamer_sample_app PRIVATE ${GST_INCLUDE_DIRS})
-target_include_directories(kinesis_video_gstreamer_sample_rtsp_app PRIVATE ${GST_INCLUDE_DIRS})
-
 target_link_libraries(KinesisVideoProducerJNI)
 
 target_link_libraries(producer
-        log4cplus
-        crypto
-        ssl
-        gtest
-        gtest_main
-        curl)
+        ${PRODUCER_LIBRARIES}
+        ${GTEST_MAIN}
+        ${GTEST})
 
 target_link_libraries(start
         producer
@@ -294,19 +330,8 @@ target_link_libraries(start
 
 target_link_libraries(kinesis_video_gstreamer_sample_app
         producer
-        pthread
-        dl
-        gstreamer-1.0
-        gstapp-1.0
-        gobject-2.0
-        glib-2.0)
+        ${GST_DEMO_LIBRARIES})
 
 target_link_libraries(kinesis_video_gstreamer_sample_rtsp_app
         producer
-        pthread
-        dl
-        gstreamer-1.0
-        gstapp-1.0
-        gobject-2.0
-        glib-2.0)
-
+        ${GST_DEMO_LIBRARIES})

--- a/kinesis-video-native-build/install-script
+++ b/kinesis-video-native-build/install-script
@@ -10,51 +10,53 @@ set -e
 echo " ===========================Starting to build ===========================
               Kinesis Video Stream Producer SDK and Demo Application
        ========================================================================
-       Following open source libraries and tools will be downloaded and built 
+       Following open source libraries and tools will be downloaded and built
        before building the producer sdk.
        ========================================================================
        # ------------------------- BUILD-TOOLS -------------------------------#
         autoconf   automake
         bison      curl
         flex       gettext
-        googletest iconv  
-        libffi     libpcre 
-        libtools   log4cplus 
-        m4         openssl 
-        zlib  
-        
+        googletest iconv
+        libffi     libpcre
+        libtools   log4cplus
+        m4         openssl
+        zlib
+
         # ------------------------- GSTREAMER - for demo application --------#
         GStreamer, GStreamer plugins, yasm, gst-libav and x264.
         ------------------------------------------------------------------------
-        *** NOTE *** for MacOS High Sierra: Use 
-            brew install autoconf  
+        *** NOTE *** for MacOS High Sierra: Use
+            brew install autoconf
             brew install bison before running this script
         ------------------------------------------------------------------------
         ========================================================================
-        This install script downloads and builds the dependent libraries from  
-        source in the ./kinesis-video-native-build/downloads directory only. 
+        This install script downloads and builds the dependent libraries from
+        source in the ./kinesis-video-native-build/downloads directory only.
         ========================================================================
  "
 
 KINESIS_VIDEO_ROOT=`pwd`
 
-# Make confirmation optional for Docker builds 
-# e.g. ./install-script -a 
+# Make confirmation optional for Docker builds
+# e.g. ./install-script -a
 user_confirmation='N'
 
 # To skip building the gstreamer-plugin-ugly use -e option
 # ./install-script  -e
 # Using ./install-script with no option
-# prpmpts for user confirmation - to continue (Y) or exit (N). 
+# prompts for user confirmation - to continue (Y) or exit (N).
 # It also builds all the plugins.
 build_extras="Y"
 
 # if any cert issues in downloading the open source dependencies
-# run the install-script with -c option e.g. ./install-script -c 
+# run the install-script with -c option e.g. ./install-script -c
 # this will add the --cacert option for curl.
 addl_curl_args=""
 
-while getopts ":a :e :c" opt; do
+max_parallel=2
+do_cleanup=false
+while getopts ":a :e :c j: :d" opt; do
   case $opt in
     a)
       user_confirmation='Y'
@@ -68,13 +70,20 @@ while getopts ":a :e :c" opt; do
       addl_curl_args="--cacert $KINESIS_VIDEO_ROOT/cacert.pem"
       echo "using additional curl args " >&2
       ;;
+    j)
+      max_parallel=$OPTARG
+      echo "passing -j $max_parallel to make"
+      ;;
+    d)
+      do_cleanup=true
+      echo "Cleaning up library installation files after finish"
+      ;;
   esac
 done
 
-
 if [ "$user_confirmation" != "Y" ]; then
   echo "
-      Y - Confirm to proceed with Producer SDK build 
+      Y - Confirm to proceed with Producer SDK build
       N - Exit Producer SDK build"
   echo -n "Enter selection: "
   read user_confirmation
@@ -82,7 +91,7 @@ if [ "$user_confirmation" != "Y" ]; then
 fi
 
 if [[ "$user_confirmation" = "N" || "$user_confirmation" = "n" ]]; then
-    echo "Existing install" 
+    echo "Existing install"
     exit
 fi
 # --------- install-script build options --------------------------------------
@@ -107,8 +116,10 @@ if [ ! -d "$CERTS_FOLDER" ]; then
     mkdir "$CERTS_FOLDER"
 fi
 
- 
-
+SYS_CURL=`which curl` || echo "Curl not found. Please install curl."
+if [ -z "$SYS_CURL" ]; then
+  exit
+fi
 
 LIB_DESTINATION_FOLDER_PATH="$KINESIS_VIDEO_ROOT/downloads/local/lib"
 
@@ -131,7 +142,7 @@ CERT_PEM_FILE="$CERTS_FOLDER/cert.pem"
 if [ ! -f "$CERT_PEM_FILE" ];then
   echo "cert.pem" file does not exist in the $KINESIS_VIDEO_ROOT directory
   echo "Downloading the https://www.amazontrust.com/repository/SFSRootCAG2.pem to $CERTS_FOLDER/cert.pem"
-  curl -L "https://www.amazontrust.com/repository/SFSRootCAG2.pem" -o "$CERTS_FOLDER/cert.pem"
+  $SYS_CURL -L "https://www.amazontrust.com/repository/SFSRootCAG2.pem" -o "$CERTS_FOLDER/cert.pem"
 fi
 
 # -------- Setting environment variables for cmake ----------------------------
@@ -159,13 +170,13 @@ if [ ! -f $DOWNLOADS/local/lib/libssl.a ]; then
   if [ ! -f $DOWNLOADS/openssl-1.1.0f.tar.gz ]; then
     cd $DOWNLOADS
     #download_cmd="curl -L $addl_curl_args "https://www.openssl.org/source/openssl-1.1.0f.tar.gz" -o "openssl-1.1.0f.tar.gz" "
-    curl -L $addl_curl_args "https://www.openssl.org/source/openssl-1.1.0f.tar.gz" -o "openssl-1.1.0f.tar.gz"
+    $SYS_CURL -L $addl_curl_args "https://www.openssl.org/source/openssl-1.1.0f.tar.gz" -o "openssl-1.1.0f.tar.gz"
   fi
   cd $DOWNLOADS
   tar -xvf openssl-1.1.0f.tar.gz
   cd $DOWNLOADS/openssl-1.1.0f
   ./config  --prefix=$DOWNLOADS/local/ --openssldir=$DOWNLOADS/local/
-  make
+  make -j $max_parallel
   make install
 fi
 
@@ -174,20 +185,20 @@ if [ ! -f $DOWNLOADS/local/lib/libcurl.a ]; then
   echo "Curl lib not found. Installing"
   if [ ! -f $DOWNLOADS/curl-7.57.0.tar.xz ]; then
     cd $DOWNLOADS
-    curl -L $addl_curl_args "https://curl.haxx.se/download/curl-7.57.0.tar.xz" -o "curl-7.57.0.tar.xz"
+    $SYS_CURL -L $addl_curl_args "https://curl.haxx.se/download/curl-7.57.0.tar.xz" -o "curl-7.57.0.tar.xz"
   fi
   cd $DOWNLOADS
   tar -xvf curl-7.57.0.tar.xz
   cd $DOWNLOADS/curl-7.57.0
 
   if [ -f "$CERT_PEM_FILE" ] ;then
-    ./configure --prefix=$DOWNLOADS/local/ --enable-dynamic --disable-rtsp --disable-ldap --without-zlib --with-ssl=$DOWNLOADS/local/ --with-ca-bundle=$CERT_PEM_FILE 
-  else 
+    ./configure --prefix=$DOWNLOADS/local/ --enable-dynamic --disable-rtsp --disable-ldap --without-zlib --with-ssl=$DOWNLOADS/local/ --with-ca-bundle=$CERT_PEM_FILE
+  else
     echo "Cannot find the cert.pem at $CERTS_FOLDER -- libcurl build requires cert.pem; existing."
     echo "Download the https://www.amazontrust.com/repository/SFSRootCAG2.pem to $CERTS_FOLDER/cert.pem"
-    exit 
-  fi  
-  make
+    exit
+  fi
+  make -j $max_parallel
   make install
 fi
 
@@ -197,13 +208,13 @@ if [ ! -f $DOWNLOADS/local/lib/liblog4cplus.dylib ]; then
     echo "log4cplus lib not found. Installing"
     if [ ! -f $DOWNLOADS/log4cplus-1.2.0.tar.xz ]; then
       cd $DOWNLOADS
-      curl -L $addl_curl_args "http://sourceforge.net/projects/log4cplus/files/log4cplus-stable/1.2.0/log4cplus-1.2.0.tar.xz" -o "log4cplus-1.2.0.tar.xz"
+      $SYS_CURL -L $addl_curl_args "http://sourceforge.net/projects/log4cplus/files/log4cplus-stable/1.2.0/log4cplus-1.2.0.tar.xz" -o "log4cplus-1.2.0.tar.xz"
     fi
     cd $DOWNLOADS
     tar -xvf log4cplus-1.2.0.tar.xz
     cd $DOWNLOADS/log4cplus-1.2.0
     ./configure --prefix=$DOWNLOADS/local/
-    make
+    make -j $max_parallel
     make install
   fi
 fi
@@ -214,13 +225,13 @@ if [ ! -f $DOWNLOADS/local/lib/libgettextlib.dylib ]; then
    echo "gettext lib not found. Installing"
    if [ ! -f $DOWNLOADS/gettext-0.19.8.tar.xz ]; then
      cd $DOWNLOADS
-     curl -L $addl_curl_args "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.19.8.tar.xz" -o "gettext-0.19.8.tar.xz"
+     $SYS_CURL -L $addl_curl_args "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.19.8.tar.xz" -o "gettext-0.19.8.tar.xz"
    fi
    cd $DOWNLOADS
    tar -xvf gettext-0.19.8.tar.xz
    cd $DOWNLOADS/gettext-0.19.8
    ./configure --prefix=$DOWNLOADS/local/
-   make
+   make -j $max_parallel
    make install
  fi
 fi
@@ -232,13 +243,13 @@ if [ ! -f $DOWNLOADS/local/lib/libffi.dylib ]; then
     echo "libffi lib not found. Installing"
     if [ ! -f $DOWNLOADS/libffi-3.2.1.tar.gz ]; then
       cd $DOWNLOADS
-      curl -L $addl_curl_args "https://sourceware.org/ftp/libffi/libffi-3.2.1.tar.gz" -o "libffi-3.2.1.tar.gz"
+      $SYS_CURL -L $addl_curl_args "https://sourceware.org/ftp/libffi/libffi-3.2.1.tar.gz" -o "libffi-3.2.1.tar.gz"
     fi
     cd $DOWNLOADS
     tar -xvf libffi-3.2.1.tar.gz
     cd $DOWNLOADS/libffi-3.2.1
     ./configure --prefix=$DOWNLOADS/local/
-    make
+    make -j $max_parallel
     make install
   fi
 fi
@@ -249,13 +260,13 @@ if [ ! -f $DOWNLOADS/local/lib/libpcre.dylib ]; then
     echo "pcre lib not found. Installing"
     if [ ! -f $DOWNLOADS/pcre-8.41.tar.gz ]; then
       cd $DOWNLOADS
-      curl -L $addl_curl_args "https://ftp.pcre.org/pub/pcre/pcre-8.41.tar.gz" -o "pcre-8.41.tar.gz"
+      $SYS_CURL -L $addl_curl_args "https://ftp.pcre.org/pub/pcre/pcre-8.41.tar.gz" -o "pcre-8.41.tar.gz"
     fi
     cd $DOWNLOADS
     tar -xvf pcre-8.41.tar.gz
     cd $DOWNLOADS/pcre-8.41
     ./configure --prefix=$DOWNLOADS/local/
-    make
+    make -j $max_parallel
     make install
   fi
 fi
@@ -266,13 +277,13 @@ if [ ! -f $DOWNLOADS/local/lib/libz.dylib ]; then
     echo "zlib lib not found. Installing"
     if [ ! -f $DOWNLOADS/zlib-1.2.11.tar.gz ]; then
       cd $DOWNLOADS
-      curl -L $addl_curl_args "https://www.zlib.net/zlib-1.2.11.tar.gz" -o "zlib-1.2.11.tar.gz"
+      $SYS_CURL -L $addl_curl_args "https://www.zlib.net/zlib-1.2.11.tar.gz" -o "zlib-1.2.11.tar.gz"
     fi
     cd $DOWNLOADS
     tar -xvf zlib-1.2.11.tar.gz
     cd $DOWNLOADS/zlib-1.2.11
     ./configure --prefix=$DOWNLOADS/local/
-    make
+    make -j $max_parallel
     make install
   fi
 fi
@@ -283,13 +294,13 @@ if [ ! -f $DOWNLOADS/local/lib/libiconv.dylib ]; then
     echo "iconv lib not found. Installing"
     if [ ! -f $DOWNLOADS/libiconv-1.15.tar.gz ]; then
       cd $DOWNLOADS
-      curl -L $addl_curl_args "https://ftp.gnu.org/gnu/libiconv/libiconv-1.15.tar.gz" -o "libiconv-1.15.tar.gz"
+      $SYS_CURL -L $addl_curl_args "https://ftp.gnu.org/gnu/libiconv/libiconv-1.15.tar.gz" -o "libiconv-1.15.tar.gz"
     fi
     cd $DOWNLOADS
     tar -xvf libiconv-1.15.tar.gz
     cd $DOWNLOADS/libiconv-1.15
     ./configure --prefix=$DOWNLOADS/local/
-    make
+    make -j $max_parallel
     make install
   fi
 fi
@@ -301,13 +312,13 @@ if [[ $PLATFORM == 'linux' ]]; then
       echo "libmount lib not found. Installing"
       if [ ! -f $DOWNLOADS/util-linux-2.31.tar.gz ]; then
         cd $DOWNLOADS
-        curl -L $addl_curl_args "https://www.kernel.org/pub/linux/utils/util-linux/v2.31/util-linux-2.31.tar.gz" -o "util-linux-2.31.tar.gz"
+        $SYS_CURL -L $addl_curl_args "https://www.kernel.org/pub/linux/utils/util-linux/v2.31/util-linux-2.31.tar.gz" -o "util-linux-2.31.tar.gz"
       fi
       cd $DOWNLOADS
       tar -xvf util-linux-2.31.tar.gz
       cd $DOWNLOADS/util-linux-2.31
       ./configure --prefix=$DOWNLOADS/local/ --disable-all-programs --enable-libmount --enable-libblkid
-      make
+      make -j $max_parallel
       make install
     fi
   fi
@@ -318,13 +329,13 @@ fi
     echo "m4 not found. Installing"
     if [ ! -f $DOWNLOADS/m4-1.4.10.tar.gz ]; then
       cd $DOWNLOADS
-      curl -L $addl_curl_args "https://ftp.gnu.org/gnu/m4/m4-1.4.10.tar.gz" -o "m4-1.4.10.tar.xz"
+      $SYS_CURL -L $addl_curl_args "https://ftp.gnu.org/gnu/m4/m4-1.4.10.tar.gz" -o "m4-1.4.10.tar.xz"
     fi
     cd $DOWNLOADS
     tar -xvf m4-1.4.10.tar.xz
     cd $DOWNLOADS/m4-1.4.10
     ./configure --prefix=$DOWNLOADS/local  CFLAGS="-I$DOWNLOADS/local/include" LDFLAGS="-L$DOWNLOADS/local/lib"
-    make
+    make -j $max_parallel
     make install
  fi
 #-----------------------liby.a (bison) --------------------------------------------------------------------------------
@@ -333,13 +344,13 @@ if [[ $PLATFORM != 'mac' || $KERNEL_VERSION < 17 ]]; then
     echo "bison not found. Installing"
     if [ ! -f $DOWNLOADS/bison-2.3.tar.gz ]; then
       cd $DOWNLOADS
-      curl -L $addl_curl_args "https://ftp.gnu.org/gnu/bison/bison-3.0.4.tar.gz" -o "bison-3.0.4.tar.xz"
+      $SYS_CURL -L $addl_curl_args "https://ftp.gnu.org/gnu/bison/bison-3.0.4.tar.gz" -o "bison-3.0.4.tar.xz"
     fi
     cd $DOWNLOADS
     tar -xvf bison-3.0.4.tar.xz
     cd $DOWNLOADS/bison-3.0.4
     ./configure --prefix=$DOWNLOADS/local  CFLAGS="-I$DOWNLOADS/local/include" LDFLAGS="-L$DOWNLOADS/local/lib"
-    make
+    make -j $max_parallel
     make install
  fi
 fi
@@ -350,13 +361,13 @@ fi
           echo "flex not found. Installing"
           if [ ! -f $DOWNLOADS/flex-2.6.3.tar.gz ]; then
             cd $DOWNLOADS
-            curl -L $addl_curl_args "https://github.com/westes/flex/releases/download/v2.6.3/flex-2.6.3.tar.gz" -o "flex-2.6.3.tar.xz"
+            $SYS_CURL -L $addl_curl_args "https://github.com/westes/flex/releases/download/v2.6.3/flex-2.6.3.tar.gz" -o "flex-2.6.3.tar.xz"
           fi
           cd $DOWNLOADS
           tar -xvf flex-2.6.3.tar.xz
           cd $DOWNLOADS/flex-2.6.3
           ./configure --prefix=$DOWNLOADS/local  CFLAGS="-I$DOWNLOADS/local/include" LDFLAGS="-L$DOWNLOADS/local/lib"
-          make
+          make -j $max_parallel
           make install
       fi
   fi
@@ -368,13 +379,13 @@ fi
       echo "libtools not found. Installing"
       if [ ! -f $DOWNLOADS/libtool-2.4.6.tar.gz ]; then
         cd $DOWNLOADS
-        curl -L $addl_curl_args "https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.xz" -o "libtool-2.4.6.tar.xz"
+        $SYS_CURL -L $addl_curl_args "https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.xz" -o "libtool-2.4.6.tar.xz"
       fi
       cd $DOWNLOADS
       tar -xvf libtool-2.4.6.tar.xz
       cd $DOWNLOADS/libtool-2.4.6
-      ./configure --prefix=$DOWNLOADS/local  CFLAGS="-I$DOWNLOADS/local/include" LDFLAGS="-L$DOWNLOADS/local/lib" 
-      make
+      ./configure --prefix=$DOWNLOADS/local  CFLAGS="-I$DOWNLOADS/local/include" LDFLAGS="-L$DOWNLOADS/local/lib"
+      make -j $max_parallel
       make install
     fi
   fi
@@ -392,14 +403,14 @@ if [ ! -f $DOWNLOADS/local/lib/libglib-2.0.dylib ]; then
   echo "glib lib not found. Installing"
    if [ ! -f $DOWNLOADS/glib-2.54.2.tar.xz ]; then
      cd $DOWNLOADS
-     curl -L $addl_curl_args "http://ftp.gnome.org/pub/gnome/sources/glib/2.54/glib-2.54.2.tar.xz" -o "glib-2.54.2.tar.xz"
+     $SYS_CURL -L $addl_curl_args "http://ftp.gnome.org/pub/gnome/sources/glib/2.54/glib-2.54.2.tar.xz" -o "glib-2.54.2.tar.xz"
    fi
    cd $DOWNLOADS
    tar -xvf glib-2.54.2.tar.xz
    cd $DOWNLOADS/glib-2.54.2
   # autoreconf -f -i
    ./configure --prefix=$DOWNLOADS/local/ --with-pcre --with-libiconv --disable-gtk-doc  --disable-man
-   make
+   make -j $max_parallel
    make install
  fi
 fi
@@ -410,16 +421,14 @@ if [ ! -f $DOWNLOADS/local/lib/libgtest.dylib ]; then
     echo "gtest lib not found. Installing"
     if [ ! -f $DOWNLOADS/google-test-1.8.0.gz ]; then
       cd $DOWNLOADS
-      curl -L $addl_curl_args "https://github.com/google/googletest/archive/release-1.8.0.tar.gz" -o "google-test-1.8.0.gz"
+      $SYS_CURL -L $addl_curl_args "https://github.com/google/googletest/archive/release-1.8.0.tar.gz" -o "google-test-1.8.0.gz"
     fi
     cd $DOWNLOADS
     tar -xvf google-test-1.8.0.gz
     cd googletest-release-1.8.0/googletest
-    cmake -DBUILD_SHARED_LIBS=ON .
-    make
-    mkdir -p $DOWNLOADS/local/lib
-    cp -r ./include $DOWNLOADS/local
-    cp ./lib* $DOWNLOADS/local/lib
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=$DOWNLOADS/local -DCMAKE_INSTALL_NAME_DIR=$DOWNLOADS/local/lib .
+    make -j $max_parallel
+    make install
   fi
 fi
 
@@ -430,13 +439,13 @@ if [[ $PLATFORM != 'mac' || $KERNEL_VERSION < 17 ]]; then
     echo "autoconf not found. Installing"
     if [ ! -f $DOWNLOADS/autoconf-2.69.tar.gz ]; then
       cd $DOWNLOADS
-      curl -L $addl_curl_args "http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.xz" -o "autoconf-2.69.tar.xz"
+      $SYS_CURL -L $addl_curl_args "http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.xz" -o "autoconf-2.69.tar.xz"
     fi
     cd $DOWNLOADS
     tar -xvf autoconf-2.69.tar.xz
     cd $DOWNLOADS/autoconf-2.69
     ./configure --prefix=$DOWNLOADS/local  CFLAGS="-I$DOWNLOADS/local/include" LDFLAGS="-L$DOWNLOADS/local/lib"
-    make
+    make -j $max_parallel
     make install
  fi
 fi
@@ -445,13 +454,13 @@ fi
     echo "automake not found. Installing"
     if [ ! -f $DOWNLOADS/automake-1.15.1.tar.gz ]; then
       cd $DOWNLOADS
-      curl -L $addl_curl_args "http://ftp.gnu.org/gnu/automake/automake-1.15.1.tar.xz" -o "automake-1.15.1.tar.xz"
+      $SYS_CURL -L $addl_curl_args "http://ftp.gnu.org/gnu/automake/automake-1.15.1.tar.xz" -o "automake-1.15.1.tar.xz"
     fi
     cd $DOWNLOADS
     tar -xvf automake-1.15.1.tar.xz
     cd $DOWNLOADS/automake-1.15.1
     ./configure --prefix=$DOWNLOADS/local  CFLAGS="-I$DOWNLOADS/local/include" LDFLAGS="-L$DOWNLOADS/local/lib"
-    make
+    make -j $max_parallel
     make install
 fi
 
@@ -465,7 +474,7 @@ if [ ! -f $DOWNLOADS/local/lib/libgstreamer-1.0.dylib ]; then
     export ARCHFLAGS="-arch x86_64"
     if [ ! -f $DOWNLOADS/gstreamer-1.12.3.tar.xz ]; then
       cd $DOWNLOADS
-      curl -L $addl_curl_args "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.12.3.tar.xz" -o "gstreamer-1.12.3.tar.xz"
+      $SYS_CURL -L $addl_curl_args "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.12.3.tar.xz" -o "gstreamer-1.12.3.tar.xz"
     fi
     cd $DOWNLOADS
     tar -xvf gstreamer-1.12.3.tar.xz
@@ -478,7 +487,7 @@ if [ ! -f $DOWNLOADS/local/lib/libgstreamer-1.0.dylib ]; then
     done
 
     ./configure --prefix=$DOWNLOADS/local --disable-gtk-doc -- CFLAGS="-I$DOWNLOADS/local/include" LDFLAGS="-L$DOWNLOADS/local/lib"
-    make
+    make -j $max_parallel
     make install
   fi
 fi
@@ -489,7 +498,7 @@ if [ ! -f $DOWNLOADS/local/lib/libgstvideo-1.0.dylib ]; then
     echo "gst-plugin-base not found. Installing"
     if [ ! -f $DOWNLOADS/gst-plugins-base-1.12.3.tar.xz ]; then
       cd $DOWNLOADS
-      curl -L $addl_curl_args "https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-1.12.3.tar.xz" -o "gst-plugins-base-1.12.3.tar.xz"
+      $SYS_CURL -L $addl_curl_args "https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-1.12.3.tar.xz" -o "gst-plugins-base-1.12.3.tar.xz"
     fi
     cd $DOWNLOADS
     tar -xvf gst-plugins-base-1.12.3.tar.xz
@@ -502,7 +511,7 @@ if [ ! -f $DOWNLOADS/local/lib/libgstvideo-1.0.dylib ]; then
     done
 
     ./configure --prefix=$DOWNLOADS/local --disable-gtk-doc -- CFLAGS="-I$DOWNLOADS/local/include" LDFLAGS="-L$DOWNLOADS/local/lib"
-    make
+    make -j $max_parallel
     make install
   fi
 fi
@@ -512,7 +521,7 @@ if [ ! -f $DOWNLOADS/local/lib/gstreamer-1.0/libgstavi.la ]; then
   echo "gst-plugin-good not found. Installing"
   if [ ! -f $DOWNLOADS/gst-plugins-good-1.12.3.tar.xz ]; then
     cd $DOWNLOADS
-    curl -L $addl_curl_args "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-1.12.3.tar.xz" -o "gst-plugins-good-1.12.3.tar.xz"
+    $SYS_CURL -L $addl_curl_args "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-1.12.3.tar.xz" -o "gst-plugins-good-1.12.3.tar.xz"
   fi
   cd $DOWNLOADS
   tar -xvf gst-plugins-good-1.12.3.tar.xz
@@ -525,7 +534,7 @@ if [ ! -f $DOWNLOADS/local/lib/gstreamer-1.0/libgstavi.la ]; then
   done
 
   ./configure --prefix=$DOWNLOADS/local --disable-examples --disable-x --disable-gtk-doc  CFLAGS="-I$DOWNLOADS/local/include" LDFLAGS="-L$DOWNLOADS/local/lib"
-  make
+  make -j $max_parallel
   make install
 fi
 
@@ -535,7 +544,7 @@ if [ ! -f $DOWNLOADS/local/lib/libgstbadvideo-1.0.dylib ]; then
     echo "gst-plugin-bad not found. Installing"
     if [ ! -f $DOWNLOADS/gst-plugins-bad-1.12.3.tar.xz ]; then
       cd $DOWNLOADS
-      curl -L $addl_curl_args  "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.12.3.tar.xz" -o "gst-plugins-bad-1.12.3.tar.xz"
+      $SYS_CURL -L $addl_curl_args "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.12.3.tar.xz" -o "gst-plugins-bad-1.12.3.tar.xz"
     fi
     cd $DOWNLOADS
     tar -xvf gst-plugins-bad-1.12.3.tar.xz
@@ -548,7 +557,7 @@ if [ ! -f $DOWNLOADS/local/lib/libgstbadvideo-1.0.dylib ]; then
     done
 
     ./configure --prefix=$DOWNLOADS/local --disable-gtk-doc --disable-wayland  --disable-opencv --disable-ldap --disable-rtsp --without-zlib --without-ssl --disable-yadif --disable-sdl --disable-debug --disable-dependency-tracking LIBTOOL="$DOWNLOADS/gst-plugins-bad-1.12.3/libtool --tag=CC" CFLAGS="-I$DOWNLOADS/local/include" LDFLAGS="-L$DOWNLOADS/local/lib"
-    make
+    make -j $max_parallel
     make install
   fi
 fi
@@ -558,7 +567,7 @@ if [ ! -f $DOWNLOADS/local/bin/yasm ]; then
   echo "yasm-1.3.0.tar.gz not found. Installing"
    if [ ! -f $DOWNLOADS/yasm-1.3.0.tar.gz ]; then
      cd $DOWNLOADS
-     curl -L $addl_curl_args "http://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz" -o "yasm-1.3.0.tar.gz"
+     $SYS_CURL -L $addl_curl_args "http://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz" -o "yasm-1.3.0.tar.gz"
      cd $DOWNLOADS
    fi
    cd $DOWNLOADS
@@ -571,7 +580,7 @@ if [ ! -f $DOWNLOADS/local/bin/yasm ]; then
      fi
    done
    ./configure --prefix=$DOWNLOADS/local  CFLAGS="-I$DOWNLOADS/local/include" LDFLAGS="-L$DOWNLOADS/local/lib"
-   make
+   make -j $max_parallel
    make install
 fi
 
@@ -581,7 +590,7 @@ if [ ! -f $DOWNLOADS/local/lib/gstreamer-1.0/libgstlibav.so ]; then
     echo "gst-libav not found. Installing"
     if [ ! -f $DOWNLOADS/gst-libav-1.12.4.tar.xz ]; then
       cd $DOWNLOADS
-      curl -L $addl_curl_args "https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-1.12.4.tar.xz" -o "gst-libav-1.12.4.tar.xz"
+      $SYS_CURL -L $addl_curl_args "https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-1.12.4.tar.xz" -o "gst-libav-1.12.4.tar.xz"
     fi
     cd $DOWNLOADS
     tar -xvf gst-libav-1.12.4.tar.xz
@@ -593,13 +602,13 @@ if [ ! -f $DOWNLOADS/local/lib/gstreamer-1.0/libgstlibav.so ]; then
       fi
     done
     ./configure --prefix=$DOWNLOADS/local CFLAGS="-I$DOWNLOADS/local/include" LDFLAGS="-L$DOWNLOADS/local/lib"
-    make
+    make -j $max_parallel
     make install
   fi
 fi
 
 #  ---------Don't build ugly-plugins and x264  if called as install-script -e -----------------------------------------
-# build_extras 
+# build_extras
 
 if [ "$build_extras" == "Y" ]; then
 
@@ -609,7 +618,7 @@ if [ "$build_extras" == "Y" ]; then
       echo "x264 not found. Installing"
       if [ ! -f $DOWNLOADS/x264-snapshot-20171204-2245-stable.tar.bz2 ]; then
         cd $DOWNLOADS
-        curl -L $addl_curl_args "https://download.videolan.org/x264/snapshots/x264-snapshot-20171204-2245-stable.tar.bz2" -o "x264-snapshot-20171204-2245-stable.tar.bz2"
+        $SYS_CURL -L $addl_curl_args "https://download.videolan.org/x264/snapshots/x264-snapshot-20171204-2245-stable.tar.bz2" -o "x264-snapshot-20171204-2245-stable.tar.bz2"
       fi
       cd $DOWNLOADS
       tar -xvf x264-snapshot-20171204-2245-stable.tar.bz2
@@ -622,7 +631,7 @@ if [ "$build_extras" == "Y" ]; then
       done
 
       ./configure --prefix=$DOWNLOADS/local --enable-shared --disable-cli --disable-asm
-      make
+      make -j $max_parallel
       make install
     fi
   fi
@@ -633,7 +642,7 @@ if [ "$build_extras" == "Y" ]; then
       echo "gst-plugin-ugly not found. Installing"
       if [ ! -f $DOWNLOADS/gst-plugins-ugly-1.12.3.tar.xz ]; then
         cd $DOWNLOADS
-        curl -L $addl_curl_args "https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-1.12.3.tar.xz" -o "gst-plugins-ugly-1.12.3.tar.xz"
+        $SYS_CURL -L $addl_curl_args "https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-1.12.3.tar.xz" -o "gst-plugins-ugly-1.12.3.tar.xz"
       fi
       cd $DOWNLOADS
       tar -xvf gst-plugins-ugly-1.12.3.tar.xz
@@ -646,12 +655,12 @@ if [ "$build_extras" == "Y" ]; then
       done
 
       ./configure --prefix=$DOWNLOADS/local --disable-gtk-doc CFLAGS="-I$DOWNLOADS/local/include" LDFLAGS="-L$DOWNLOADS/local/lib"
-      make
+      make -j $max_parallel
       make install
     fi
   fi
 
-else 
+else
   echo " **** Skipping gst-plugins-ugly, yasm and x264 ***** "
 fi # build_extras
 
@@ -666,7 +675,7 @@ if [[ $sys_info =~ ^arm ]]; then
       echo "gst-omx not found. Installing"
       if [ ! -f $DOWNLOADS/gst-omx-1.10.4.tar.xz ]; then
         cd $DOWNLOADS
-        curl -L $addl_curl_args "https://gstreamer.freedesktop.org/src/gst-omx/gst-omx-1.10.4.tar.xz" -o "gst-omx-1.10.4.tar.xz"
+        $SYS_CURL -L $addl_curl_args "https://gstreamer.freedesktop.org/src/gst-omx/gst-omx-1.10.4.tar.xz" -o "gst-omx-1.10.4.tar.xz"
       fi
       cd $DOWNLOADS
       tar -xvf gst-omx-1.10.4.tar.xz
@@ -679,11 +688,17 @@ if [[ $sys_info =~ ^arm ]]; then
       done
 
       ./configure --prefix=$DOWNLOADS/local --disable-gtk-doc --with-omx-header-path=/opt/vc/include/IL --with-omx-target=rpi CFLAGS="-I$DOWNLOADS/local/include" LDFLAGS="-L$DOWNLOADS/local/lib"
-      make
+      make -j $max_parallel
       make install
     fi
   fi
-fi 
+fi
+
+# ---Clean Up----------------------------------------------------------------------------------------------------------
+if [ "$do_cleanup" = true ]; then
+  cd $KINESIS_VIDEO_ROOT/downloads
+  rm -rf $(ls -I local)
+fi
 
 # ---Setting environment variables for cmake --------------------------------------------------------------------------
 
@@ -693,16 +708,16 @@ export CMAKE_PREFIX_PATH="$DOWNLOADS/local"
 ## --------- build kinesis video --------------------------------------------------------------------------------------
 cd $KINESIS_VIDEO_ROOT
 cmake CMakeLists.txt
-make producer
-make start
-make kinesis_video_gstreamer_sample_app
-make kinesis_video_gstreamer_sample_rtsp_app
+make -j $max_parallel producer
+make -j $max_parallel start
+make -j $max_parallel kinesis_video_gstreamer_sample_app
+make -j $max_parallel kinesis_video_gstreamer_sample_rtsp_app
 # copy the kvssink plugin into the library folder
 cp libproducer* "$LIB_DESTINATION_FOLDER_PATH"
 
 #  Environment variables in ~/.bashrc or ~/.bash_profile or ~/.zshrc
-echo you may want to add the following environment variables 
-echo in ~/.bashrc or ~/.bash_profile or ~/.zshrc 
+echo you may want to add the following environment variables
+echo in ~/.bashrc or ~/.bash_profile or ~/.zshrc
 
 export LD_LIBRARY_PATH="$KINESIS_VIDEO_ROOT/downloads/local/lib":$LD_LIBRARY_PATH
 export PATH="$KINESIS_VIDEO_ROOT/downloads/local/bin":$PATH


### PR DESCRIPTION
7a5cb25 add README for using pi image.
4e8d554 by default run make with -j 2
79bc1a0 use pkg-config and cmake find_library to locate libraries
a8f2467 rm cmake and gcc installation files in the same step to reduce size
cbfb47d add option to clean up installation files after build. add option to parallelize make, use system curl to download libraries.
b5aa632 add raspberry pi docker file
c0d414a new install script option change
6b122f1 optimizing the docker image; updating ubuntu docker image to include gstreamer plugin
2228b7b Updating docker readme for pre-built images

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
