### PR TITLE
Use absolute timestamp as default in gstreamer samples/plugin

### DIFF
--- a/kinesis-video-gst-demo/kinesis_video_gstreamer_sample_app.cpp
+++ b/kinesis-video-gst-demo/kinesis_video_gstreamer_sample_app.cpp
@@ -34,7 +34,7 @@ LOGGER_TAG("com.amazonaws.kinesis.video.gstreamer");
 #define DEFAULT_TIMECODE_SCALE_MILLISECONDS 1
 #define DEFAULT_KEY_FRAME_FRAGMENTATION TRUE
 #define DEFAULT_FRAME_TIMECODES TRUE
-#define DEFAULT_ABSOLUTE_FRAGMENT_TIMES FALSE
+#define DEFAULT_ABSOLUTE_FRAGMENT_TIMES TRUE
 #define DEFAULT_FRAGMENT_ACKS TRUE
 #define DEFAULT_RESTART_ON_ERROR TRUE
 #define DEFAULT_RECALCULATE_METRICS TRUE
@@ -74,7 +74,9 @@ typedef struct _CustomData {
             base_pts(0),
             max_frame_pts(0),
             key_frame_pts(0),
-            main_loop(NULL) {
+            main_loop(NULL),
+            first_pts(GST_CLOCK_TIME_NONE),
+            use_absolute_fragment_times(true) {
         producer_start_time = chrono::duration_cast<nanoseconds>(systemCurrentTime().time_since_epoch()).count();
     }
 
@@ -126,6 +128,11 @@ typedef struct _CustomData {
     unique_ptr<Credentials> credential;
 
     uint64_t synthetic_dts;
+
+    bool use_absolute_fragment_times;
+
+    // Pts of first video frame
+    uint64_t first_pts;
 } CustomData;
 
 namespace com { namespace amazonaws { namespace kinesis { namespace video {
@@ -383,6 +390,14 @@ static GstFlowReturn on_new_sample(GstElement *sink, CustomData *data) {
             if (CHECK_FRAME_FLAG_KEY_FRAME(kinesis_video_flags)) {
                 data->key_frame_pts = buffer->pts;
             }
+        } else if (data->use_absolute_fragment_times) {
+            if (data->first_pts == GST_CLOCK_TIME_NONE) {
+                data->first_pts = buffer->pts;
+            }
+            if (data->producer_start_time == GST_CLOCK_TIME_NONE) {
+                data->producer_start_time = chrono::duration_cast<nanoseconds>(systemCurrentTime().time_since_epoch()).count();
+            }
+            buffer->pts += data->producer_start_time - data->first_pts;
         }
 
         if (!gst_buffer_map(buffer, &info, GST_MAP_READ)){
@@ -533,11 +548,11 @@ void kinesis_video_stream_init(CustomData *data) {
     SPRINTF(tag_val, "piValue");
 
     STREAMING_TYPE streaming_type = DEFAULT_STREAMING_TYPE;
-    bool use_absolute_fragment_times = DEFAULT_ABSOLUTE_FRAGMENT_TIMES;
+    data->use_absolute_fragment_times = DEFAULT_ABSOLUTE_FRAGMENT_TIMES;
 
     if (data->streamSource == FILE_SOURCE) {
         streaming_type = STREAMING_TYPE_OFFLINE;
-        use_absolute_fragment_times = true;
+        data->use_absolute_fragment_times = true;
     }
 
     unique_ptr<StreamDefinition> stream_definition(new StreamDefinition(
@@ -552,7 +567,7 @@ void kinesis_video_stream_init(CustomData *data) {
         milliseconds(DEFAULT_TIMECODE_SCALE_MILLISECONDS),
         DEFAULT_KEY_FRAME_FRAGMENTATION,
         DEFAULT_FRAME_TIMECODES,
-        use_absolute_fragment_times,
+        data->use_absolute_fragment_times,
         DEFAULT_FRAGMENT_ACKS,
         DEFAULT_RESTART_ON_ERROR,
         DEFAULT_RECALCULATE_METRICS,
@@ -970,6 +985,12 @@ int gstreamer_init(int argc, char* argv[], CustomData *data) {
     GstElement *pipeline;
     int ret;
     GstStateChangeReturn gst_ret;
+
+    // Reset first frame pts
+    data->first_pts = GST_CLOCK_TIME_NONE;
+
+    // Reset producer start time
+    data->producer_start_time = GST_CLOCK_TIME_NONE;
 
     switch (data->streamSource) {
         case LIVE_SOURCE:

--- a/kinesis-video-gstreamer-plugin/src/gstkvssink.h
+++ b/kinesis-video-gstreamer-plugin/src/gstkvssink.h
@@ -147,7 +147,9 @@ typedef struct _CustomData {
             pts_base(0),
             media_type(VIDEO_ONLY),
             first_video_frame(true),
-            frame_count(0)  {}
+            frame_count(0),
+            first_pts(GST_CLOCK_TIME_NONE),
+            producer_start_time(GST_CLOCK_TIME_NONE) {}
     unique_ptr<KinesisVideoProducer> kinesis_video_producer;
     shared_ptr<KinesisVideoStream> kinesis_video_stream;
 
@@ -162,6 +164,8 @@ typedef struct _CustomData {
 
     uint64_t last_dts;
     uint64_t pts_base;
+    uint64_t first_pts;
+    uint64_t producer_start_time;
 } CustomData;
 
 #endif /* __GST_KVS_SINK_H__ */


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Use absolute timestamp as default in gstreamer samples/plugin

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
