### PR TITLE
Enable caching by default

### DIFF
--- a/samples/kvs_gstreamer_audio_video_sample.cpp
+++ b/samples/kvs_gstreamer_audio_video_sample.cpp
@@ -631,10 +631,11 @@ void kinesis_video_init(CustomData *data) {
         LOG_AND_THROW("No valid credential method was found");
     }
 
-    data->kinesis_video_producer = KinesisVideoProducer::createSync(move(device_info_provider),
-                                                                    move(client_callback_provider),
-                                                                    move(stream_callback_provider),
-                                                                    move(credential_provider),
+    data->kinesis_video_producer = KinesisVideoProducer::createSync(std::move(device_info_provider),
+                                                                    std::move(client_callback_provider),
+                                                                    std::move(stream_callback_provider),
+                                                                    std::move(credential_provider),
+                                                                    API_CALL_CACHE_TYPE_ALL,
                                                                     defaultRegionStr);
 
     LOG_DEBUG("Client is ready");
@@ -682,7 +683,7 @@ void kinesis_video_stream_init(CustomData *data) {
         DEFAULT_VIDEO_TRACKID));
 
     stream_definition->addTrack(DEFAULT_AUDIO_TRACKID, DEFAULT_AUDIO_TRACK_NAME, DEFAULT_AUDIO_CODEC_ID, MKV_TRACK_INFO_TYPE_AUDIO);
-    data->kinesis_video_stream = data->kinesis_video_producer->createStreamSync(move(stream_definition));
+    data->kinesis_video_stream = data->kinesis_video_producer->createStreamSync(std::move(stream_definition));
     data->stream_started.clear();
 
     // since we are starting new putMedia, timestamp need not be padded.

--- a/samples/kvs_gstreamer_multistream_sample.cpp
+++ b/samples/kvs_gstreamer_multistream_sample.cpp
@@ -322,10 +322,11 @@ void kinesis_video_init(CustomData *data) {
                                        std::chrono::seconds(180)));
     unique_ptr<CredentialProvider> credential_provider(new SampleCredentialProvider(*credentials_.get()));
 
-    data->kinesis_video_producer = KinesisVideoProducer::createSync(move(device_info_provider),
-                                                                    move(client_callback_provider),
-                                                                    move(stream_callback_provider),
-                                                                    move(credential_provider),
+    data->kinesis_video_producer = KinesisVideoProducer::createSync(std::move(device_info_provider),
+                                                                    std::move(client_callback_provider),
+                                                                    std::move(stream_callback_provider),
+                                                                    std::move(credential_provider),
+                                                                    API_CALL_CACHE_TYPE_ALL,
                                                                     defaultRegionStr);
 
     LOG_DEBUG("Client is ready");
@@ -360,7 +361,7 @@ void kinesis_stream_init(string stream_name, CustomData *data, string stream_han
         DEFAULT_TRACKNAME,
         nullptr,
         0));
-    auto kvs_stream = data->kinesis_video_producer->createStreamSync(move(stream_definition));
+    auto kvs_stream = data->kinesis_video_producer->createStreamSync(std::move(stream_definition));
     data->kinesis_video_stream_handles[stream_handle_key] = kvs_stream;
     data->frame_data_size_map[stream_handle_key] = DEFAULT_BUFFER_SIZE;
     data->frame_data_map[stream_handle_key] = new uint8_t[DEFAULT_BUFFER_SIZE];

--- a/samples/kvs_gstreamer_sample.cpp
+++ b/samples/kvs_gstreamer_sample.cpp
@@ -528,10 +528,11 @@ void kinesis_video_init(CustomData *data) {
         LOG_AND_THROW("No valid credential method was found");
     }
 
-    data->kinesis_video_producer = KinesisVideoProducer::createSync(move(device_info_provider),
-                                                                    move(client_callback_provider),
-                                                                    move(stream_callback_provider),
-                                                                    move(credential_provider),
+    data->kinesis_video_producer = KinesisVideoProducer::createSync(std::move(device_info_provider),
+                                                                    std::move(client_callback_provider),
+                                                                    std::move(stream_callback_provider),
+                                                                    std::move(credential_provider),
+                                                                    API_CALL_CACHE_TYPE_ALL,
                                                                     defaultRegionStr);
 
     LOG_DEBUG("Client is ready");
@@ -580,7 +581,7 @@ void kinesis_video_stream_init(CustomData *data) {
         DEFAULT_TRACKNAME,
         nullptr,
         0));
-    data->kinesis_video_stream = data->kinesis_video_producer->createStreamSync(move(stream_definition));
+    data->kinesis_video_stream = data->kinesis_video_producer->createStreamSync(std::move(stream_definition));
 
     // reset state
     data->stream_status = STATUS_SUCCESS;

--- a/src/CachingEndpointOnlyCallbackProvider.cpp
+++ b/src/CachingEndpointOnlyCallbackProvider.cpp
@@ -12,18 +12,18 @@ using std::unique_ptr;
 using std::string;
 
 CachingEndpointOnlyCallbackProvider::CachingEndpointOnlyCallbackProvider(
-        unique_ptr <ClientCallbackProvider> client_callback_provider,
-        unique_ptr <StreamCallbackProvider> stream_callback_provider,
-        unique_ptr <CredentialProvider> credentials_provider,
+        std::unique_ptr <ClientCallbackProvider> client_callback_provider,
+        std::unique_ptr <StreamCallbackProvider> stream_callback_provider,
+        std::unique_ptr <CredentialProvider> credentials_provider,
         const string& region,
         const string& control_plane_uri,
         const std::string &user_agent_name,
         const std::string &custom_user_agent,
         const std::string &cert_path,
         std::chrono::duration<uint64_t> caching_update_period) : CachingEndpointOnlyCallbackProvider(
-                move(client_callback_provider),
-                move(stream_callback_provider),
-                move(credentials_provider),
+                std::move(client_callback_provider),
+                std::move(stream_callback_provider),
+                std::move(credentials_provider),
                 region,
                 control_plane_uri,
                 user_agent_name,
@@ -42,9 +42,9 @@ CachingEndpointOnlyCallbackProvider::CachingEndpointOnlyCallbackProvider(
         const std::string &custom_user_agent,
         const std::string &cert_path,
         uint64_t cache_update_period) : DefaultCallbackProvider(
-                move(client_callback_provider),
-                move(stream_callback_provider),
-                move(credentials_provider),
+                std::move(client_callback_provider),
+                std::move(stream_callback_provider),
+                std::move(credentials_provider),
                 region,
                 control_plane_uri,
                 user_agent_name,

--- a/src/DefaultCallbackProvider.cpp
+++ b/src/DefaultCallbackProvider.cpp
@@ -334,9 +334,9 @@ DefaultCallbackProvider::DefaultCallbackProvider(
         const std::string &cert_path,
         bool is_caching_endpoint,
         std::chrono::duration<uint64_t> caching_update_period) : DefaultCallbackProvider (
-                move(client_callback_provider),
-                move(stream_callback_provider),
-                move(credentials_provider),
+                std::move(client_callback_provider),
+                std::move(stream_callback_provider),
+                std::move(credentials_provider),
                 region,
                 control_plane_uri,
                 user_agent_name,
@@ -357,9 +357,9 @@ DefaultCallbackProvider::DefaultCallbackProvider(
         const std::string &cert_path,
         API_CALL_CACHE_TYPE api_call_caching,
         std::chrono::duration<uint64_t> caching_update_period) : DefaultCallbackProvider (
-                move(client_callback_provider),
-                move(stream_callback_provider),
-                move(credentials_provider),
+                std::move(client_callback_provider),
+                std::move(stream_callback_provider),
+                std::move(credentials_provider),
                 region,
                 control_plane_uri,
                 user_agent_name,
@@ -380,9 +380,9 @@ DefaultCallbackProvider::DefaultCallbackProvider(
         const std::string &cert_path,
         bool is_caching_endpoint,
         uint64_t caching_update_period) : DefaultCallbackProvider (
-                move(client_callback_provider),
-                move(stream_callback_provider),
-                move(credentials_provider),
+                std::move(client_callback_provider),
+                std::move(stream_callback_provider),
+                std::move(credentials_provider),
                 region,
                 control_plane_uri,
                 user_agent_name,
@@ -408,9 +408,9 @@ DefaultCallbackProvider::DefaultCallbackProvider(
           control_plane_uri_(control_plane_uri),
           cert_path_(cert_path) {
     STATUS retStatus = STATUS_SUCCESS;
-    client_callback_provider_ = move(client_callback_provider);
-    stream_callback_provider_ = move(stream_callback_provider);
-    credentials_provider_ = move(credentials_provider);
+    client_callback_provider_ = std::move(client_callback_provider);
+    stream_callback_provider_ = std::move(stream_callback_provider);
+    credentials_provider_ = std::move(credentials_provider);
     PStreamCallbacks pContinuoutsRetryStreamCallbacks = NULL;
     std::string custom_user_agent_ = CPP_SDK_CUSTOM_USERAGENT + custom_user_agent;
 

--- a/src/DefaultCallbackProvider.h
+++ b/src/DefaultCallbackProvider.h
@@ -57,7 +57,7 @@ public:
             const std::string &user_agent_name = EMPTY_STRING,
             const std::string &custom_user_agent = EMPTY_STRING,
             const std::string &cert_path = EMPTY_STRING,
-            API_CALL_CACHE_TYPE api_call_caching = API_CALL_CACHE_TYPE_NONE,
+            API_CALL_CACHE_TYPE api_call_caching = API_CALL_CACHE_TYPE_ALL,
             std::chrono::duration<uint64_t> caching_update_period = std::chrono::seconds(DEFAULT_ENDPOINT_CACHE_UPDATE_PERIOD / HUNDREDS_OF_NANOS_IN_A_SECOND));
 
     explicit DefaultCallbackProvider(

--- a/src/KinesisVideoProducer.cpp
+++ b/src/KinesisVideoProducer.cpp
@@ -52,7 +52,7 @@ unique_ptr<KinesisVideoProducer> KinesisVideoProducer::create(
     }
 
     kinesis_video_producer->client_handle_ = client_handle;
-    kinesis_video_producer->callback_provider_ = move(callback_provider);
+    kinesis_video_producer->callback_provider_ = std::move(callback_provider);
 
     return kinesis_video_producer;
 }
@@ -77,6 +77,31 @@ unique_ptr<KinesisVideoProducer> KinesisVideoProducer::createSync(
             device_info_provider->getCustomUserAgent(),
             device_info_provider->getCertPath(),
             is_caching_endpoint,
+            caching_update_period));
+
+    return KinesisVideoProducer::createSync(std::move(device_info_provider), std::move(callback_provider));
+}
+
+unique_ptr<KinesisVideoProducer> KinesisVideoProducer::createSync(
+        unique_ptr<DeviceInfoProvider> device_info_provider,
+        unique_ptr<ClientCallbackProvider> client_callback_provider,
+        unique_ptr<StreamCallbackProvider> stream_callback_provider,
+        unique_ptr<CredentialProvider> credential_provider,
+        API_CALL_CACHE_TYPE api_call_caching,
+        const std::string &region,
+        const std::string &control_plane_uri,
+        const std::string &user_agent_name,
+        uint64_t caching_update_period) {
+
+    unique_ptr<DefaultCallbackProvider> callback_provider(new DefaultCallbackProvider(std::move(client_callback_provider),
+            std::move(stream_callback_provider),
+            std::move(credential_provider),
+            region,
+            control_plane_uri,
+            user_agent_name,
+            device_info_provider->getCustomUserAgent(),
+            device_info_provider->getCertPath(),
+            api_call_caching,
             caching_update_period));
 
     return KinesisVideoProducer::createSync(std::move(device_info_provider), std::move(callback_provider));

--- a/src/KinesisVideoProducer.h
+++ b/src/KinesisVideoProducer.h
@@ -86,6 +86,17 @@ public:
 
     static std::unique_ptr<KinesisVideoProducer> createSync(
             std::unique_ptr<DeviceInfoProvider> device_info_provider,
+            std::unique_ptr<ClientCallbackProvider> client_callback_provider,
+            std::unique_ptr<StreamCallbackProvider> stream_callback_provider,
+            std::unique_ptr<CredentialProvider> credential_provider,
+            API_CALL_CACHE_TYPE api_call_caching = API_CALL_CACHE_TYPE_ALL,
+            const std::string &region = DEFAULT_AWS_REGION,
+            const std::string &control_plane_uri = "",
+            const std::string &user_agent_name = DEFAULT_USER_AGENT_NAME,
+            uint64_t caching_update_period = DEFAULT_ENDPOINT_CACHE_UPDATE_PERIOD);
+
+    static std::unique_ptr<KinesisVideoProducer> createSync(
+            std::unique_ptr<DeviceInfoProvider> device_info_provider,
             std::unique_ptr<CallbackProvider> callback_provider);
 
     virtual ~KinesisVideoProducer();

--- a/src/KinesisVideoStream.cpp
+++ b/src/KinesisVideoStream.cpp
@@ -28,7 +28,7 @@ bool KinesisVideoStream::putFrame(KinesisVideoFrame& frame) const {
     assert(0 != stream_handle_);
     STATUS status = putKinesisVideoFrame(stream_handle_, &frame);
     if (STATUS_FAILED(status)) {
-        LOG_ERROR("Put frame for " << this->stream_name_ << "failed with 0x" << std::hex << status);
+        LOG_ERROR("Put frame for " << this->stream_name_ << " failed with 0x" << std::hex << status);
         return false;
     }
 

--- a/src/gstreamer/KvsSinkStreamCallbackProvider.cpp
+++ b/src/gstreamer/KvsSinkStreamCallbackProvider.cpp
@@ -71,8 +71,12 @@ STATUS
 KvsSinkStreamCallbackProvider::streamClosedHandler(UINT64 custom_data,
                                                    STREAM_HANDLE stream_handle,
                                                    UPLOAD_HANDLE upload_handle) {
-    UNUSED_PARAM(custom_data);
-    LOG_DEBUG("Reported streamClosed callback for stream handle " << stream_handle << ". Upload handle " << upload_handle);
+    std::string streamName = "";
+    auto customDataObj = reinterpret_cast<KvsSinkCustomData*>(custom_data);
+    if(customDataObj != NULL && customDataObj->kvs_sink != NULL) {
+        streamName = customDataObj->kvs_sink->stream_name;
+    }
+    LOG_DEBUG("[" << streamName << "]Reported streamClosed callback");
     return STATUS_SUCCESS;
 }
 

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -375,6 +375,7 @@ void kinesis_video_producer_init(GstKvsSink *kvssink)
                                                                     std::move(client_callback_provider),
                                                                     std::move(stream_callback_provider),
                                                                     std::move(credential_provider),
+                                                                    API_CALL_CACHE_TYPE_ALL,
                                                                     region_str,
                                                                     control_plane_uri_str,
                                                                     kvssink->user_agent);
@@ -458,7 +459,7 @@ void create_kinesis_video_stream(GstKvsSink *kvssink) {
         stream_definition->setFrameOrderMode(FRAME_ORDERING_MODE_MULTI_TRACK_AV_COMPARE_PTS_ONE_MS_COMPENSATE_EOFR);
     }
 
-    data->kinesis_video_stream = data->kinesis_video_producer->createStreamSync(move(stream_definition));
+    data->kinesis_video_stream = data->kinesis_video_producer->createStreamSync(std::move(stream_definition));
     data->frame_count = 0;
     cout << "Stream is ready" << endl;
 }
@@ -1223,9 +1224,6 @@ bool put_frame(shared_ptr<KvsSinkCustomData> data, void *frame_data, size_t len,
             g_signal_emit(G_OBJECT(data->kvs_sink), data->metric_signal_id, 0, kvs_sink_metric);
             delete kvs_sink_metric;
         }
-    }
-    else if(!ret) {
-        LOG_DEBUG("Failed to put the frame");
     }
     return ret;
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Enable caching by default and set policy to ALL
- Tested kvssink and all samples in the samples folder
- Introduced new helper APIs to set this up
- If stream is not pre-created and policy is set to API_CALL_CACHE_TYPE_ENDPOINT_ONLY, the sample would encounter STREAM_NOT_FOUND error since we cache only the endpoint and not the describe call result.
- Couple of other compiler warning fixes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
