### PR TITLE
Check system for cproducer before doing git clone

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,17 +84,24 @@ set(BUILD_COMMON_LWS
 set(BUILD_COMMON_CURL
     TRUE
     CACHE BOOL "Build ProducerC with CURL Support" FORCE)
-set(DEPENDENCY_DOWNLOAD_PATH ${CMAKE_CURRENT_SOURCE_DIR}/dependency)
-if(NOT EXISTS ${DEPENDENCY_DOWNLOAD_PATH})
-  file(MAKE_DIRECTORY ${DEPENDENCY_DOWNLOAD_PATH})
-endif()
-fetch_repo(kvscproducer)
-add_subdirectory(${DEPENDENCY_DOWNLOAD_PATH}/libkvscproducer/kvscproducer-src EXCLUDE_FROM_ALL)
 
 ############# find dependent libraries ############
 
 find_package(Threads)
 find_package(PkgConfig REQUIRED)
+
+pkg_check_modules(KVSCPRODUCER libcproducer)
+if(KVSCPRODUCER_FOUND)
+  set(OPEN_SRC_INCLUDE_DIRS ${OPEN_SRC_INCLUDE_DIRS} ${KVSCPRODUCER_INCLUDE_DIRS})
+  link_directories(${KVSCPRODUCER_LIBRARY_DIRS})
+else()
+  set(DEPENDENCY_DOWNLOAD_PATH ${CMAKE_CURRENT_SOURCE_DIR}/dependency)
+  if(NOT EXISTS ${DEPENDENCY_DOWNLOAD_PATH})
+    file(MAKE_DIRECTORY ${DEPENDENCY_DOWNLOAD_PATH})
+  endif()
+  fetch_repo(kvscproducer)
+  add_subdirectory(${DEPENDENCY_DOWNLOAD_PATH}/libkvscproducer/kvscproducer-src EXCLUDE_FROM_ALL)
+endif()
 
 if (OPEN_SRC_INSTALL_PREFIX)
   find_package(CURL REQUIRED PATHS ${OPEN_SRC_INSTALL_PREFIX})


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, the CMakeLists.txt assumes that you do not have the kvscproducer library and does a git checkout of https://github.com/awslabs/amazon-kinesis-video-streams-producer-c in order to meet the required dependency. This makes producer-sdk-cpp much harder to package (e.g. RPM/DEB) as most distributions do not permit network access during build and this forced git call will fail.

This patch checks for the kvscproducer library dependency that producer-sdk-cpp cares about (libcproducer) and uses it if found. A more specific check could be done here to ensure that the found library has the necessary functionality, but to be honest, it would be easier to use a proper versioning scheme for kvscproducer and just check for supported version.

If the kvscproducer library is not found, it falls back to doing the git checkout logic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
