### PR TITLE
Update outdated instruction

### DIFF
--- a/docs/linux.md
+++ b/docs/linux.md
@@ -141,7 +141,7 @@ AWS_ACCESS_KEY_ID=YourAccessKeyId AWS_SECRET_ACCESS_KEY=YourSecretAccessKey ./kv
 Change your current working directory to `build`. Launch the sample application with a stream name and a path to the file and it will start streaming.
 
 ```
-AWS_ACCESS_KEY_ID=YourAccessKeyId AWS_SECRET_ACCESS_KEY=YourSecretAccessKey ./kvs_gstreamer_audio_video_sample <my-stream> </path/to/file>
+AWS_ACCESS_KEY_ID=YourAccessKeyId AWS_SECRET_ACCESS_KEY=YourSecretAccessKey ./kvs_gstreamer_audio_video_sample <my-stream> -f </path/to/file>
 ```
 
 ##### Running the GStreamer sample application to stream audio and video from live source


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* We have to add `-f` to specify the file path for `kvs_gstreamer_audio_video_sample`.
https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/blob/70f74f14cf27b09f71dc1889f36eb6e04cdd90a8/samples/kvs_gstreamer_audio_video_sample.cpp#L1037-L1062


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
