### PR TITLE
add support for CN region

### DIFF
--- a/src/DefaultCallbackProvider.cpp
+++ b/src/DefaultCallbackProvider.cpp
@@ -421,6 +421,10 @@ DefaultCallbackProvider::DefaultCallbackProvider(
                              + "."
                              + region_
                              + CONTROL_PLANE_URI_POSTFIX;
+        // If region is in CN, add CN region uri postfix
+        if(region_.rfind("cn-", 0) == 0) {
+            control_plane_uri_ += ".cn";
+        }
     }
 
     getStreamCallbacks();


### PR DESCRIPTION
Signed-off-by: Alex Li <zhiqinli@amazon.com>

*Issue #, if available:*
KVS is now available in [China region](https://www.amazonaws.cn/en/new/2023/amazon-kinesis-video-streams-is--available-in-the-amazon-web-services-china-beijing-region-operated-by-sinnet/?nc1=h_ls)

In China region, all API endpoint will have postfix ".amazonaws.com.cn" instead of ".amazonaws.com". Use current SDK will cause DNS resolving error when call APIs in KVS control plane. Similar issue can be observed in WebRTC SDK as well.

*Description of changes:*
This commit will generate correct `control_plane_uri` according to configured region. Related to https://github.com/awslabs/amazon-kinesis-video-streams-producer-c/pull/344


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
