### PR TITLE
Move check out of switch

### DIFF
--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -779,16 +779,18 @@ gst_kvs_sink_set_property(GObject *object, guint prop_id,
             break;
         case PROP_DISABLE_BUFFER_CLIPPING: {
             kvssink->disable_buffer_clipping = g_value_get_boolean(value);
-            if (kvssink->disable_buffer_clipping == FALSE) {
-                gst_collect_pads_set_clip_function(kvssink->collect,
-                                                   GST_DEBUG_FUNCPTR(gst_collect_pads_clip_running_time), kvssink);
-            }
             break;
         }
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
             break;
     }
+
+    if (kvssink->disable_buffer_clipping == FALSE) {
+        gst_collect_pads_set_clip_function(kvssink->collect,
+                                           GST_DEBUG_FUNCPTR(gst_collect_pads_clip_running_time), kvssink);
+    }
+
 }
 
 static void

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -249,6 +249,12 @@ void kinesis_video_producer_init(GstKvsSink *kvssink)
     string region_str;
     bool credential_is_static = true;
 
+    // This needs to happen after we've read in ALL of the properties
+    if (kvssink->disable_buffer_clipping == FALSE) {
+        gst_collect_pads_set_clip_function(kvssink->collect,
+                                           GST_DEBUG_FUNCPTR(gst_collect_pads_clip_running_time), kvssink);
+    }
+
     if (0 == strcmp(kvssink->access_key, DEFAULT_ACCESS_KEY)) { // if no static credential is available in plugin property.
         if (nullptr == (access_key = getenv(ACCESS_KEY_ENV_VAR))
             || nullptr == (secret_key = getenv(SECRET_KEY_ENV_VAR))) { // if no static credential is available in env var.
@@ -777,20 +783,13 @@ gst_kvs_sink_set_property(GObject *object, guint prop_id,
         case PROP_FILE_START_TIME:
             kvssink->file_start_time = g_value_get_uint64 (value);
             break;
-        case PROP_DISABLE_BUFFER_CLIPPING: {
+        case PROP_DISABLE_BUFFER_CLIPPING:
             kvssink->disable_buffer_clipping = g_value_get_boolean(value);
             break;
-        }
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
             break;
     }
-
-    if (kvssink->disable_buffer_clipping == FALSE) {
-        gst_collect_pads_set_clip_function(kvssink->collect,
-                                           GST_DEBUG_FUNCPTR(gst_collect_pads_clip_running_time), kvssink);
-    }
-
 }
 
 static void

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -250,7 +250,7 @@ void kinesis_video_producer_init(GstKvsSink *kvssink)
     bool credential_is_static = true;
 
     // This needs to happen after we've read in ALL of the properties
-    if (kvssink->disable_buffer_clipping == FALSE) {
+    if (!kvssink->disable_buffer_clipping) {
         gst_collect_pads_set_clip_function(kvssink->collect,
                                            GST_DEBUG_FUNCPTR(gst_collect_pads_clip_running_time), kvssink);
     }
@@ -981,7 +981,7 @@ gst_kvs_sink_handle_sink_event (GstCollectPads *pads,
             LOG_INFO("received kvs-add-metadata event");
             if (NULL == gst_structure_get_string(structure, KVS_ADD_METADATA_NAME) ||
                 NULL == gst_structure_get_string(structure, KVS_ADD_METADATA_VALUE) ||
-                FALSE == gst_structure_get_boolean(structure, KVS_ADD_METADATA_PERSISTENT, &persistent)) {
+                !gst_structure_get_boolean(structure, KVS_ADD_METADATA_PERSISTENT, &persistent)) {
 
                 LOG_WARN("Event structure contains invalid field: " << std::string(gst_structure_to_string (structure)));
                 goto CleanUp;
@@ -992,7 +992,7 @@ gst_kvs_sink_handle_sink_event (GstCollectPads *pads,
             is_persist = persistent;
 
             bool result = data->kinesis_video_stream->putFragmentMetadata(metadata_name, metadata_value, is_persist);
-            if (false == result) {
+            if (!result) {
                 LOG_WARN("Failed to putFragmentMetadata. name: " << metadata_name << ", value: " << metadata_value << ", persistent: " << is_persist);
             }
             gst_event_unref (event);

--- a/src/gstreamer/gstkvssink.h
+++ b/src/gstreamer/gstkvssink.h
@@ -101,6 +101,7 @@ struct _GstKvsSink {
     gboolean                    fragment_acks;
     gboolean                    restart_on_error;
     gboolean                    recalculate_metrics;
+    gboolean                    disable_buffer_clipping;
     guint                       framerate;
     guint                       avg_bandwidth_bps;
     guint                       buffer_duration_seconds;


### PR DESCRIPTION
With the previous commit the behavior was to *always* disable clipping unless the property was explicitly set, so default was not honored.  Moved the clip function set up to the producer init which happens *after* ALL of the properties have been read in.  Tested both with and without defaults and explicitly set parameter, works as expected
