### PR TITLE
update log4cplus sources from sourceforge to github

### DIFF
--- a/kinesis-video-native-build/install-script
+++ b/kinesis-video-native-build/install-script
@@ -210,7 +210,7 @@ if [ ! -f $DOWNLOADS/local/lib/liblog4cplus.dylib ]; then
     echo "log4cplus lib not found. Installing"
     if [ ! -f $DOWNLOADS/log4cplus-1.2.0.tar.xz ]; then
       cd $DOWNLOADS
-      $SYS_CURL -L $addl_curl_args "http://sourceforge.net/projects/log4cplus/files/log4cplus-stable/1.2.0/log4cplus-1.2.0.tar.xz" -o "log4cplus-1.2.0.tar.xz"
+      $SYS_CURL -L $addl_curl_args "https://github.com/log4cplus/log4cplus/releases/download/REL_1_2_0/log4cplus-1.2.0.tar.xz" -o "log4cplus-1.2.0.tar.xz"
     fi
     cd $DOWNLOADS
     tar -xvf log4cplus-1.2.0.tar.xz

--- a/kinesis-video-native-build/min-install-script
+++ b/kinesis-video-native-build/min-install-script
@@ -50,7 +50,7 @@ if [ ! -f $DOWNLOADS/local/lib/liblog4cplus.dylib ]; then
     echo "log4cplus lib not found. Installing"
     if [ ! -f $DOWNLOADS/log4cplus-1.2.0.tar.xz ]; then
       cd $DOWNLOADS
-      curl -L "https://sourceforge.net/projects/log4cplus/files/log4cplus-stable/1.2.0/log4cplus-1.2.0.tar.xz" -o "log4cplus-1.2.0.tar.xz"
+      curl -L "https://github.com/log4cplus/log4cplus/releases/download/REL_1_2_0/log4cplus-1.2.0.tar.xz" -o "log4cplus-1.2.0.tar.xz"
     fi
     cd $DOWNLOADS
     tar -xvf log4cplus-1.2.0.tar.xz

--- a/kinesis-video-native-build/msys2-install-script
+++ b/kinesis-video-native-build/msys2-install-script
@@ -140,7 +140,7 @@ if [ ! -f ${MINGW_PREFIX}/lib/liblog4cplus.dll.a ]; then
   echo "log4cplus lib not found. Installing"
   if [ ! -f $DOWNLOADS/log4cplus-1.2.0.tar.xz ]; then
     cd $DOWNLOADS
-    curl -L "https://sourceforge.net/projects/log4cplus/files/log4cplus-stable/1.2.0/log4cplus-1.2.0.tar.xz" -o "log4cplus-1.2.0.tar.xz"
+    curl -L "https://github.com/log4cplus/log4cplus/releases/download/REL_1_2_0/log4cplus-1.2.0.tar.xz" -o "log4cplus-1.2.0.tar.xz"
   fi
   cd $DOWNLOADS
   tar -xvf log4cplus-1.2.0.tar.xz


### PR DESCRIPTION
*Description of changes:*

Part of our continuous integration pipeline requires building the KVS Producer SDK, but it is failing because downloading `log4cplus` from SourceForge appears to be unreliable (frequently getting `curl: (35) gnutls_handshake() failed: Error in the push function.` errors as of March 5th, 2019).

We believe that downloading from GitHub is more reliable and would like the install scripts to be updated to download the `log4cplus` sources from GitHub.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.