### PR TITLE
fix(sample): move putEventMetadata after putFrame

### DIFF
--- a/samples/kvs_gstreamer_sample.cpp
+++ b/samples/kvs_gstreamer_sample.cpp
@@ -401,12 +401,13 @@ static GstFlowReturn on_new_sample(GstElement *sink, CustomData *data) {
         if (!gst_buffer_map(buffer, &info, GST_MAP_READ)){
             goto CleanUp;
         }
-        if (CHECK_FRAME_FLAG_KEY_FRAME(kinesis_video_flags)) {
-            data->kinesis_video_stream->putEventMetadata(STREAM_EVENT_TYPE_NOTIFICATION | STREAM_EVENT_TYPE_IMAGE_GENERATION, NULL);
-        }
 
         put_frame(data->kinesis_video_stream, info.data, info.size, std::chrono::nanoseconds(buffer->pts),
                                std::chrono::nanoseconds(buffer->dts), kinesis_video_flags);
+
+        if (CHECK_FRAME_FLAG_KEY_FRAME(kinesis_video_flags)) {
+            data->kinesis_video_stream->putEventMetadata(STREAM_EVENT_TYPE_NOTIFICATION | STREAM_EVENT_TYPE_IMAGE_GENERATION, NULL);
+        }
     }
 
 CleanUp:

--- a/src/KinesisVideoStream.cpp
+++ b/src/KinesisVideoStream.cpp
@@ -66,7 +66,7 @@ bool KinesisVideoStream::start(const std::string& hexEncodedCodecPrivateData, ui
     STATUS status;
 
     if (STATUS_FAILED(status = hexDecode((PCHAR) pStrCpd, 0, NULL, &size))) {
-        LOG_ERROR("Failed to get the size of the buffer for hex decoding the codec private data with: " << status);
+        LOG_ERROR("Failed to get the size of the buffer for hex decoding the codec private data with: 0x" << std::hex << status);
         return false;
     }
 
@@ -78,7 +78,7 @@ bool KinesisVideoStream::start(const std::string& hexEncodedCodecPrivateData, ui
     }
 
     if (STATUS_FAILED(status = hexDecode((PCHAR) pStrCpd, 0, pBuffer, &size))) {
-        LOG_ERROR("Failed to hex decode the codec private data with: " << status);
+        LOG_ERROR("Failed to hex decode the codec private data with: 0x" << std::hex << status);
         ::free(pBuffer);
         return false;
     }
@@ -97,7 +97,7 @@ bool KinesisVideoStream::start(const unsigned char* codecPrivateData, size_t cod
 
     if (STATUS_FAILED(status = kinesisVideoStreamFormatChanged(stream_handle_, (UINT32) codecPrivateDataSize,
                                                                (PBYTE) codecPrivateData, (UINT64) trackId))) {
-        LOG_ERROR("Failed to set the codec private data with: " << status);
+        LOG_ERROR("Failed to set the codec private data with: 0x" << std::hex << status);
         return false;
     }
 
@@ -115,7 +115,7 @@ bool KinesisVideoStream::resetConnection() {
     STATUS status = STATUS_SUCCESS;
 
     if (STATUS_FAILED(status = kinesisVideoStreamResetConnection(stream_handle_))) {
-        LOG_ERROR("Failed to reset the connection with: " << status);
+        LOG_ERROR("Failed to reset the connection with: 0x" << std::hex << status);
         return false;
     }
 
@@ -126,7 +126,7 @@ bool KinesisVideoStream::resetStream() {
     STATUS status = STATUS_SUCCESS;
 
     if (STATUS_FAILED(status = kinesisVideoStreamResetStream(stream_handle_))) {
-        LOG_ERROR("Failed to reset the stream with: " << status);
+        LOG_ERROR("Failed to reset the stream with: 0x" << std::hex << status);
         return false;
     }
 
@@ -144,7 +144,7 @@ bool KinesisVideoStream::stop() {
     STATUS status;
 
     if (STATUS_FAILED(status = stopKinesisVideoStream(stream_handle_))) {
-        LOG_ERROR("Failed to stop the stream with: " << status);
+        LOG_ERROR("Failed to stop the stream with: 0x" << std::hex << status);
         return false;
     }
 
@@ -155,7 +155,7 @@ bool KinesisVideoStream::stopSync() {
     STATUS status;
 
     if (STATUS_FAILED(status = stopKinesisVideoStreamSync(stream_handle_))) {
-        LOG_ERROR("Failed to stop the stream with: " << status);
+        LOG_ERROR("Failed to stop the stream with: 0x" << std::hex << status);
         return false;
     }
 
@@ -164,31 +164,31 @@ bool KinesisVideoStream::stopSync() {
 
 KinesisVideoStreamMetrics KinesisVideoStream::getMetrics() const {
     STATUS status = ::getKinesisVideoStreamMetrics(stream_handle_, (PStreamMetrics) stream_metrics_.getRawMetrics());
-    LOG_AND_THROW_IF(STATUS_FAILED(status), "Failed to get stream metrics with: " << status);
+    LOG_AND_THROW_IF(STATUS_FAILED(status), "Failed to get stream metrics with: 0x" << std::hex << status);
 
     return stream_metrics_;
 }
 
-bool KinesisVideoStream::putFragmentMetadata(const std::string &name, const std::string &value, bool persistent){
+bool KinesisVideoStream::putFragmentMetadata(const std::string &name, const std::string &value, bool persistent) {
     const char* pMetadataName = name.c_str();
     const char* pMetadataValue = value.c_str();
     STATUS status = ::putKinesisVideoFragmentMetadata(stream_handle_, (PCHAR) pMetadataName, (PCHAR) pMetadataValue, persistent);
     if (STATUS_FAILED(status)) {
-        LOG_ERROR("Failed to insert fragment metadata with: " << status);
+        LOG_ERROR("Failed to insert fragment metadata with: 0x" << std::hex << status);
         return false;
     }
 
     return true;
 }
 
-bool KinesisVideoStream::putEventMetadata(uint32_t event, PStreamEventMetadata pStreamEventMetadata)
-{
-
+bool KinesisVideoStream::putEventMetadata(uint32_t event, PStreamEventMetadata pStreamEventMetadata) {
     STATUS status = ::putKinesisVideoEventMetadata(stream_handle_, event, pStreamEventMetadata);
+
     if (STATUS_FAILED(status)) {
-        LOG_ERROR("Failed to insert event metadata with: " << status);
+        LOG_ERROR("Failed to insert event metadata with: 0x" << std::hex << status);
         return false;
     }
+
     return true;
 }
 


### PR DESCRIPTION
*Issue #, if available:*
When running the sample (`./kvs_gstreamer_sample test-stream ~/test.mp4`), we see the following error:
```
[ERROR] [30-05-2023 21:09:32:144.912 GMT] putKinesisVideoEventMetadata(): operation returned status code: 0x5200008c
[ERROR] [30-05-2023 21:09:32:144.981 GMT] Failed to insert event metadata with: 1375731852
```

Which correlates to [STREAM_NOT_STARTED](https://github.com/awslabs/amazon-kinesis-video-streams-pic/blob/532178bbd4d2e6e6511fa8ffa62a15dba58c02f0/src/client/include/com/amazonaws/kinesis/video/client/Include.h#L189).

*Description of changes:*
* In kvs_gstreamer_sample, move `putEventMetadata` after `putFrame`. When uploading a file with only a single keyframe, and if the keyframe is the first frame in the file, the event metadata will not get added. This is because the stream is started in the putFrame call, and we attempt to add the event metadata before the putFrame call. This causes the put event metadata to fail the first time, but succeed the rest of the times. Since there isn't a second keyframe in the file, the metadata would never get put.
* Also, translate the error codes into the hex format.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
