### PR TITLE
Escape character for PATH variables in the generated set script

### DIFF
--- a/kinesis-video-native-build/install-script
+++ b/kinesis-video-native-build/install-script
@@ -682,8 +682,8 @@ cd "${KINESIS_VIDEO_ROOT}"
 # invoked first.
 # adding $KINESIS_VIDEO_ROOT/downloads/local/lib to $LD_LIBRARY_PATH so the linker can find the libraries.
 cat > set_kvs_sdk_env.sh << END_TEXT
-export PATH="$KINESIS_VIDEO_ROOT/downloads/local/bin":$PATH
-export LD_LIBRARY_PATH="$KINESIS_VIDEO_ROOT/downloads/local/lib:$LD_LIBRARY_PATH"
+export PATH="$KINESIS_VIDEO_ROOT/downloads/local/bin:\$PATH"
+export LD_LIBRARY_PATH="$KINESIS_VIDEO_ROOT/downloads/local/lib:\$LD_LIBRARY_PATH"
 END_TEXT
 chmod a+x set_kvs_sdk_env.sh
 


### PR DESCRIPTION
When generating the `set_kvs_sdk_env.sh` script near the end of the install-script the $PATH and $LD_LIBRARY_PATH aren't escaped. I'm not sure if this is intentional however it causes problems when running `set_kvs_sdk_env.sh` if the $PATH is empty during the install.

Example of the line in `set_kvs_sdk_env.sh` after a build.

```bash
export PATH="/usr/src/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/bin":
```

Post changes I get

```bash
export PATH="/usr/src/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/downloads/local/bin:$PATH"
```

I was able to reproduce this error in a docker container. I could be incorrect (maybe the way this process works in a docker container is different).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
