### PR TITLE
Invoke stopSync in NULL state transition

### DIFF
--- a/src/KinesisVideoStream.cpp
+++ b/src/KinesisVideoStream.cpp
@@ -160,7 +160,6 @@ bool KinesisVideoStream::stop() {
 
 bool KinesisVideoStream::stopSync() {
     STATUS status;
-    LOG_INFO("Stopping streaming");
     if (STATUS_FAILED(status = stopKinesisVideoStreamSync(stream_handle_))) {
         LOG_ERROR("Failed to stop the stream with: " << status << " for " << this->stream_name_);
         return false;

--- a/src/KinesisVideoStream.cpp
+++ b/src/KinesisVideoStream.cpp
@@ -160,7 +160,7 @@ bool KinesisVideoStream::stop() {
 
 bool KinesisVideoStream::stopSync() {
     STATUS status;
-
+    LOG_INFO("Stopping streaming");
     if (STATUS_FAILED(status = stopKinesisVideoStreamSync(stream_handle_))) {
         LOG_ERROR("Failed to stop the stream with: " << status << " for " << this->stream_name_);
         return false;

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -1604,10 +1604,14 @@ gst_kvs_sink_change_state(GstElement *element, GstStateChange transition) {
             }
             break;
         case GST_STATE_CHANGE_READY_TO_PAUSED:
+            LOG_INFO("Collecting pads");
             gst_collect_pads_start (kvssink->collect);
+            LOG_INFO("Collected pads");
             break;
         case GST_STATE_CHANGE_PAUSED_TO_READY:
+            LOG_INFO("Stopping pads");
             gst_collect_pads_stop (kvssink->collect);
+            LOG_INFO("Stopped pads");
             break;
         default:
             break;

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -1613,6 +1613,9 @@ gst_kvs_sink_change_state(GstElement *element, GstStateChange transition) {
             gst_collect_pads_stop (kvssink->collect);
             LOG_INFO("Stopped pads");
             break;
+        case GST_STATE_CHANGE_READY_TO_NULL:
+            LOG_INFO("Pipeline state changed to NULL");
+            break;
         default:
             break;
     }

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -1611,11 +1611,11 @@ gst_kvs_sink_change_state(GstElement *element, GstStateChange transition) {
         case GST_STATE_CHANGE_PAUSED_TO_READY:
             LOG_INFO("Stopping pads");
             gst_collect_pads_stop (kvssink->collect);
+            data->kinesis_video_stream->stopSync();
             LOG_INFO("Stopped pads");
             break;
         case GST_STATE_CHANGE_READY_TO_NULL:
             LOG_INFO("Pipeline state changed to NULL");
-            data->kinesis_video_stream->stopSync();
             break;
         default:
             break;

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -1352,9 +1352,10 @@ gst_kvs_sink_handle_buffer (GstCollectPads * pads,
             }
         }
 
-        put_frame(kvssink->data, info.data, info.size,
+        bool ret = put_frame(kvssink->data, info.data, info.size,
                   std::chrono::nanoseconds(buf->pts),
                   std::chrono::nanoseconds(buf->dts), kinesis_video_flags, track_id, data->frame_count);
+        LOG_INFO("Put frame returned..." << ret);
         data->frame_count++;
     }
     else {

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -1252,7 +1252,7 @@ gst_kvs_sink_handle_buffer (GstCollectPads * pads,
     GstMapInfo info;
 
     info.data = NULL;
-
+    LOG_INFO("Here");
     // eos reached
     if (buf == NULL && track_data == NULL) {
         LOG_INFO("Received event for " << kvssink->stream_name);

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -1615,6 +1615,7 @@ gst_kvs_sink_change_state(GstElement *element, GstStateChange transition) {
             break;
         case GST_STATE_CHANGE_READY_TO_NULL:
             LOG_INFO("Pipeline state changed to NULL");
+            data->kinesis_video_stream->stopSync();
             break;
         default:
             break;

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -1182,6 +1182,13 @@ gst_kvs_sink_handle_sink_event (GstCollectPads *pads,
             event = NULL;
             break;
         }
+        case GST_EVENT_EOS: {
+            LOG_INFO("EOS Event received in sink");
+            if(kvs_sink_track_data == NULL) {
+                LOG_INFO("Null track data");
+            }
+            break;
+        }
         default:
             break;
     }

--- a/src/gstreamer/gstkvssink.h
+++ b/src/gstreamer/gstkvssink.h
@@ -134,6 +134,7 @@ struct _GstKvsSink {
     guint                       num_audio_streams;
     guint                       num_video_streams;
 
+
     std::unique_ptr<Credentials> credentials_;
     std::shared_ptr<KvsSinkCustomData> data;
 };
@@ -162,7 +163,8 @@ struct _KvsSinkCustomData {
             on_first_frame(true),
             frame_count(0),
             first_pts(GST_CLOCK_TIME_NONE),
-            producer_start_time(GST_CLOCK_TIME_NONE) {}
+            producer_start_time(GST_CLOCK_TIME_NONE),
+            streamingStopped(false) {}
     std::unique_ptr<KinesisVideoProducer> kinesis_video_producer;
     std::shared_ptr<KinesisVideoStream> kinesis_video_stream;
 
@@ -174,6 +176,7 @@ struct _KvsSinkCustomData {
     bool get_metrics;
     uint32_t frame_count;
     bool on_first_frame;
+    bool streamingStopped;
     uint64_t frame_pts;
 
     std::atomic_uint stream_status;

--- a/src/gstreamer/gstkvssink.h
+++ b/src/gstreamer/gstkvssink.h
@@ -176,7 +176,7 @@ struct _KvsSinkCustomData {
     bool get_metrics;
     uint32_t frame_count;
     bool on_first_frame;
-    bool streamingStopped;
+    std::atomic<bool> streamingStopped;
     uint64_t frame_pts;
 
     std::atomic_uint stream_status;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In case the streaming needs to be stopped abruptly, be it because of an error or to not let it run till EOS is received, we want to ensure stopStreamSync() is invoked when pipeline is transition to NULL after stopping data collection from buffer. Also added some logging around cleanup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
