### PR TITLE
Version user agent string from kvssink

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   mac-os-build-clang:
-    runs-on: macos-latest
+    runs-on: macos-13
     env:
       AWS_KVS_LOG_LEVEL: 2
     permissions:
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install dependencies
         run: |
-          brew install pkg-config openssl cmake gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly log4cplus gst-libav
+          brew install pkg-config openssl cmake gstreamer log4cplus
       - name: Build repository
         run: |
           mkdir build && cd build
@@ -42,7 +42,7 @@ jobs:
           ./tst/producerTest
 
   mac-os-build-gcc:
-    runs-on: macos-11
+    runs-on: macos-13
     permissions:
       id-token: write
       contents: read
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install dependencies
         run: |
-          brew install pkg-config openssl cmake gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly log4cplus gst-libav
+          brew install pkg-config openssl cmake gstreamer log4cplus
       - name: Build repository
         run: |
           mkdir build && cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake;${CMAKE_MODULE_PATH}")
 include(Utilities)
 project(KinesisVideoProducerCpp)
 
+project(KinesisVideoProducerCpp VERSION 3.3.1)
+
 set(CMAKE_CXX_STANDARD 11)
 include(GNUInstallDirs)
 
@@ -24,6 +26,8 @@ option(ADDRESS_SANITIZER "Build with AddressSanitize." OFF)
 option(MEMORY_SANITIZER "Build with MemorySanitizer" OFF)
 option(THREAD_SANITIZER "Build with ThreadSanitizer" OFF)
 option(UNDEFINED_BEHAVIOR_SANITIZER "Build with UndefinedBehaviorSanitizer" OFF)
+
+add_definitions(-DVERSION_STRING=\"${PROJECT_VERSION}\")
 
 set(CMAKE_MACOSX_RPATH TRUE)
 get_filename_component(ROOT "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -370,7 +370,7 @@ void kinesis_video_producer_init(GstKvsSink *kvssink)
         LOG_INFO("Getting URL from env for " << kvssink->stream_name);
         control_plane_uri_str = string(control_plane_uri);
     }
-
+    LOG_INFO("User agent string: " << kvssink->user_agent);
     data->kinesis_video_producer = KinesisVideoProducer::createSync(std::move(device_info_provider),
                                                                     std::move(client_callback_provider),
                                                                     std::move(stream_callback_provider),
@@ -711,7 +711,7 @@ gst_kvs_sink_init(GstKvsSink *kvssink) {
 
     // Stream definition
     kvssink->stream_name = g_strdup (DEFAULT_STREAM_NAME);
-    kvssink->user_agent = g_strdup(KVS_CLIENT_USER_AGENT_NAME);
+    kvssink->user_agent = g_strdup(KVS_CLIENT_USER_AGENT_NAME "/" KVSSINK_USER_AGENT_POSTFIX_VERSION);
     kvssink->retention_period_hours = DEFAULT_RETENTION_PERIOD_HOURS;
     kvssink->kms_key_id = g_strdup (DEFAULT_KMS_KEY_ID);
     kvssink->streaming_type = DEFAULT_STREAMING_TYPE;

--- a/src/gstreamer/gstkvssink.h
+++ b/src/gstreamer/gstkvssink.h
@@ -57,6 +57,11 @@ G_BEGIN_DECLS
   (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_KVS_SINK))
 #define GST_KVS_SINK_CAST(obj) ((GstKvsSink *)obj)
 
+#ifdef VERSION_STRING
+#define KVSSINK_USER_AGENT_POSTFIX_VERSION VERSION_STRING
+#else
+#define KVSSINK_USER_AGENT_POSTFIX_VERSION "UNKNOWN"
+#endif
 
 typedef struct _GstKvsSink GstKvsSink;
 typedef struct _GstKvsSinkClass GstKvsSinkClass;


### PR DESCRIPTION
What was changed?

By default, the user agent string for the CPP SDK was set to AWS-SDK-KVS-CPP-CLIENT. Set a CPP kvssink specific default user agent.

Why was it changed?

When trying to debug a problem that requires checking backend, it is impossible to understand the source of the request since this SDK depends on producer C SDK and there are other SDKs that depend on producer C SDK as well. This change helps with the differentiation and simplify debugging

How was it changed?

Setting the default format to: AWS-SDK-KVS-CPP-CLIENT/`<version>`
Changed the CMake to set project version which is read to set the user agent string. This would have to be changed before every release

Testing:

Added unit test to test out default agent string and supplied agent string
Tested locally with kvssink pipeline with custom user-agent string and SDK default.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
