### PR TITLE
Bugfix: Show log level of log messages instead of given logger level

### DIFF
--- a/kinesis-video-c-producer/src/source/FileLoggerPlatformCallbackProvider.c
+++ b/kinesis-video-c-producer/src/source/FileLoggerPlatformCallbackProvider.c
@@ -70,7 +70,7 @@ VOID fileLoggerLogPrintFn(UINT32 level, PCHAR tag, PCHAR fmt, ...)
     if (level >= GET_LOGGER_LOG_LEVEL() && gFileLogger != NULL) {
         MUTEX_LOCK(gFileLogger->lock);
 
-        addLogMetadata(logFmtString, (UINT32) ARRAY_SIZE(logFmtString), fmt);
+        addLogMetadata(logFmtString, (UINT32) ARRAY_SIZE(logFmtString), fmt, level);
 
         if (gFileLogger->printLog) {
             va_start(valist, fmt);

--- a/kinesis-video-pic/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
+++ b/kinesis-video-pic/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
@@ -909,9 +909,10 @@ PUBLIC_API UINT32 loggerGetLogLevel();
  * @PCHAR - IN - buffer holding the log
  * @UINT32 - IN - buffer length
  * @PCHAR - IN - log format string
+ * @UINT32 - IN - log level
  * @return - VOID
  */
-PUBLIC_API VOID addLogMetadata(PCHAR, UINT32, PCHAR);
+PUBLIC_API VOID addLogMetadata(PCHAR, UINT32, PCHAR, UINT32);
 
 /**
  * Updates a CRC32 checksum

--- a/kinesis-video-pic/src/utils/src/Logger.c
+++ b/kinesis-video-pic/src/utils/src/Logger.c
@@ -2,9 +2,9 @@
 
 static volatile SIZE_T gLoggerLogLevel = LOG_LEVEL_WARN;
 
-PCHAR getLogLevelStr()
+PCHAR getLogLevelStr(UINT32 loglevel)
 {
-    switch (loggerGetLogLevel()) {
+    switch (loglevel) {
         case LOG_LEVEL_VERBOSE:
             return LOG_LEVEL_VERBOSE_STR;
         case LOG_LEVEL_DEBUG:
@@ -22,7 +22,7 @@ PCHAR getLogLevelStr()
     }
 }
 
-VOID addLogMetadata(PCHAR buffer, UINT32 bufferLen, PCHAR fmt)
+VOID addLogMetadata(PCHAR buffer, UINT32 bufferLen, PCHAR fmt, UINT32 logLevel)
 {
     UINT32 timeStrLen = 0;
     /* space for "yyyy-mm-dd HH:MM:SS\0" + space + null */
@@ -44,7 +44,7 @@ VOID addLogMetadata(PCHAR buffer, UINT32 bufferLen, PCHAR fmt)
         timeString[0] = '\0';
     }
 
-    offset = (UINT32) SNPRINTF(buffer, bufferLen, "%s%-*s ", timeString, MAX_LOG_LEVEL_STRLEN, getLogLevelStr());
+    offset = (UINT32) SNPRINTF(buffer, bufferLen, "%s%-*s ", timeString, MAX_LOG_LEVEL_STRLEN, getLogLevelStr(logLevel));
 #ifdef ENABLE_LOG_THREAD_ID
     offset += SNPRINTF(buffer + offset, bufferLen - offset, "%s ", tidString);
 #endif
@@ -62,7 +62,7 @@ VOID defaultLogPrint(UINT32 level, PCHAR tag, PCHAR fmt, ...)
     UNUSED_PARAM(tag);
 
     if (level >= logLevel) {
-        addLogMetadata(logFmtString, (UINT32) ARRAY_SIZE(logFmtString), fmt);
+        addLogMetadata(logFmtString, (UINT32) ARRAY_SIZE(logFmtString), fmt, level);
 
         va_list valist;
         va_start(valist, fmt);


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Before fixing the issue, when running ./kinesis_video_cproducer_video_only_sample my-stream, all logs are debug.
```
2020-01-11 00:22:02 DEBUG   heapInitialize(): Initializing native heap with limit size 134217728, spill ratio 0% and flags 0x00000001
2020-01-11 00:22:02 DEBUG   heapInitialize(): Creating AIV heap.
2020-01-11 00:22:02 DEBUG   heapInitialize(): Heap is initialized OK
2020-01-11 00:22:02 DEBUG   stepStateMachine(): State Machine - Current state: 0x0000000000000001, Next state: 0x0000000000000002
2020-01-11 00:22:02 DEBUG   stepStateMachine(): State Machine - Current state: 0x0000000000000002, Next state: 0x0000000000000010
2020-01-11 00:22:02 DEBUG   createDeviceResultEvent(): Create device result event.
2020-01-11 00:22:02 DEBUG   stepStateMachine(): State Machine - Current state: 0x0000000000000010, Next state: 0x0000000000000040
2020-01-11 00:22:02 DEBUG   createKinesisVideoStream(): Creating Kinesis Video Stream.
2020-01-11 00:22:02 DEBUG   stepStateMachine(): State Machine - Current state: 0x0000000000000001, Next state: 0x0000000000000002
2020-01-11 00:22:02 DEBUG   writeHeaderCallback(): RequestId: b6990209-7c72-4558-ac58-002c1aa670c4
2020-01-11 00:22:02 DEBUG   describeStreamCurlHandler(): DescribeStream API response: {"StreamInfo":{"CreationTime":1.532801748056E9,"DataRetentionInHours":720,"DeviceName":"Kinesis
```

After fixing the issue
```
2020-01-11 00:16:42 INFO    heapInitialize(): Initializing native heap with limit size 134217728, spill ratio 0% and flags 0x00000001
2020-01-11 00:16:42 INFO    heapInitialize(): Creating AIV heap.
2020-01-11 00:16:42 INFO    heapInitialize(): Heap is initialized OK
2020-01-11 00:16:42 DEBUG   stepStateMachine(): State Machine - Current state: 0x0000000000000001, Next state: 0x0000000000000002
2020-01-11 00:16:42 DEBUG   stepStateMachine(): State Machine - Current state: 0x0000000000000002, Next state: 0x0000000000000010
2020-01-11 00:16:42 INFO    createDeviceResultEvent(): Create device result event.
2020-01-11 00:16:42 DEBUG   stepStateMachine(): State Machine - Current state: 0x0000000000000010, Next state: 0x0000000000000040
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
