### PR TITLE
provide option for non-standard GStreamer src/mux plugins which have …

### DIFF
--- a/src/gstreamer/gstkvssink.h
+++ b/src/gstreamer/gstkvssink.h
@@ -101,6 +101,7 @@ struct _GstKvsSink {
     gboolean                    fragment_acks;
     gboolean                    restart_on_error;
     gboolean                    recalculate_metrics;
+    gboolean                    disable_buffer_clipping;
     guint                       framerate;
     guint                       avg_bandwidth_bps;
     guint                       buffer_duration_seconds;


### PR DESCRIPTION
Introduces new `kvssink` property `disable-buffer-clipping`.  This defaults to false and most users will not need to set it.  However some src/mux elements produce non-standard segment start times.  If you are aware that your src/mux elements do this then you can try to set this value to true.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
