### PR TITLE
Fix cert file must ending with pem

### DIFF
--- a/kinesis-video-c-producer/src/source/Common/Curl/CurlCall.c
+++ b/kinesis-video-c-producer/src/source/Common/Curl/CurlCall.c
@@ -15,7 +15,6 @@ STATUS blockingCurlCall(PRequestInfo pRequestInfo, PCallInfo pCallInfo)
     struct curl_slist* pHeaderList = NULL;
     CHAR errorBuffer[CURL_ERROR_SIZE];
     errorBuffer[0] = '\0';
-    UINT32 length;
     STAT_STRUCT entryStat;
     BOOL secureConnection;
 
@@ -39,13 +38,6 @@ STATUS blockingCurlCall(PRequestInfo pRequestInfo, PCallInfo pCallInfo)
                 // Assume it's the path as we have a directory
                 curl_easy_setopt(curl, CURLOPT_CAPATH, pRequestInfo->certPath);
             } else {
-                // We should check for the extension being PEM
-                length = (UINT32) STRNLEN(pRequestInfo->certPath, MAX_PATH_LEN);
-                CHK(length > ARRAY_SIZE(CA_CERT_PEM_FILE_EXTENSION), STATUS_INVALID_ARG_LEN);
-                CHK(0 ==
-                    STRCMPI(CA_CERT_PEM_FILE_EXTENSION, &pRequestInfo->certPath[length - ARRAY_SIZE(CA_CERT_PEM_FILE_EXTENSION) + 1]),
-                    STATUS_INVALID_CA_CERT_PATH);
-
                 curl_easy_setopt(curl, CURLOPT_CAINFO, pRequestInfo->certPath);
             }
         }

--- a/kinesis-video-c-producer/src/source/Response.c
+++ b/kinesis-video-c-producer/src/source/Response.c
@@ -143,7 +143,6 @@ STATUS initializeCurlSession(PRequestInfo pRequestInfo,
     STATUS retStatus = STATUS_SUCCESS;
     BOOL secureConnection;
     CURL* pCurl = NULL;
-    UINT32 length;
     STAT_STRUCT entryStat;
 
     CHK(pRequestInfo != NULL && pCallInfo != NULL && ppCurl != NULL, STATUS_NULL_ARG);
@@ -178,13 +177,6 @@ STATUS initializeCurlSession(PRequestInfo pRequestInfo,
                 // Assume it's the path as we have a directory
                 curl_easy_setopt(pCurl, CURLOPT_CAPATH, pRequestInfo->certPath);
             } else {
-                // We should check for the extension being PEM
-                length = (UINT32) STRNLEN(pRequestInfo->certPath, MAX_PATH_LEN);
-                CHK(length > ARRAY_SIZE(CA_CERT_FILE_SUFFIX), STATUS_INVALID_ARG_LEN);
-                CHK(0 ==
-                    STRCMPI(CA_CERT_FILE_SUFFIX, &pRequestInfo->certPath[length - ARRAY_SIZE(CA_CERT_FILE_SUFFIX) + 1]),
-                    STATUS_INVALID_CA_CERT_PATH);
-
                 curl_easy_setopt(pCurl, CURLOPT_CAINFO, pRequestInfo->certPath);
             }
         }


### PR DESCRIPTION
*Issue https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/issues/277 *

*Description of changes:*
Remove of checking for cert file must be ending with pem. (I can end with crt, cert, etc., no need to do a checking on that.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
