### PR TITLE
raspberry pi gst-launch-1.0 option misspell

### DIFF
--- a/install-instructions-linux.md
+++ b/install-instructions-linux.md
@@ -222,7 +222,7 @@ $ gst-launch-1.0 v4l2src do-timestamp=TRUE device=/dev/video0 ! h264parse ! vide
 ###### Running the `gst-launch-1.0` command to start streaming from camera source in **Raspberry-PI**.
 
 ```
-$ gst-launch-1.0 v4l2src do-timestamp=TRUE device=/dev/video0 ! videoconvert ! video/x-raw,format=I420,width=640,height=480,framerate=30/1 ! omxh264enc control-rate=1 target-bitrate=5120000 periodicity-idr=45 inline-header=FALSE ! h264parse ! video/x-h264,stream-format=avc,alignment=au,width=640,height=480,framerate=30/1 ! kvssink stream-name=YourStreamName frame-timestamp=dts-only access-key=YourAccessKey secret-key=YourSecretKey
+$ gst-launch-1.0 v4l2src do-timestamp=TRUE device=/dev/video0 ! videoconvert ! video/x-raw,format=I420,width=640,height=480,framerate=30/1 ! omxh264enc control-rate=1 target-bitrate=5120000 periodicty-idr=45 inline-header=FALSE ! h264parse ! video/x-h264,stream-format=avc,alignment=au,width=640,height=480,framerate=30/1 ! kvssink stream-name=YourStreamName frame-timestamp=dts-only access-key=YourAccessKey secret-key=YourSecretKey
 ```
 
 **Note:**  Raspberry PI camera module requires `frame-timestamp=dts-only` . If USB camera is used for streaming then this property is optional.


### PR DESCRIPTION
*Description of changes:*

Option `periodicity-idr` doen't work for me and `periodicty-idr` worked.
Actually I'm not sure about it whether it is misspell or problem of my running environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

ps. I don't expect this to be merged like #98  
But just want to point out options and help other people as possible I can!
Thank you for keep this library.