### PR TITLE
gstreamer: plugin: finalize: free producer resources

### DIFF
--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -645,10 +645,6 @@ gst_kvs_sink_finalize(GObject *object) {
     GstKvsSink *kvssink = GST_KVS_SINK (object);
     auto data = kvssink->data;
 
-    if (data->kinesis_video_stream) {
-        data->kinesis_video_producer->freeStream(data->kinesis_video_stream);
-    }
-
     gst_object_unref(kvssink->collect);
     g_free(kvssink->stream_name);
     g_free(kvssink->content_type);
@@ -662,6 +658,9 @@ gst_kvs_sink_finalize(GObject *object) {
     }
     if (kvssink->stream_tags) {
         gst_structure_free (kvssink->stream_tags);
+    }
+    if (data->kinesis_video_producer) {
+        data->kinesis_video_producer.reset();
     }
     G_OBJECT_CLASS (parent_class)->finalize(object);
 }


### PR DESCRIPTION
When using gstreamer with gst/gst.h (as opposed to launching using command
line tools such as gst-launch-1.0), on plugin finalize, all resources must
be freed, otherwise a very substantial memory leak occurs. By resetting
the pointer (removing all references or assigning to null) this change
solved a huge memory leak (found, tested and fixed on a real target).

*Issue #, if available:* #682