### PR TITLE
use more specific name for custom data struct. Use unordered set inst…

### DIFF
--- a/src/gstreamer/KvsSinkStreamCallbackProvider.cpp
+++ b/src/gstreamer/KvsSinkStreamCallbackProvider.cpp
@@ -20,7 +20,7 @@ KvsSinkStreamCallbackProvider::streamErrorReportHandler(UINT64 custom_data,
                                                         UINT64 errored_timecode,
                                                         STATUS status_code) {
     LOG_ERROR("Reported stream error. Errored timecode: " << errored_timecode << " Status: 0x" << std::hex << status_code);
-    auto customDataObj = reinterpret_cast<CustomData*>(custom_data);
+    auto customDataObj = reinterpret_cast<KvsSinkCustomData*>(custom_data);
 
     // ignore if the sdk can recover from the error
     if (!IS_RECOVERABLE_ERROR(status_code)) {

--- a/src/gstreamer/KvsSinkStreamCallbackProvider.h
+++ b/src/gstreamer/KvsSinkStreamCallbackProvider.h
@@ -6,9 +6,9 @@
 
 namespace com { namespace amazonaws { namespace kinesis { namespace video {
     class KvsSinkStreamCallbackProvider : public StreamCallbackProvider {
-        std::shared_ptr<CustomData> data;
+        std::shared_ptr<KvsSinkCustomData> data;
     public:
-        KvsSinkStreamCallbackProvider(std::shared_ptr<CustomData> data) : data(data) {}
+        KvsSinkStreamCallbackProvider(std::shared_ptr<KvsSinkCustomData> data) : data(data) {}
 
         UINT64 getCallbackCustomData() override {
             return reinterpret_cast<UINT64> (data.get());

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -619,7 +619,7 @@ gst_kvs_sink_init(GstKvsSink *kvssink) {
     kvssink->track_info_type = MKV_TRACK_INFO_TYPE_VIDEO;
     kvssink->audio_codec_id = g_strdup (DEFAULT_AUDIO_CODEC_ID_AAC);
 
-    kvssink->data = make_shared<CustomData>();
+    kvssink->data = make_shared<KvsSinkCustomData>();
 
     // Mark plugin as sink
     GST_OBJECT_FLAG_SET (kvssink, GST_ELEMENT_FLAG_SINK);
@@ -930,11 +930,11 @@ gst_kvs_sink_handle_sink_event (GstCollectPads *pads,
                 // Send cpd to kinesis video stream
                 ret = data->kinesis_video_stream->start(codec_private_data, KVS_PCM_CPD_SIZE_BYTE, track_id);
 
-            } else if (data->track_cpd.count(track_id) == 0 && gst_structure_has_field(gststructforcaps, "codec_data")) {
+            } else if (data->track_cpd_received.count(track_id) == 0 && gst_structure_has_field(gststructforcaps, "codec_data")) {
                 const GValue *gstStreamFormat = gst_structure_get_value(gststructforcaps, "codec_data");
                 gchar *cpd = gst_value_serialize(gstStreamFormat);
                 string cpd_str = string(cpd);
-                data->track_cpd[track_id] = cpd_str;
+                data->track_cpd_received.insert(track_id);
                 g_free(cpd);
 
                 // Send cpd to kinesis video stream

--- a/src/gstreamer/gstkvssink.h
+++ b/src/gstreamer/gstkvssink.h
@@ -37,7 +37,7 @@
 #include <mutex>
 #include <atomic>
 #include <gst/base/gstcollectpads.h>
-#include <map>
+#include <unordered_set>
 
 using namespace com::amazonaws::kinesis::video;
 
@@ -60,8 +60,7 @@ G_BEGIN_DECLS
 
 typedef struct _GstKvsSink GstKvsSink;
 typedef struct _GstKvsSinkClass GstKvsSinkClass;
-
-typedef struct _CustomData CustomData;
+typedef struct _KvsSinkCustomData KvsSinkCustomData;
 
 /* all information needed for one track */
 typedef struct _GstKvsSinkTrackData {
@@ -128,7 +127,7 @@ struct _GstKvsSink {
     guint                       num_video_streams;
 
     unique_ptr<Credentials> credentials_;
-    shared_ptr<CustomData> data;
+    shared_ptr<KvsSinkCustomData> data;
 };
 
 struct _GstKvsSinkClass {
@@ -139,9 +138,9 @@ GType gst_kvs_sink_get_type (void);
 
 G_END_DECLS
 
-typedef struct _CustomData {
+struct _KvsSinkCustomData {
 
-    _CustomData():
+    _KvsSinkCustomData():
             stream_status(STATUS_SUCCESS),
             last_dts(0),
             pts_base(0),
@@ -153,7 +152,7 @@ typedef struct _CustomData {
     unique_ptr<KinesisVideoProducer> kinesis_video_producer;
     shared_ptr<KinesisVideoStream> kinesis_video_stream;
 
-    map<uint64_t, string> track_cpd;
+    unordered_set<uint64_t> track_cpd_received;
     GstKvsSink *kvsSink;
     MediaType media_type;
     bool first_video_frame;
@@ -165,6 +164,6 @@ typedef struct _CustomData {
     uint64_t pts_base;
     uint64_t first_pts;
     uint64_t producer_start_time;
-} CustomData;
+};
 
 #endif /* __GST_KVS_SINK_H__ */


### PR DESCRIPTION
…ead of map to track whether cpd has been received for each track.
There was a struct name collision for CustomData struct in file uploader that cause it to crash in Ubuntu.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
