### PR TITLE
Minor syntax fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ cmake -DBUILD_JNI=TRUE
 The GStreamer plugin and samples are NOT built by default.  If you wish to build them you MUST add -DBUILD_GSTREAMER_PLUGIN=TRUE when running cmake:
 
 ```
-cmake -DBUILD_GSTREAMER_PLUGIN=TRUE
+cmake -DBUILD_GSTREAMER_PLUGIN=TRUE ..
 ```
 
 ### Compiling 


### PR DESCRIPTION
`..` is required for fetching files from parent dir ... without `..` it throws an error

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
