### PR TITLE
Call parse_args from install-script-common.sh

### DIFF
--- a/kinesis-video-native-build/java-install-script
+++ b/kinesis-video-native-build/java-install-script
@@ -22,6 +22,7 @@ build_gst_artifact=FALSE
 build_jni_only=TRUE
 build_producer=FALSE
 env_var=""
+parse_args $@
 
 setup
 


### PR DESCRIPTION
Call the parse_args function so that we can set `max_parallel` to something higher than 2.