### PR TITLE
Aligning parameter ordering

### DIFF
--- a/docker_native_scripts/Dockerfile
+++ b/docker_native_scripts/Dockerfile
@@ -51,7 +51,7 @@ ENTRYPOINT ["/opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-na
 # rtspdockertest      latest              54f0d65f69b2        Less than a second ago   2.82GB
 #
 # === Start the container with credentials ===
-# $ docker run -it 54f0d65f69b2 <AWS_ACCESS_KEY_ID> <AWS_SECRET_ACCESS_KEY> <RTSP_URL> <STREAM_NAME>
+# $ docker run -it 54f0d65f69b2 <AWS_ACCESS_KEY_ID> <AWS_SECRET_ACCESS_KEY> <STREAM_NAME> <RTSP_URL>
 #
 #
 #


### PR DESCRIPTION
*Description of changes:*
Aligning parameter ordering.

As it is in the README file: https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/blob/master/docker_native_scripts/README.md
Which is the proper way, also the AWS SDK example page is misaligned: https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/examples-rtsp.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
