### PR TITLE
change resetKinesisVideoConnection to terminate all active upload han…

### DIFF
--- a/kinesis-video-c-producer/src/source/CurlApiCallbacks.c
+++ b/kinesis-video-c-producer/src/source/CurlApiCallbacks.c
@@ -2188,7 +2188,7 @@ CleanUp:
     return (PVOID) (ULONG_PTR) retStatus;
 }
 
-// Accquire activeUploads lock before calling this function!!!
+// Acquire activeUploads lock before calling this function!!!
 STATUS findRequestWithUploadHandle(UPLOAD_HANDLE uploadHandle, PCurlApiCallbacks pCurlApiCallbacks,
                                    PCurlRequest *ppCurlRequest)
 {

--- a/kinesis-video-c-producer/src/source/Response.c
+++ b/kinesis-video-c-producer/src/source/Response.c
@@ -693,7 +693,7 @@ SIZE_T postReadCallback(PCHAR pBuffer, SIZE_T size, SIZE_T numItems, PVOID custo
             // Media pipeline thread might be blocked due to heap or temporal limit.
             // Pause curl read and wait for persisted ack.
             if (bytesWritten == 0) {
-                DLOGD("Pausing CURL read for upload handle: %" PRIu64, uploadHandle);
+                DLOGV("Pausing CURL read for upload handle: %" PRIu64, uploadHandle);
                 bytesWritten = CURL_READFUNC_PAUSE;
             }
             break;

--- a/kinesis-video-c-producer/tst/ProducerTestFixture.h
+++ b/kinesis-video-c-producer/tst/ProducerTestFixture.h
@@ -313,8 +313,10 @@ protected:
     volatile BOOL mCurlWriteCallbackPassThrough;
 
     STATUS mReadStatus;
-    UINT32 mReadSize;
-    UPLOAD_HANDLE mAbortUploadhandle;
+    STATUS mInjectReadStatus;
+    UINT32 mInjectedReadSize;
+    UPLOAD_HANDLE mReadAbortUploadhandle;
+    UPLOAD_HANDLE mWriteAbortUploadhandle;
 
     // reset st connection
     UINT32 mResetStreamCounter;

--- a/kinesis-video-pic/src/client/include/com/amazonaws/kinesis/video/client/Include.h
+++ b/kinesis-video-pic/src/client/include/com/amazonaws/kinesis/video/client/Include.h
@@ -187,14 +187,15 @@ extern "C" {
 #define STATUS_CLIENT_SHUTTING_DOWN                                                 STATUS_CLIENT_BASE + 0x00000087
 #define STATUS_PUTMEDIA_LAST_PERSIST_ACK_NOT_RECEIVED								STATUS_CLIENT_BASE + 0x00000088
 
-#define IS_RECOVERABLE_ERROR(error)     ((error) == STATUS_ACK_ERR_INVALID_MKV_DATA ||          \
-                                        (error) == STATUS_ACK_ERR_FRAGMENT_ARCHIVAL_ERROR ||    \
-                                        (error) == STATUS_INVALID_ACK_KEY_START ||              \
-                                        (error) == STATUS_INVALID_ACK_DUPLICATE_KEY_NAME ||     \
-                                        (error) == STATUS_INVALID_ACK_INVALID_VALUE_START ||    \
-                                        (error) == STATUS_INVALID_ACK_INVALID_VALUE_END ||      \
-                                        (error) == STATUS_ACK_TIMESTAMP_NOT_IN_VIEW_WINDOW ||   \
-                                        (error) == STATUS_ACK_ERR_FRAGMENT_DURATION_REACHED)    \
+#define IS_RECOVERABLE_ERROR(error)     ((error) == STATUS_ACK_ERR_INVALID_MKV_DATA ||          	\
+                                        (error) == STATUS_ACK_ERR_FRAGMENT_ARCHIVAL_ERROR ||    	\
+                                        (error) == STATUS_INVALID_ACK_KEY_START ||              	\
+                                        (error) == STATUS_INVALID_ACK_DUPLICATE_KEY_NAME ||     	\
+                                        (error) == STATUS_INVALID_ACK_INVALID_VALUE_START ||    	\
+                                        (error) == STATUS_INVALID_ACK_INVALID_VALUE_END ||      	\
+                                        (error) == STATUS_ACK_TIMESTAMP_NOT_IN_VIEW_WINDOW ||   	\
+                                        (error) == STATUS_PUTMEDIA_LAST_PERSIST_ACK_NOT_RECEIVED ||	\
+                                        (error) == STATUS_ACK_ERR_FRAGMENT_DURATION_REACHED)    	\
 
 #define IS_RETRIABLE_ERROR(error)       ((error) == STATUS_DESCRIBE_STREAM_CALL_FAILED ||       \
                                         (error) == STATUS_CREATE_STREAM_CALL_FAILED ||          \

--- a/kinesis-video-pic/src/client/include/com/amazonaws/kinesis/video/client/Include.h
+++ b/kinesis-video-pic/src/client/include/com/amazonaws/kinesis/video/client/Include.h
@@ -185,6 +185,7 @@ extern "C" {
 #define STATUS_MAX_FRAME_TIMESTAMP_DELTA_BETWEEN_TRACKS_EXCEEDED                    STATUS_CLIENT_BASE + 0x00000085
 #define STATUS_STREAM_SHUTTING_DOWN                                                 STATUS_CLIENT_BASE + 0x00000086
 #define STATUS_CLIENT_SHUTTING_DOWN                                                 STATUS_CLIENT_BASE + 0x00000087
+#define STATUS_PUTMEDIA_LAST_PERSIST_ACK_NOT_RECEIVED								STATUS_CLIENT_BASE + 0x00000088
 
 #define IS_RECOVERABLE_ERROR(error)     ((error) == STATUS_ACK_ERR_INVALID_MKV_DATA ||          \
                                         (error) == STATUS_ACK_ERR_FRAGMENT_ARCHIVAL_ERROR ||    \

--- a/kinesis-video-pic/src/client/include/com/amazonaws/kinesis/video/client/Include.h
+++ b/kinesis-video-pic/src/client/include/com/amazonaws/kinesis/video/client/Include.h
@@ -2164,7 +2164,8 @@ PUBLIC_API STATUS kinesisVideoStreamGetStreamInfo(STREAM_HANDLE,
 PUBLIC_API STATUS kinesisVideoStreamResetStream(STREAM_HANDLE);
 
 /**
- * Reset connection for stream, continue sending existing data in buffer with new connection
+ * Reset connection for stream. All existing putMedia connection will be terminated first.
+ * Continue sending existing data with new connection
  *
  * @param 1 STREAM_HANDLE - The stream handle to reset
  *

--- a/kinesis-video-pic/src/client/src/Client.c
+++ b/kinesis-video-pic/src/client/src/Client.c
@@ -1031,14 +1031,14 @@ CleanUp:
 /**
  * Put stream with endless payload API call result event
  */
-STATUS putStreamResultEvent(UINT64 customData, SERVICE_CALL_RESULT callResult, UPLOAD_HANDLE streamHandle)
+STATUS putStreamResultEvent(UINT64 customData, SERVICE_CALL_RESULT callResult, UPLOAD_HANDLE uploadHandle)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     BOOL releaseClientSemaphore = FALSE, releaseStreamSemaphore = FALSE;
     PKinesisVideoStream pKinesisVideoStream = FROM_STREAM_HANDLE(customData);
 
-    DLOGI("Put stream result event.");
+    DLOGI("Put stream result event. New upload handle %" PRIu64, uploadHandle);
     CHK(pKinesisVideoStream != NULL && pKinesisVideoStream->pKinesisVideoClient != NULL, STATUS_NULL_ARG);
 
     // Shutdown sequencer
@@ -1048,7 +1048,7 @@ STATUS putStreamResultEvent(UINT64 customData, SERVICE_CALL_RESULT callResult, U
     CHK_STATUS(semaphoreAcquire(pKinesisVideoStream->base.shutdownSemaphore, INFINITE_TIME_VALUE));
     releaseStreamSemaphore = TRUE;
 
-    CHK_STATUS(putStreamResult(pKinesisVideoStream, callResult, streamHandle));
+    CHK_STATUS(putStreamResult(pKinesisVideoStream, callResult, uploadHandle));
 
 CleanUp:
 

--- a/kinesis-video-pic/src/client/src/Client.c
+++ b/kinesis-video-pic/src/client/src/Client.c
@@ -1135,7 +1135,7 @@ STATUS kinesisVideoStreamTerminated(STREAM_HANDLE streamHandle, UPLOAD_HANDLE st
     BOOL releaseClientSemaphore = FALSE, releaseStreamSemaphore = FALSE;
     PKinesisVideoStream pKinesisVideoStream = FROM_STREAM_HANDLE(streamHandle);
 
-    DLOGI("Stream terminated event.");
+    DLOGI("Stream 0x%" PRIx64 " terminated upload handle %" PRIu64 " with service call result %u.", streamHandle, streamUploadHandle, callResult);
     CHK(pKinesisVideoStream != NULL && pKinesisVideoStream->pKinesisVideoClient != NULL, STATUS_NULL_ARG);
 
     // Shutdown sequencer

--- a/kinesis-video-pic/src/client/src/Stream.c
+++ b/kinesis-video-pic/src/client/src/Stream.c
@@ -1497,8 +1497,19 @@ CleanUp:
     // Remove the upload handle if it is in UPLOAD_HANDLE_STATE_TERMINATED state
     if (NULL != pUploadHandleInfo && pUploadHandleInfo->state == UPLOAD_HANDLE_STATE_TERMINATED) {
         deleteStreamUploadInfo(pKinesisVideoStream, pUploadHandleInfo);
+
+        // if there is no more active upload handle and we still have bytes to transfer,
+        // call kinesisVideoStreamResetConnection to create new upload session.
         pUploadHandleInfo = NULL;
         pUploadHandleInfo = getStreamUploadInfoWithState(pKinesisVideoStream, UPLOAD_HANDLE_STATE_ACTIVE);
+
+        if (pUploadHandleInfo == NULL) {
+            // Get the duration and the size
+            getAvailableViewSize(pKinesisVideoStream, &duration, &viewByteSize);
+            if (viewByteSize != 0) {
+                kinesisVideoStreamResetConnection(TO_STREAM_HANDLE(pKinesisVideoStream));
+            }
+        }
     }
 
     if (clientLocked) {

--- a/kinesis-video-pic/src/client/src/Stream.c
+++ b/kinesis-video-pic/src/client/src/Stream.c
@@ -1500,7 +1500,6 @@ CleanUp:
 
         // if there is no more active upload handle and we still have bytes to transfer,
         // call kinesisVideoStreamResetConnection to create new upload session.
-        pUploadHandleInfo = NULL;
         pUploadHandleInfo = getStreamUploadInfoWithState(pKinesisVideoStream, UPLOAD_HANDLE_STATE_ACTIVE);
 
         if (pUploadHandleInfo == NULL) {

--- a/kinesis-video-pic/src/client/src/Stream.c
+++ b/kinesis-video-pic/src/client/src/Stream.c
@@ -1499,14 +1499,6 @@ CleanUp:
         deleteStreamUploadInfo(pKinesisVideoStream, pUploadHandleInfo);
         pUploadHandleInfo = NULL;
         pUploadHandleInfo = getStreamUploadInfoWithState(pKinesisVideoStream, UPLOAD_HANDLE_STATE_ACTIVE);
-
-        if (pUploadHandleInfo == NULL) {
-            // Get the duration and the size
-            getAvailableViewSize(pKinesisVideoStream, &duration, &viewByteSize);
-            if (viewByteSize != 0) {
-                streamTerminatedEvent(pKinesisVideoStream, INVALID_UPLOAD_HANDLE_VALUE, SERVICE_CALL_RESULT_OK, FALSE);
-            }
-        }
     }
 
     if (clientLocked) {

--- a/kinesis-video-pic/src/client/src/StreamEvent.c
+++ b/kinesis-video-pic/src/client/src/StreamEvent.c
@@ -689,9 +689,9 @@ STATUS streamTerminatedEvent(PKinesisVideoStream pKinesisVideoStream, UPLOAD_HAN
                             // dont spawn new session since there is already an active one.
                             spawnNewUploadSession = FALSE;
 
-                            DLOGW("Upload handle %" PRIu64 " terminated with result %u while other upload handles are active."
-                                "Data sent through upload handle %" PRIu64 " may not be fully persisted.",
-                                uploadHandle, callResult, uploadHandle);
+                            DLOGW("Last fragment with timestamp %" PRIu64 " for upload handle %" PRIu64 " might not be fully persisted",
+                                pUploadHandleInfo->lastFragmentTs,
+                                uploadHandle);
 
                             if (pUploadHandleInfo->state == UPLOAD_HANDLE_STATE_AWAITING_ACK &&
                                 pKinesisVideoClient->clientCallbacks.streamErrorReportFn != NULL) {


### PR DESCRIPTION
…dles. Add unit test simulating curl timeout. When an upload get an error, only indicate rollback if there is no other active upload handle.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
