### PR TITLE
Untie stream-name and thing-name

### DIFF
--- a/src/gstreamer/Util/KvsSinkUtil.cpp
+++ b/src/gstreamer/Util/KvsSinkUtil.cpp
@@ -67,7 +67,8 @@ gboolean parseIotCredentialGstructure(GstStructure *g_struct, std::map<std::stri
         ++it) {
         params_key_set.insert(it->first);
     }
-    if( params_key_set.count(IOT_THING_NAME) == 0) {
+
+    if(params_key_set.count(IOT_THING_NAME) == 0) {
         params_key_set.insert(IOT_THING_NAME);
     }
 

--- a/src/gstreamer/Util/KvsSinkUtil.cpp
+++ b/src/gstreamer/Util/KvsSinkUtil.cpp
@@ -8,7 +8,8 @@ static const std::set<std::string> iot_param_set = {IOT_GET_CREDENTIAL_ENDPOINT,
                                                     CERTIFICATE_PATH,
                                                     PRIVATE_KEY_PATH,
                                                     CA_CERT_PATH,
-                                                    ROLE_ALIASES};
+                                                    ROLE_ALIASES,
+                                                    IOT_THING_NAME};
 
 static const time_t time_point = std::time(NULL);
 static const long timezone_offset =
@@ -66,6 +67,10 @@ gboolean parseIotCredentialGstructure(GstStructure *g_struct, std::map<std::stri
         ++it) {
         params_key_set.insert(it->first);
     }
+    if( params_key_set.count(IOT_THING_NAME) == 0) {
+        params_key_set.insert(IOT_THING_NAME);
+    }
+
     if (params_key_set != iot_param_set) {
         std::ostringstream ostream;
         std::copy(iot_param_set.begin(), iot_param_set.end(), std::ostream_iterator<std::string>(ostream, ","));

--- a/src/gstreamer/Util/KvsSinkUtil.h
+++ b/src/gstreamer/Util/KvsSinkUtil.h
@@ -13,6 +13,7 @@
 #define PRIVATE_KEY_PATH "key-path"
 #define CA_CERT_PATH "ca-path"
 #define ROLE_ALIASES "role-aliases"
+#define IOT_THING_NAME "iot-thing-name"
 
 namespace kvs_sink_util{
 

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -295,12 +295,17 @@ void kinesis_video_producer_init(GstKvsSink *kvssink)
             LOG_AND_THROW("Failed to parse Iot credentials");
         }
 
+        std::map<std::string, std::string>::iterator it = iot_cert_params.find(IOT_THING_NAME); 
+        if (it == iot_cert_params.end() ) {
+            iot_cert_params.insert( std::pair<std::string,std::string>(IOT_THING_NAME, kvssink->stream_name) );
+        }
+
         credential_provider.reset(new IotCertCredentialProvider(iot_cert_params[IOT_GET_CREDENTIAL_ENDPOINT],
                 iot_cert_params[CERTIFICATE_PATH],
                 iot_cert_params[PRIVATE_KEY_PATH],
                 iot_cert_params[ROLE_ALIASES],
                 iot_cert_params[CA_CERT_PATH],
-                kvssink->stream_name));
+                iot_cert_params[IOT_THING_NAME] ) );
     } else {
         credential_provider.reset(new RotatingCredentialProvider(kvssink->credential_file_path));
     }

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -296,7 +296,7 @@ void kinesis_video_producer_init(GstKvsSink *kvssink)
         }
 
         std::map<std::string, std::string>::iterator it = iot_cert_params.find(IOT_THING_NAME); 
-        if (it == iot_cert_params.end() ) {
+        if (it == iot_cert_params.end()) {
             iot_cert_params.insert( std::pair<std::string,std::string>(IOT_THING_NAME, kvssink->stream_name) );
         }
 


### PR DESCRIPTION
*Issue #781*

*Description of changes:*
This change will allow an optional extra parameter to the iot-certificate called iot-thing-name so it uses the `iot-thing-name` for authentication and not always assumes the stream-name is the thing-name. This decoupling allows multiple streams per iot-thing (for example if there are more than 1 camera connected to your device)

example of usage:
`kvssink  name=aname storage-size=512  iot-certificate="iot-certificate,endpoint=xxxxx.credentials.iot.ap-southeast-2.amazonaws.com,cert-path=/greengrass/v2/thingCert.crt,key-path=/greengrass/v2/privKey.key,ca-path=/greengrass/v2/rootCA.pem,role-aliases=KvsCameraIoTRoleAlias,iot-thing-name=smartdvr-1423019132001" aws-region="ap-southeast-2" log-config="/etc/mtdata/kvssink-log.config"  stream-name=smartdvr-1423019132001-video1 
`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
