### PR TITLE
Update path to gsstreamer pkg-config.exe

### DIFF
--- a/.github/build_windows.bat
+++ b/.github/build_windows.bat
@@ -1,6 +1,7 @@
 call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
 mkdir build
 cd build
+update PKG_CONFIG_EXECUTABLE in CMakeLists.txt to match the actual path to pkg-config.exe (i.e. default: PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe", updated: PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\msvc_x86_64\\bin\\pkg-config.exe")
 cmd.exe /c cmake -G "NMake Makefiles" ..
 cmake -G "NMake Makefiles" -DBUILD_TEST=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE ..
 nmake


### PR DESCRIPTION
make sure that CMakeLists.txt has the right path to gstreamer's pkg-config.exe:
- default:   PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe"
- updated: PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\msvc_x86_64\\bin\\pkg-config.exe")

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
