### PR TITLE
Update cmake version to be more specific

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
         # At least one of jobs should use a specific version of cmake so that we know the lower bound version
         - cmake --version
         - sudo rm `which cmake`
-        - sh -c "wget https://cmake.org/files/v3.12/cmake-3.12.4.tar.gz && tar -xf cmake-3.* && cd cmake-3.12.4 && ./bootstrap && make -j4 && sudo make install"
+        - sh -c "wget https://cmake.org/files/v3.0/cmake-3.0.2.tar.gz && tar -xf cmake-3.* && cd cmake-3.0.2 && ./bootstrap && make -j4 && sudo make install"
         - hash -d cmake
         - cmake --version
         - mkdir build && cd build && cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,12 @@ matrix:
       os: linux
       compiler: gcc
       before_script:
+        # At least one of jobs should use a specific version of cmake so that we know the lower bound version
+        - cmake --version
+        - sudo rm `which cmake`
+        - sh -c "wget https://cmake.org/files/v3.12/cmake-3.12.4.tar.gz && tar -xf cmake-3.* && cd cmake-3.12.4 && ./bootstrap && make -j4 && sudo make install"
+        - hash -d cmake
+        - cmake --version
         - mkdir build && cd build && cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE
       after_success:
         - for test_file in $(find CMakeFiles/KinesisVideoProducer.dir gstkvssink.dir KinesisVideoProducerJNI.dir -name '*.gcno'); do gcov $test_file; done

--- a/CMake/Dependencies/libkvscproducer-CMakeLists.txt
+++ b/CMake/Dependencies/libkvscproducer-CMakeLists.txt
@@ -7,7 +7,7 @@ include(ExternalProject)
 # clone repo only
 ExternalProject_Add(libkvscproducer-download
 	GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-producer-c.git
-    GIT_TAG           2ab5602f1e4ddb6ba5d365580d4ea327e1f6f29e
+    GIT_TAG           cmake-update
     SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvscproducer-src"
 	BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvscproducer-build"
 	CONFIGURE_COMMAND ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ if(APPLE AND NOT DEFINED ENV{MACOSX_DEPLOYMENT_TARGET} AND NOT DEFINED ENV{SDKRO
   set(CMAKE_OSX_DEPLOYMENT_TARGET ${CMAKE_SYSTEM_VERSION})
 endif()
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12.4)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake;${CMAKE_MODULE_PATH}")
 include(Utilities)
 project(KinesisVideoProducerCpp)


### PR DESCRIPTION
Issue #494 

The PR will add a specific supported CMake version to the CI so that if we accidentally use a feature that's not available in the supported version, the CI will fail.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
