### PR TITLE
Updated readme to include sudo during docker login

### DIFF
--- a/docker_native_scripts/raspberry-pi-docker/README.md
+++ b/docker_native_scripts/raspberry-pi-docker/README.md
@@ -29,8 +29,10 @@ you will see an **output** similar to the one below.
 
 2.  `docker login -u AWS -p <Password>   https://<YourAccountId>.dkr.ecr.us-west-2.amazonaws.com`
 
-Run the command as such in your command prompt. This will authorize the `docker pull` which you will be running next.
+Copy it and ensure that it has no whitespaces, or blank lines and run the command as such in your command prompt. 
 
+Note, if you might need to add a `sudo` to it, as we are running the docker pulls as *sudo* in the next steps.
+This will authorize the `docker pull` which you will be running next. 
 
 #### Step 2: Pull Image
 


### PR DESCRIPTION
I added a note in the readme to inform users to remember to clean the output of the `aws ecr get-login` command and to add a `sudo` when doing a `docker login`, as this is what we are using in the later stages.

I spent a bit of time figuring this out, so I thought I would make a PR. 

*Issue #, if available:*

*Description of changes:* 

Updated the readme to be more informative.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
