### PR TITLE
Remove 'using namespace std' from all headers

### DIFF
--- a/samples/kvs_gstreamer_audio_video_sample.cpp
+++ b/samples/kvs_gstreamer_audio_video_sample.cpp
@@ -15,6 +15,7 @@
 #include <queue>
 
 using namespace std;
+using namespace std::chrono;
 using namespace com::amazonaws::kinesis::video;
 using namespace log4cplus;
 

--- a/samples/kvs_gstreamer_multistream_sample.cpp
+++ b/samples/kvs_gstreamer_multistream_sample.cpp
@@ -9,6 +9,7 @@
 #include <map>
 
 using namespace std;
+using namespace std::chrono;
 using namespace com::amazonaws::kinesis::video;
 using namespace log4cplus;
 

--- a/samples/kvs_gstreamer_sample.cpp
+++ b/samples/kvs_gstreamer_sample.cpp
@@ -10,6 +10,7 @@
 #include <IotCertCredentialProvider.h>
 
 using namespace std;
+using namespace std::chrono;
 using namespace com::amazonaws::kinesis::video;
 using namespace log4cplus;
 

--- a/src/KinesisVideoProducer.cpp
+++ b/src/KinesisVideoProducer.cpp
@@ -5,6 +5,10 @@ namespace com { namespace amazonaws { namespace kinesis { namespace video {
 
 LOGGER_TAG("com.amazonaws.kinesis.video");
 
+using std::shared_ptr;
+using std::stringstream;
+using std::unique_ptr;
+
 unique_ptr<KinesisVideoProducer> KinesisVideoProducer::create(
         unique_ptr<DeviceInfoProvider> device_info_provider,
         unique_ptr<ClientCallbackProvider> client_callback_provider,

--- a/src/KinesisVideoProducer.h
+++ b/src/KinesisVideoProducer.h
@@ -186,7 +186,7 @@ protected:
     /**
      * Map of the handle to stream object
      */
-    ThreadSafeMap<STREAM_HANDLE, shared_ptr<KinesisVideoStream>> active_streams_;
+    ThreadSafeMap<STREAM_HANDLE, std::shared_ptr<KinesisVideoStream>> active_streams_;
 };
 
 } // namespace video

--- a/src/KinesisVideoProducerMetrics.h
+++ b/src/KinesisVideoProducerMetrics.h
@@ -4,8 +4,6 @@
 
 #include "com/amazonaws/kinesis/video/client/Include.h"
 
-using namespace std;
-
 namespace com { namespace amazonaws { namespace kinesis { namespace video {
 
 /**

--- a/src/KinesisVideoStreamMetrics.h
+++ b/src/KinesisVideoStreamMetrics.h
@@ -4,9 +4,6 @@
 
 #include "com/amazonaws/kinesis/video/client/Include.h"
 
-using namespace std;
-using namespace std::chrono;
-
 namespace com { namespace amazonaws { namespace kinesis { namespace video {
 
 /**
@@ -27,15 +24,15 @@ public:
     /**
      * Returns the current view duration in millis
      */
-    duration<uint64_t, milli> getCurrentViewDuration() const {
-        return milliseconds(stream_metrics_.currentViewDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    std::chrono::duration<uint64_t, std::milli> getCurrentViewDuration() const {
+        return std::chrono::milliseconds(stream_metrics_.currentViewDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     }
 
     /**
      * Returns the overall view duration in millis
      */
-    duration<uint64_t, milli> getOverallViewDuration() const {
-        return milliseconds(stream_metrics_.overallViewDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    std::chrono::duration<uint64_t, std::milli> getOverallViewDuration() const {
+        return std::chrono::milliseconds(stream_metrics_.overallViewDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     }
 
     /**

--- a/src/StreamDefinition.cpp
+++ b/src/StreamDefinition.cpp
@@ -5,6 +5,15 @@ namespace com { namespace amazonaws { namespace kinesis { namespace video {
 
 LOGGER_TAG("com.amazonaws.kinesis.video");
 
+using std::map;
+using std::milli;
+using std::ratio;
+using std::string;
+using std::vector;
+using std::chrono::duration;
+using std::chrono::duration_cast;
+using std::chrono::nanoseconds;
+
 StreamDefinition::StreamDefinition(
         string stream_name,
         duration <uint64_t, ratio<3600>> retention_period,

--- a/src/StreamDefinition.h
+++ b/src/StreamDefinition.h
@@ -14,9 +14,6 @@
 
 #define DEFAULT_TRACK_ID 1
 
-using namespace std;
-using namespace std::chrono;
-
 namespace com { namespace amazonaws { namespace kinesis { namespace video {
 
 /**
@@ -25,8 +22,8 @@ namespace com { namespace amazonaws { namespace kinesis { namespace video {
  */
 typedef struct StreamTrackInfo__ {
     const uint64_t track_id;
-    const string track_name;
-    const string codec_id;
+    const std::string track_name;
+    const std::string codec_id;
     const uint8_t* cpd;
     uint32_t cpd_size;
     MKV_TRACK_INFO_TYPE track_type;
@@ -45,15 +42,15 @@ public:
      * @param tags The Kinesis Video PIC stream tags which should be set for this stream.
      */
     StreamDefinition(
-            string stream_name,
-            duration<uint64_t, ratio<3600>> retention_period,
-            const map<string, string>* tags = nullptr,
-            string kms_key_id = "",
+            std::string stream_name,
+            std::chrono::duration<uint64_t, std::ratio<3600>> retention_period,
+            const std::map<std::string, std::string>* tags = nullptr,
+            std::string kms_key_id = "",
             STREAMING_TYPE streaming_type = STREAMING_TYPE_REALTIME,
-            string content_type = "video/h264",
-            duration<uint64_t, milli> max_latency = milliseconds::zero(),
-            duration<uint64_t, milli> fragment_duration = milliseconds(2000),
-            duration<uint64_t, milli> timecode_scale = milliseconds(1),
+            std::string content_type = "video/h264",
+            std::chrono::duration<uint64_t, std::milli> max_latency = std::chrono::milliseconds::zero(),
+            std::chrono::duration<uint64_t, std::milli> fragment_duration = std::chrono::milliseconds(2000),
+            std::chrono::duration<uint64_t, std::milli> timecode_scale = std::chrono::milliseconds(1),
             bool key_frame_fragmentation = true,
             bool frame_timecodes = true,
             bool absolute_fragment_times = true,
@@ -63,23 +60,23 @@ public:
             uint32_t nal_adaptation_flags = NAL_ADAPTATION_ANNEXB_NALS | NAL_ADAPTATION_ANNEXB_CPD_NALS,
             uint32_t frame_rate = 25,
             uint32_t avg_bandwidth_bps = 4 * 1024 * 1024,
-            duration<uint64_t> buffer_duration = seconds(120),
-            duration<uint64_t> replay_duration = seconds(40),
-            duration<uint64_t> connection_staleness = seconds(30),
-            string codec_id = "V_MPEG4/ISO/AVC",
-            string track_name = "kinesis_video",
+            std::chrono::duration<uint64_t> buffer_duration = std::chrono::seconds(120),
+            std::chrono::duration<uint64_t> replay_duration = std::chrono::seconds(40),
+            std::chrono::duration<uint64_t> connection_staleness = std::chrono::seconds(30),
+            std::string codec_id = "V_MPEG4/ISO/AVC",
+            std::string track_name = "kinesis_video",
             const uint8_t* codecPrivateData = nullptr,
             uint32_t codecPrivateDataSize = 0,
             MKV_TRACK_INFO_TYPE track_type = MKV_TRACK_INFO_TYPE_VIDEO,
-            const vector<uint8_t> segment_uuid = vector<uint8_t>(),
+            const std::vector<uint8_t> segment_uuid = std::vector<uint8_t>(),
             const uint64_t default_track_id = DEFAULT_TRACK_ID,
             CONTENT_STORE_PRESSURE_POLICY contentStorePressurePolicy = CONTENT_STORE_PRESSURE_POLICY_DROP_TAIL_ITEM,
             CONTENT_VIEW_OVERFLOW_POLICY contentViewOverflowPolicy = CONTENT_VIEW_OVERFLOW_POLICY_DROP_UNTIL_FRAGMENT_START
     );
 
     void addTrack(const uint64_t track_id,
-                  const string &track_name,
-                  const string &codec_id,
+                  const std::string &track_name,
+                  const std::string &codec_id,
                   MKV_TRACK_INFO_TYPE track_type,
                   const uint8_t* codecPrivateData = nullptr,
                   uint32_t codecPrivateDataSize = 0);
@@ -91,7 +88,7 @@ public:
     /**
      * @return A reference to the human readable stream name.
      */
-    const string& getStreamName() const;
+    const std::string& getStreamName() const;
 
     /**
      * @return A the number of tracks
@@ -107,7 +104,7 @@ private:
     /**
      * Human readable name of the stream. Usually: <sensor ID>.camera_<stream_tag>
      */
-    string stream_name_;
+    std::string stream_name_;
 
     /**
      * Map of key/value pairs to be added as tags on the Kinesis Video stream
@@ -117,7 +114,7 @@ private:
     /**
      * Vector of StreamTrackInfo that contain track metadata
      */
-    vector<StreamTrackInfo> track_info_;
+    std::vector<StreamTrackInfo> track_info_;
 
     /**
      * The underlying object

--- a/src/common/PutFrameHelper.cpp
+++ b/src/common/PutFrameHelper.cpp
@@ -5,6 +5,8 @@ namespace com { namespace amazonaws { namespace kinesis { namespace video {
 
 LOGGER_TAG("com.amazonaws.kinesis.video");
 
+using std::shared_ptr;
+
 PutFrameHelper::PutFrameHelper(
         shared_ptr<KinesisVideoStream> kinesis_video_stream,
         uint64_t mkv_timecode_scale_ns,

--- a/src/common/PutFrameHelper.h
+++ b/src/common/PutFrameHelper.h
@@ -2,6 +2,7 @@
 #define __PUT_FRAME_HELPER_H__
 
 #include "KinesisVideoProducer.h"
+#include <memory>
 #include <queue>
 #include <vector>
 
@@ -29,13 +30,13 @@ namespace com { namespace amazonaws { namespace kinesis { namespace video {
  * video key frame can be put into the stream.
  */
 class PutFrameHelper {
-    shared_ptr<KinesisVideoStream> kinesis_video_stream;
+    std::shared_ptr<KinesisVideoStream> kinesis_video_stream;
     bool put_frame_status;
     uint8_t* data_buffer;
     uint32_t data_buffer_size;
 public:
     PutFrameHelper(
-            shared_ptr<KinesisVideoStream> kinesis_video_stream,
+            std::shared_ptr<KinesisVideoStream> kinesis_video_stream,
             uint64_t mkv_timecode_scale_ns = DEFAULT_MKV_TIMECODE_SCALE_NS,
             uint32_t max_audio_queue_size = DEFAULT_MAX_AUDIO_QUEUE_SIZE,
             uint32_t max_video_queue_size = DEFAULT_MAX_VIDEO_QUEUE_SIZE,

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -65,6 +65,7 @@
 LOGGER_TAG("com.amazonaws.kinesis.video.gstkvs");
 
 using namespace std;
+using namespace std::chrono;
 using namespace log4cplus;
 
 GST_DEBUG_CATEGORY_STATIC (gst_kvs_sink_debug);

--- a/src/gstreamer/gstkvssink.h
+++ b/src/gstreamer/gstkvssink.h
@@ -126,8 +126,8 @@ struct _GstKvsSink {
     guint                       num_audio_streams;
     guint                       num_video_streams;
 
-    unique_ptr<Credentials> credentials_;
-    shared_ptr<KvsSinkCustomData> data;
+    std::unique_ptr<Credentials> credentials_;
+    std::shared_ptr<KvsSinkCustomData> data;
 };
 
 struct _GstKvsSinkClass {
@@ -149,16 +149,16 @@ struct _KvsSinkCustomData {
             frame_count(0),
             first_pts(GST_CLOCK_TIME_NONE),
             producer_start_time(GST_CLOCK_TIME_NONE) {}
-    unique_ptr<KinesisVideoProducer> kinesis_video_producer;
-    shared_ptr<KinesisVideoStream> kinesis_video_stream;
+    std::unique_ptr<KinesisVideoProducer> kinesis_video_producer;
+    std::shared_ptr<KinesisVideoStream> kinesis_video_stream;
 
-    unordered_set<uint64_t> track_cpd_received;
+    std::unordered_set<uint64_t> track_cpd_received;
     GstKvsSink *kvsSink;
     MediaType media_type;
     bool first_video_frame;
     uint32_t frame_count;
 
-    atomic_uint stream_status;
+    std::atomic_uint stream_status;
 
     uint64_t last_dts;
     uint64_t pts_base;

--- a/tst/ProducerApiTest.cpp
+++ b/tst/ProducerApiTest.cpp
@@ -1,6 +1,10 @@
 #include "ProducerTestFixture.h"
 
 namespace com { namespace amazonaws { namespace kinesis { namespace video {
+
+using namespace std;
+using namespace std::chrono;
+
 class ProducerApiTest : public ProducerTestBase {
 };
 
@@ -574,4 +578,3 @@ TEST_F(ProducerApiTest, segment_uuid_variations)
 }  // namespace kinesis
 }  // namespace amazonaws
 }  // namespace com
-

--- a/tst/ProducerTestFixture.h
+++ b/tst/ProducerTestFixture.h
@@ -15,9 +15,6 @@
 #include <atomic>
 #include <map>
 
-using namespace std;
-using namespace std::chrono;
-
 namespace com { namespace amazonaws { namespace kinesis { namespace video {
 
 LOGGER_TAG("com.amazonaws.kinesis.video.TEST");
@@ -225,17 +222,17 @@ public:
         return key_frame_interval_ * frame_duration_ / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
     }
 
-    atomic_bool stop_called_;
-    atomic_bool frame_dropped_;
-    atomic_bool buffer_duration_pressure_;
-    atomic_bool storage_overflow_;
-    atomic_bool buffering_ack_in_sequence_;
-    atomic_uint error_status_;
-    map<UPLOAD_HANDLE, uint64_t> previous_buffering_ack_timestamp_;
+    std::atomic_bool stop_called_;
+    std::atomic_bool frame_dropped_;
+    std::atomic_bool buffer_duration_pressure_;
+    std::atomic_bool storage_overflow_;
+    std::atomic_bool buffering_ack_in_sequence_;
+    std::atomic_uint error_status_;
+    std::map<UPLOAD_HANDLE, uint64_t> previous_buffering_ack_timestamp_;
 
 protected:
 
-    void handlePressure(atomic_bool &pressure_flag, uint32_t grace_period_seconds) {
+    void handlePressure(std::atomic_bool &pressure_flag, uint32_t grace_period_seconds) {
         // first time pressure is detected
         if (pressure_flag && current_pressure_state_ == OK) {
             current_pressure_state_ = PRESSURING; // update state
@@ -275,7 +272,7 @@ protected:
         char const *sessionToken;
         char const *defaultRegion;
         char const *caCertPath;
-        string sessionTokenStr;
+        std::string sessionTokenStr;
         if (nullptr == (accessKey = getenv(ACCESS_KEY_ENV_VAR))) {
             accessKey = "AccessKey";
             access_key_set_ = false;
@@ -288,19 +285,19 @@ protected:
         if (nullptr == (sessionToken = getenv(SESSION_TOKEN_ENV_VAR))) {
             sessionTokenStr = "";
         } else {
-            sessionTokenStr = string(sessionToken);
+            sessionTokenStr = std::string(sessionToken);
         }
 
         if (nullptr != (defaultRegion = getenv(DEFAULT_REGION_ENV_VAR))) {
-            defaultRegion_ = string(defaultRegion);
+            defaultRegion_ = std::string(defaultRegion);
         }
 
         if (nullptr != (caCertPath = getenv(CACERT_PATH_ENV_VAR))) {
-            caCertPath_ = string(caCertPath);
+            caCertPath_ = std::string(caCertPath);
         }
 
-        credentials_.reset(new Credentials(string(accessKey),
-                string(secretKey),
+        credentials_.reset(new Credentials(std::string(accessKey),
+                std::string(secretKey),
                 sessionTokenStr,
                 std::chrono::seconds(TEST_STREAMING_TOKEN_DURATION_IN_SECONDS)));
 
@@ -316,7 +313,7 @@ protected:
         stream_callback_provider_.reset(new TestStreamCallbackProvider(this));
 
         try {
-            unique_ptr<DefaultCallbackProvider> defaultCallbackProvider;
+          std::unique_ptr<DefaultCallbackProvider> defaultCallbackProvider;
             if (cachingEndpoingProvider) {
                 defaultCallbackProvider.reset(new CachingEndpointOnlyCallbackProvider(
                         move(client_callback_provider_),
@@ -348,13 +345,13 @@ protected:
         }
     };
 
-    shared_ptr<KinesisVideoStream> CreateTestStream(int index,
+    std::shared_ptr<KinesisVideoStream> CreateTestStream(int index,
                                                     STREAMING_TYPE streaming_type = STREAMING_TYPE_REALTIME,
                                                     uint32_t max_stream_latency_ms = TEST_MAX_STREAM_LATENCY_IN_MILLIS,
                                                     int buffer_duration_seconds = 120) {
         char stream_name[MAX_STREAM_NAME_LEN];
         sprintf(stream_name, "ScaryTestStream_%d", index);
-        map<string, string> tags;
+        std::map<std::string, std::string> tags;
         char tag_name[MAX_TAG_NAME_LEN];
         char tag_val[MAX_TAG_VALUE_LEN];
         for (int i = 0; i < 5; i++) {
@@ -364,15 +361,15 @@ protected:
             tags.emplace(std::make_pair(tag_name, tag_val));
         }
 
-        unique_ptr<StreamDefinition> stream_definition(new StreamDefinition(stream_name,
-                hours(2),
+        std::unique_ptr<StreamDefinition> stream_definition(new StreamDefinition(stream_name,
+                std::chrono::hours(2),
                 &tags,
                 "",
                 streaming_type,
                 "video/h264",
-                milliseconds(max_stream_latency_ms),
-                seconds(2),
-                milliseconds(1),
+                std::chrono::milliseconds(max_stream_latency_ms),
+                std::chrono::seconds(2),
+                std::chrono::milliseconds(1),
                 true,
                 true,
                 true,
@@ -382,9 +379,9 @@ protected:
                 0,
                 25,
                 4 * 1024 * 1024,
-                seconds(buffer_duration_seconds),
-                seconds(buffer_duration_seconds),
-                seconds(50)));
+                std::chrono::seconds(buffer_duration_seconds),
+                std::chrono::seconds(buffer_duration_seconds),
+                std::chrono::seconds(50)));
         return kinesis_video_producer_->createStreamSync(move(stream_definition));
     };
 
@@ -410,15 +407,15 @@ protected:
         frame_duration_ = 1000LLU * HUNDREDS_OF_NANOS_IN_A_MILLISECOND / fps_;
     }
 
-    unique_ptr<KinesisVideoProducer> kinesis_video_producer_;
-    unique_ptr<DeviceInfoProvider> device_provider_;
-    unique_ptr<ClientCallbackProvider> client_callback_provider_;
-    unique_ptr<StreamCallbackProvider> stream_callback_provider_;
-    unique_ptr<Credentials> credentials_;
-    unique_ptr<CredentialProvider> credential_provider_;
+    std::unique_ptr<KinesisVideoProducer> kinesis_video_producer_;
+    std::unique_ptr<DeviceInfoProvider> device_provider_;
+    std::unique_ptr<ClientCallbackProvider> client_callback_provider_;
+    std::unique_ptr<StreamCallbackProvider> stream_callback_provider_;
+    std::unique_ptr<Credentials> credentials_;
+    std::unique_ptr<CredentialProvider> credential_provider_;
 
-    string defaultRegion_;
-    string caCertPath_;
+    std::string defaultRegion_;
+    std::string caCertPath_;
 
     bool access_key_set_;
 
@@ -438,7 +435,7 @@ protected:
     int64_t pressure_cooldown_time_;
 
     BYTE frameBuffer_[TEST_FRAME_SIZE];
-    shared_ptr<KinesisVideoStream> streams_[TEST_STREAM_COUNT];
+    std::shared_ptr<KinesisVideoStream> streams_[TEST_STREAM_COUNT];
 };
 
 }  // namespace video


### PR DESCRIPTION
Closes https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/issues/538

Remove `using namespace std` from all headers in the project, so as to not irreversibly modify the global namespace for users of this library.