### PR TITLE
Remove CMAKE_SOURCE_DIR

### DIFF
--- a/CMake/Utilities.cmake
+++ b/CMake/Utilities.cmake
@@ -49,7 +49,7 @@ function(build_dependency lib_name)
 
   # build library
   configure_file(
-    ${CMAKE_SOURCE_DIR}/CMake/Dependencies/lib${lib_name}-CMakeLists.txt
+    ./CMake/Dependencies/lib${lib_name}-CMakeLists.txt
     ${KINESIS_VIDEO_OPEN_SOURCE_SRC}/lib${lib_name}/CMakeLists.txt COPYONLY)
   execute_process(
     COMMAND ${CMAKE_COMMAND} ${build_args}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 
 set(KINESIS_VIDEO_PIC_SRC "${CMAKE_CURRENT_SOURCE_DIR}/open-source/amazon-kinesis-video-streams-pic/")
 set(KINESIS_VIDEO_PRODUCER_C_SRC "${CMAKE_CURRENT_SOURCE_DIR}/open-source/amazon-kinesis-video-streams-producer-c/")
-set(KINESIS_VIDEO_PRODUCER_CPP_SRC "${CMAKE_SOURCE_DIR}")
+set(KINESIS_VIDEO_PRODUCER_CPP_SRC "${CMAKE_CURRENT_SOURCE_DIR}")
 set(KINESIS_VIDEO_OPEN_SOURCE_SRC ${CMAKE_CURRENT_SOURCE_DIR}/open-source)
 
 message(STATUS "Kinesis Video PIC path is ${KINESIS_VIDEO_PIC_SRC}")
@@ -56,7 +56,7 @@ elseif(NOT EXISTS ${KINESIS_VIDEO_PRODUCER_C_SRC})
 endif()
 
 # pass ca cert location to sdk
-add_definitions(-DKVS_CA_CERT_PATH="${CMAKE_SOURCE_DIR}/certs/cert.pem")
+add_definitions(-DKVS_CA_CERT_PATH="${CMAKE_CURRENT_SOURCE_DIR}/certs/cert.pem")
 add_definitions(-DCMAKE_DETECTED_CACERT_PATH)
 
 if(BUILD_DEPENDENCIES)


### PR DESCRIPTION
When the repo is being imported from another project, `CMAKE_SOURCE_DIR` no longer points to the path originally intended.

This issue is related to what we have in the webrtc c sdk, https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/389.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
