### PR TITLE
Move log4cplus initialization

### DIFF
--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -633,6 +633,8 @@ gst_kvs_sink_init(GstKvsSink *kvssink) {
 
     kvssink->data = make_shared<KvsSinkCustomData>();
 
+    log4cplus::initialize();
+
     // Mark plugin as sink
     GST_OBJECT_FLAG_SET (kvssink, GST_ELEMENT_FLAG_SINK);
 
@@ -756,6 +758,7 @@ gst_kvs_sink_set_property(GObject *object, guint prop_id,
             break;
         case PROP_LOG_CONFIG_PATH:
             kvssink->log_config_path = g_strdup (g_value_get_string (value));
+            log4cplus::PropertyConfigurator::doConfigure(kvssink->log_config_path);
             break;
         case PROP_FRAMERATE:
             kvssink->framerate = g_value_get_uint (value);
@@ -1358,8 +1361,6 @@ gst_kvs_sink_change_state(GstElement *element, GstStateChange transition) {
 
     switch (transition) {
         case GST_STATE_CHANGE_NULL_TO_READY:
-            log4cplus::initialize();
-            log4cplus::PropertyConfigurator::doConfigure(kvssink->log_config_path);
             try {
                 kinesis_video_producer_init(kvssink);
                 init_track_data(kvssink);


### PR DESCRIPTION
This PR moves the initialization and configuration of log4cplus from the current location to a location before the log is actually used.

The motivation is that we get an error when using kvssink with log4cplus that is built with `--enable-implicit-initialization` turned off. One example of such a case is when using the system log4cplus library in Alpine.

```
$ gst-inspect-1.0 kvssink
terminate called after throwing an instance of 'std::logic_error'
  what():  log4cplus is not initialized and implicit initialization is turned off
```

I am unfamiliar with GStreamer internal and how `gst_kvs_sink_*` functions get called and in which order, so I am not sure if I moved the code in the optimal places; though this branch seems to be working without issues in my environment.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
