### PR TITLE
Elaborated on how to work with IoT credentials.

### DIFF
--- a/docs/linux.md
+++ b/docs/linux.md
@@ -55,7 +55,7 @@ $ gst-launch-1.0 -v rtspsrc location=rtsp://YourCameraRtspUrl short-header=TRUE 
 $ gst-launch-1.0 -v rtspsrc location="rtsp://YourCameraRtspUrl" short-header=TRUE ! rtph264depay ! video/x-h264, format=avc,alignment=au !
  h264parse ! kvssink stream-name="iot-stream" iot-certificate="iot-certificate,endpoint=endpoint,cert-path=/path/to/certificate,key-path=/path/to/private/key,ca-path=/path/to/ca-cert,role-aliases=role-aliases"
 ```
-You can find the RTSP URL from your IP camera manual or manufacturers product page.
+You can find the RTSP URL from your IP camera manual or manufacturers product page. For more information on how to set up IoT/role policies and role-aliases, please refer to [iot-based-credential-provider](auth.md#iot-based-credential-provider) and https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-iot.html.
 
 ###### Running the `gst-launch-1.0` command to start streaming from USB camera source in **Ubuntu**.
 ```


### PR DESCRIPTION
It is not a straight-forward process to enable KVS and IoT credentials.
It is required to read and follow through https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-iot.html.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
