### PR TITLE
fix test linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,13 +194,13 @@ if(BUILD_GSTREAMER_PLUGIN)
   target_link_libraries(gstkvssink PRIVATE ${GST_APP_LIBRARIES} KinesisVideoProducer)
 
   add_executable(kvs_gstreamer_sample samples/kvs_gstreamer_sample.cpp)
-  target_link_libraries(kvs_gstreamer_sample ${GST_APP_LIBRARIES} KinesisVideoProducer)
+  target_link_libraries(kvs_gstreamer_sample ${GST_APP_LIBRARIES} KinesisVideoProducer kvspicUtils)
 
   add_executable(kvs_gstreamer_multistream_sample samples/kvs_gstreamer_multistream_sample.cpp)
-  target_link_libraries(kvs_gstreamer_multistream_sample ${GST_APP_LIBRARIES} KinesisVideoProducer)
+  target_link_libraries(kvs_gstreamer_multistream_sample ${GST_APP_LIBRARIES} KinesisVideoProducer kvspicUtils)
 
   add_executable(kvs_gstreamer_audio_video_sample samples/kvs_gstreamer_audio_video_sample.cpp)
-  target_link_libraries(kvs_gstreamer_audio_video_sample ${GST_APP_LIBRARIES} KinesisVideoProducer)
+  target_link_libraries(kvs_gstreamer_audio_video_sample ${GST_APP_LIBRARIES} KinesisVideoProducer kvspicUtils ${CMAKE_THREAD_LIBS_INIT})
 
   add_executable(kvs_gstreamer_file_uploader_sample samples/kvs_gstreamer_file_uploader_sample.cpp)
   target_link_libraries(kvs_gstreamer_file_uploader_sample ${GST_APP_LIBRARIES})

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 add_executable(${PROJECT_NAME} ${PRODUCER_TEST_SOURCES})
 target_link_libraries(${PROJECT_NAME}
             KinesisVideoProducer
+            kvspicUtils
             ${GTEST_LIBNAME})
 add_test(${PROJECT_NAME} ${PROJECT_NAME})
 
@@ -34,6 +35,7 @@ if(BUILD_GSTREAMER_PLUGIN AND NOT WIN32)
   target_link_libraries(${GST_KVS_PLUGIN_TEST_NAME}
               ${GTEST_LIBNAME}
               KinesisVideoProducer
+              kvspicUtils
               ${GST_APP_LIBRARIES}
               ${GST_CHECK_LIBRARIES})
   add_test(${GST_KVS_PLUGIN_TEST_NAME} ${GST_KVS_PLUGIN_TEST_NAME})


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Some of the test programs fail to link without libkvspicUtils. This probably wasn't explicit before because each static lib before it just ate everything ... but with shared libs, you must be more explicit. Also, one of them wanted a threading link.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
