### PR TITLE
Fix bug that leads to losing initial frames

### DIFF
--- a/CMake/Dependencies/libkvscproducer-CMakeLists.txt
+++ b/CMake/Dependencies/libkvscproducer-CMakeLists.txt
@@ -7,7 +7,7 @@ include(ExternalProject)
 # clone repo only
 ExternalProject_Add(libkvscproducer-download
 	GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-producer-c.git
-	GIT_TAG           69f68a7263efc6435c8dcf64ed163c9baa699325
+	GIT_TAG           34cf6d1b6ec492867f6f3e5499000735f64c076b
 	SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvscproducer-src"
 	BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvscproducer-build"
 	CONFIGURE_COMMAND ""

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -1126,9 +1126,8 @@ gst_kvs_sink_handle_buffer (GstCollectPads * pads,
             if(!delta && kvs_sink_track_data->track_type == MKV_TRACK_INFO_TYPE_VIDEO) {
                 if (data->first_video_frame) {
                     data->first_video_frame = false;
-                } else {
-                    kinesis_video_flags = FRAME_FLAG_KEY_FRAME;
                 }
+                kinesis_video_flags = FRAME_FLAG_KEY_FRAME;
             }
             break;
     }


### PR DESCRIPTION
*Issue #, if available:*
#778 
#691 

*Description of changes:*
The bug leads to skipping the first frame even if it is a key frame since it is put inside the else clause. The `if` condition imply sets the flag to false to indicate the first video frame. 

Resolves #778 
Resolves #691 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
