### PR TITLE
Build automake/autoconf instead of making user install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ addons:
       - libgstreamer-plugins-base1.0-dev
       - default-jdk
 
-before_install:
-    - wget http://ftp.gnu.org/gnu/automake/automake-1.16.1.tar.gz && tar xzvf automake-1.16.1.tar.gz && cd automake-1.16.1 && ./configure && make && sudo make install && cd ..
-
 script:
   - export AWS_KVS_LOG_LEVEL=2
   - make

--- a/CMake/Dependencies/libautoconf-CMakeLists.txt
+++ b/CMake/Dependencies/libautoconf-CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(libautoconf-download NONE)
+
+find_program(MAKE_EXE NAMES make)
+
+include(ExternalProject)
+ExternalProject_Add(project_libautoconf
+    URL               http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
+    PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
+    CONFIGURE_COMMAND ${CMAKE_CURRENT_BINARY_DIR}/build/src/project_libautoconf/configure --prefix=${OPEN_SRC_INSTALL_PREFIX}
+    BUILD_COMMAND     ${MAKE_EXE} -j 4
+    BUILD_IN_SOURCE   TRUE
+    INSTALL_COMMAND   ${MAKE_EXE} install
+    TEST_COMMAND      ""
+)

--- a/CMake/Dependencies/libautomake-CMakeLists.txt
+++ b/CMake/Dependencies/libautomake-CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(libautomake-download NONE)
+
+find_program(MAKE_EXE NAMES make)
+
+include(ExternalProject)
+ExternalProject_Add(project_libautomake
+    URL               http://ftp.gnu.org/gnu/automake/automake-1.16.1.tar.gz
+    PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
+    CONFIGURE_COMMAND ${CMAKE_CURRENT_BINARY_DIR}/build/src/project_libautomake/configure --prefix=${OPEN_SRC_INSTALL_PREFIX}
+    BUILD_COMMAND     ${MAKE_EXE} -j 4
+    BUILD_IN_SOURCE   TRUE
+    INSTALL_COMMAND   ${MAKE_EXE} install
+    TEST_COMMAND      ""
+)

--- a/CMake/Utilities.cmake
+++ b/CMake/Utilities.cmake
@@ -6,6 +6,8 @@ function(build_dependency lib_name)
       openssl
       curl
       mbedtls
+      autoconf
+      automake
       log4cplus)
   list(FIND supported_libs ${lib_name} index)
   if(${index} EQUAL -1)
@@ -13,17 +15,28 @@ function(build_dependency lib_name)
     return()
   endif()
 
-  set(lib_file_name ${lib_name})
-  if (${lib_name} STREQUAL "openssl")
-    set(lib_file_name ssl)
+  set(target_found NOTFOUND)
+
+  if (${lib_name} STREQUAL "autoconf" OR ${lib_name} STREQUAL "automake")
+    find_program(
+      target_found
+      NAMES ${lib_name}
+      PATHS ${OPEN_SRC_INSTALL_PREFIX}/bin
+      NO_DEFAULT_PATH)
+  else()
+    set(lib_file_name ${lib_name})
+    if (${lib_name} STREQUAL "openssl")
+      set(lib_file_name ssl)
+    endif()
+
+    find_library(
+      target_found
+      NAMES ${lib_file_name}
+      PATHS ${OPEN_SRC_INSTALL_PREFIX}/lib
+      NO_DEFAULT_PATH)
   endif()
-  set(library_found NOTFOUND)
-  find_library(
-    library_found
-    NAMES ${lib_file_name}
-    PATHS ${OPEN_SRC_INSTALL_PREFIX}/lib
-    NO_DEFAULT_PATH)
-  if(library_found)
+
+  if(target_found)
     message(STATUS "${lib_name} already built")
     return()
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ if(BUILD_DEPENDENCIES)
 
   set(OPEN_SRC_INSTALL_PREFIX ${KINESIS_VIDEO_OPEN_SOURCE_SRC}/local)
   set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${OPEN_SRC_INSTALL_PREFIX}/lib/pkgconfig")
+  set(ENV{PATH} "$ENV{PATH}:${OPEN_SRC_INSTALL_PREFIX}/bin")
   set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${OPEN_SRC_INSTALL_PREFIX})
 
   message(STATUS "Begin building dependencies.")
@@ -74,6 +75,8 @@ if(BUILD_DEPENDENCIES)
   build_dependency(curl -DBUILD_STATIC=${BUILD_STATIC} -DUSE_OPENSSL=${USE_OPENSSL} -DUSE_MBEDTLS=${USE_MBEDTLS})
 
   build_dependency(jsmn)
+  build_dependency(autoconf)
+  build_dependency(automake)
   build_dependency(log4cplus)
 
   if(BUILD_TEST)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To download run the following command:
 `git clone --recursive https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp.git`
 
 Note: If you miss running git clone with --recursive, run `git submodule update --init` in the amazon-kinesis-video-streams-producer-sdk-cpp/open-source directory
-You will also need to install `pkg-config`, `automake-1.16` and `CMake` and a build enviroment. If you are build the GStreamer plugin you will also need to install it locally.
+You will also need to install `pkg-config` and `CMake` and a build enviroment. If you are build the GStreamer plugin you will also need to install it locally.
 
 Refer to the [FAQ](#FAQ) for platform specific instructions.
 


### PR DESCRIPTION
autoconf/automake isn't widely available at the version we need, instead
just bundle with our CMake setup

Relates to #427 #426
