### PR TITLE
fix(kvs/sink_gstreamer_sample): Use videotestsrc and add additional debug logging

### DIFF
--- a/samples/kvs_gstreamer_sample.cpp
+++ b/samples/kvs_gstreamer_sample.cpp
@@ -702,6 +702,7 @@ int gstreamer_live_source_init(int argc, char* argv[], CustomData *data, GstElem
             LOG_DEBUG("Using videotestsrc");
         } else {
             LOG_ERROR("Failed to create videotestsrc");
+            return 1;
         }
     } else {
         // Failed creating vtenc - check pi hardware encoder
@@ -717,17 +718,20 @@ int gstreamer_live_source_init(int argc, char* argv[], CustomData *data, GstElem
                 LOG_DEBUG("Using x264enc");
             } else {
                 LOG_ERROR("Failed to create x264enc");
+                return 1;
             }
         }
         source = gst_element_factory_make("v4l2src", "source");
         if (source) {
             LOG_DEBUG("Using v4l2src");
         } else {
+            LOG_DEBUG("Failed to create v4l2src, trying ksvideosrc")
             source = gst_element_factory_make("ksvideosrc", "source");
             if (source) {
                 LOG_DEBUG("Using ksvideosrc");
             } else {
-                LOG_ERROR("Unable to create src element. Tried v4l2src and ksvideosrc");
+                LOG_ERROR("Failed to create ksvideosrc");
+                return 1;
             }
         }
         vtenc = false;

--- a/samples/kvs_gstreamer_sample.cpp
+++ b/samples/kvs_gstreamer_sample.cpp
@@ -1158,7 +1158,10 @@ int main(int argc, char* argv[]) {
                 LOG_DEBUG("Attempt to upload file: " << data.file_list[i].path);
 
                 // control will return after gstreamer_init after file eos or any GST_ERROR was put on the bus.
-                gstreamer_init(argc, argv, &data);
+                if (gstreamer_init(argc, argv, &data) != 0) {
+                    LOG_ERROR("Failed to initialize gstreamer");
+                    return 1;
+                }
 
                 // check if any stream error occurred.
                 stream_status = data.stream_status.load();
@@ -1208,7 +1211,10 @@ int main(int argc, char* argv[]) {
 
     } else {
         // non file uploading scenario
-        gstreamer_init(argc, argv, &data);
+        if (gstreamer_init(argc, argv, &data) != 0) {
+            LOG_ERROR("Failed to initialize gstreamer");
+            return 1;
+        }
         if (STATUS_SUCCEEDED(stream_status)) {
             // if stream_status is success after eos, send out remaining frames.
             data.kinesis_video_stream->stopSync();

--- a/samples/kvs_gstreamer_sample.cpp
+++ b/samples/kvs_gstreamer_sample.cpp
@@ -441,8 +441,10 @@ static bool format_supported_by_source(GstCaps *src_caps, GstCaps *query_caps, i
 static bool resolution_supported(GstCaps *src_caps, GstCaps *query_caps_raw, GstCaps *query_caps_h264,
                                  CustomData &data, int width, int height, int framerate) {
     if (query_caps_h264 && format_supported_by_source(src_caps, query_caps_h264, width, height, framerate)) {
+        LOG_DEBUG("src supports h264")
         data.h264_stream_supported = true;
     } else if (query_caps_raw && format_supported_by_source(src_caps, query_caps_raw, width, height, framerate)) {
+        LOG_DEBUG("src supports raw")
         data.h264_stream_supported = false;
     } else {
         return false;
@@ -694,7 +696,8 @@ int gstreamer_live_source_init(int argc, char* argv[], CustomData *data, GstElem
     // Attempt to create vtenc encoder
     encoder = gst_element_factory_make("vtenc_h264_hw", "encoder");
     if (encoder) {
-        source = gst_element_factory_make("autovideosrc", "source");
+        LOG_DEBUG("Using videotestsrc")
+        source = gst_element_factory_make("videotestsrc", "source");
         vtenc = true;
     } else {
         // Failed creating vtenc - check pi hardware encoder
@@ -707,7 +710,10 @@ int gstreamer_live_source_init(int argc, char* argv[], CustomData *data, GstElem
             isOnRpi = false;
         }
         source = gst_element_factory_make("v4l2src", "source");
-        if (!source) {
+        if (source) {
+            LOG_DEBUG("Using v4l2src");
+        } else {
+            LOG_DEBUG("Using ksvideosrc");
             source = gst_element_factory_make("ksvideosrc", "source");
         }
         vtenc = false;
@@ -719,7 +725,9 @@ int gstreamer_live_source_init(int argc, char* argv[], CustomData *data, GstElem
     }
 
     /* configure source */
-    if (!vtenc) {
+    if (vtenc) {
+        g_object_set(G_OBJECT (source), "is-live", TRUE, NULL);
+    } else {
         g_object_set(G_OBJECT (source), "do-timestamp", TRUE, "device", "/dev/video0", NULL);
     }
 
@@ -833,6 +841,7 @@ int gstreamer_live_source_init(int argc, char* argv[], CustomData *data, GstElem
 
     /* build the pipeline */
     if (!data->h264_stream_supported) {
+        LOG_DEBUG("Constructing pipeline with encoding element")
         gst_bin_add_many(GST_BIN (pipeline), source, video_convert, source_filter, encoder, h264parse, filter,
                          appsink, NULL);
         if (!gst_element_link_many(source, video_convert, source_filter, encoder, h264parse, filter, appsink, NULL)) {
@@ -841,6 +850,7 @@ int gstreamer_live_source_init(int argc, char* argv[], CustomData *data, GstElem
             return 1;
         }
     } else {
+        LOG_DEBUG("Constructing pipeline without encoding element")
         gst_bin_add_many(GST_BIN (pipeline), source, source_filter, h264parse, filter, appsink, NULL);
         if (!gst_element_link_many(source, source_filter, h264parse, filter, appsink, NULL)) {
             g_printerr("Elements could not be linked.\n");

--- a/samples/kvs_gstreamer_sample.cpp
+++ b/samples/kvs_gstreamer_sample.cpp
@@ -696,25 +696,39 @@ int gstreamer_live_source_init(int argc, char* argv[], CustomData *data, GstElem
     // Attempt to create vtenc encoder
     encoder = gst_element_factory_make("vtenc_h264_hw", "encoder");
     if (encoder) {
-        LOG_DEBUG("Using videotestsrc")
-        source = gst_element_factory_make("videotestsrc", "source");
         vtenc = true;
+        source = gst_element_factory_make("videotestsrc", "source");
+        if (source) {
+            LOG_DEBUG("Using videotestsrc");
+        } else {
+            LOG_ERROR("Failed to create videotestsrc");
+        }
     } else {
         // Failed creating vtenc - check pi hardware encoder
         encoder = gst_element_factory_make("omxh264enc", "encoder");
         if (encoder) {
+            LOG_DEBUG("Using omxh264enc");
             isOnRpi = true;
         } else {
             // - attempt x264enc
-            encoder = gst_element_factory_make("x264enc", "encoder");
             isOnRpi = false;
+            encoder = gst_element_factory_make("x264enc", "encoder");
+            if (encoder) {
+                LOG_DEBUG("Using x264enc");
+            } else {
+                LOG_ERROR("Failed to create x264enc");
+            }
         }
         source = gst_element_factory_make("v4l2src", "source");
         if (source) {
             LOG_DEBUG("Using v4l2src");
         } else {
-            LOG_DEBUG("Using ksvideosrc");
             source = gst_element_factory_make("ksvideosrc", "source");
+            if (source) {
+                LOG_DEBUG("Using ksvideosrc");
+            } else {
+                LOG_ERROR("Unable to create src element. Tried v4l2src and ksvideosrc");
+            }
         }
         vtenc = false;
     }

--- a/samples/kvs_gstreamer_sample.cpp
+++ b/samples/kvs_gstreamer_sample.cpp
@@ -689,9 +689,25 @@ int gstreamer_live_source_init(int argc, char* argv[], CustomData *data, GstElem
        gst-launch-1.0 v4l2src device=/dev/video0 ! video/x-raw,format=I420,width=1280,height=720,framerate=15/1 ! x264enc pass=quant bframes=0 ! video/x-h264,profile=baseline,format=I420,width=1280,height=720,framerate=15/1 ! matroskamux ! filesink location=test.mkv
      */
     source_filter = gst_element_factory_make("capsfilter", "source_filter");
+    if (!source_filter) {
+        LOG_ERROR("Failed to create capsfilter (1)");
+        return 1;
+    }
     filter = gst_element_factory_make("capsfilter", "encoder_filter");
+    if (!filter) {
+        LOG_ERROR("Failed to create capsfilter (2)");
+        return 1;
+    }
     appsink = gst_element_factory_make("appsink", "appsink");
+    if (!appsink) {
+        LOG_ERROR("Failed to create appsink");
+        return 1;
+    }
     h264parse = gst_element_factory_make("h264parse", "h264parse"); // needed to enforce avc stream format
+    if (!h264parse) {
+        LOG_ERROR("Failed to create h264parse");
+        return 1;
+    }
 
     // Attempt to create vtenc encoder
     encoder = gst_element_factory_make("vtenc_h264_hw", "encoder");

--- a/samples/kvssink_gstreamer_sample.cpp
+++ b/samples/kvssink_gstreamer_sample.cpp
@@ -342,9 +342,13 @@ int gstreamer_live_source_init(int argc, char *argv[], CustomData *data, GstElem
     // Attempt to create vtenc encoder
     encoder = gst_element_factory_make("vtenc_h264_hw", "encoder");
     if (encoder) {
-        LOG_DEBUG("Using videotestsrc")
-        source = gst_element_factory_make("videotestsrc", "source");
         vtenc = true;
+        source = gst_element_factory_make("videotestsrc", "source");
+        if (source) {
+            LOG_DEBUG("Using videotestsrc");
+        } else {
+            LOG_ERROR("Failed to create videotestsrc");
+        }
     } else {
         // Failed creating vtenc - check pi hardware encoder
         encoder = gst_element_factory_make("omxh264enc", "encoder");
@@ -353,16 +357,24 @@ int gstreamer_live_source_init(int argc, char *argv[], CustomData *data, GstElem
             isOnRpi = true;
         } else {
             // - attempt x264enc
-            LOG_DEBUG("Using x264enc")
-            encoder = gst_element_factory_make("x264enc", "encoder");
             isOnRpi = false;
+            encoder = gst_element_factory_make("x264enc", "encoder");
+            if (encoder) {
+                LOG_DEBUG("Using x264enc");
+            } else {
+                LOG_ERROR("Failed to create x264enc");
+            }
         }
         source = gst_element_factory_make("v4l2src", "source");
         if (source) {
             LOG_DEBUG("Using v4l2src");
         } else {
-            LOG_DEBUG("Using ksvideosrc");
             source = gst_element_factory_make("ksvideosrc", "source");
+            if (source) {
+                LOG_DEBUG("Using ksvideosrc");
+            } else {
+                LOG_ERROR("Unable to create src element. Tried v4l2src and ksvideosrc");
+            }
         }
         vtenc = false;
     }

--- a/samples/kvssink_gstreamer_sample.cpp
+++ b/samples/kvssink_gstreamer_sample.cpp
@@ -348,6 +348,7 @@ int gstreamer_live_source_init(int argc, char *argv[], CustomData *data, GstElem
             LOG_DEBUG("Using videotestsrc");
         } else {
             LOG_ERROR("Failed to create videotestsrc");
+            return 1;
         }
     } else {
         // Failed creating vtenc - check pi hardware encoder
@@ -363,17 +364,20 @@ int gstreamer_live_source_init(int argc, char *argv[], CustomData *data, GstElem
                 LOG_DEBUG("Using x264enc");
             } else {
                 LOG_ERROR("Failed to create x264enc");
+                return 1;
             }
         }
         source = gst_element_factory_make("v4l2src", "source");
         if (source) {
             LOG_DEBUG("Using v4l2src");
         } else {
+            LOG_DEBUG("Failed to create v4l2src, trying ksvideosrc")
             source = gst_element_factory_make("ksvideosrc", "source");
             if (source) {
                 LOG_DEBUG("Using ksvideosrc");
             } else {
-                LOG_ERROR("Unable to create src element. Tried v4l2src and ksvideosrc");
+                LOG_ERROR("Failed to create ksvideosrc");
+                return 1;
             }
         }
         vtenc = false;

--- a/samples/kvssink_gstreamer_sample.cpp
+++ b/samples/kvssink_gstreamer_sample.cpp
@@ -816,7 +816,9 @@ int main(int argc, char *argv[]) {
                 LOG_DEBUG("Attempt to upload file: " << data_global.file_list[i].path);
 
                 // control will return after gstreamer_init after file eos or any GST_ERROR was put on the bus.
-                gstreamer_init(argc, argv, &data_global);
+                if (gstreamer_init(argc, argv, &data_global) != 0) {
+                    return 1;
+                }
 
                 // check if any stream error occurred.
                 stream_status = data_global.stream_status.load();
@@ -860,7 +862,9 @@ int main(int argc, char *argv[]) {
 
     } else {
         // non file uploading scenario
-        gstreamer_init(argc, argv, &data_global);
+        if (gstreamer_init(argc, argv, &data_global) != 0) {
+            return 1;
+        }
 	stream_status = data_global.stream_status.load();
         if (STATUS_SUCCEEDED(stream_status)) {
             LOG_INFO("Stream succeeded");

--- a/samples/kvssink_gstreamer_sample.cpp
+++ b/samples/kvssink_gstreamer_sample.cpp
@@ -335,9 +335,25 @@ int gstreamer_live_source_init(int argc, char *argv[], CustomData *data, GstElem
 
     /* create the elemnents */
     source_filter = gst_element_factory_make("capsfilter", "source_filter");
+    if (!source_filter) {
+        LOG_ERROR("Failed to create capsfilter (1)");
+        return 1;
+    }
     filter = gst_element_factory_make("capsfilter", "encoder_filter");
+    if (!filter) {
+        LOG_ERROR("Failed to create capsfilter (2)");
+        return 1;
+    }
     kvssink = gst_element_factory_make("kvssink", "kvssink");
+    if (!kvssink) {
+        LOG_ERROR("Failed to create kvssink");
+        return 1;
+    }
     h264parse = gst_element_factory_make("h264parse", "h264parse"); // needed to enforce avc stream format
+    if (!h264parse) {
+        LOG_ERROR("Failed to create h264parse");
+        return 1;
+    }
 
     // Attempt to create vtenc encoder
     encoder = gst_element_factory_make("vtenc_h264_hw", "encoder");


### PR DESCRIPTION
### Issue #, if available
When running the sample on a mac in live_source mode (`./kvs_gstreamer_sample demo-stream`), we would get "Elements could not be linked." error. We tested this on both m1 mac, and intel mac, each using `GStreamer Core Library version 1.22.5` and encountered this error both times.

### What was changed, and how was it changed?
* In live_source mode, use `videotestsrc` instead of `autovideosrc`
* Add additional debug logs
* The same was also applied to `kvssink_gstreamer_sample`, as these samples are very similar.
  * Fix typo in `kvssink_gstreamer_sample`: `gracefully`.

### Why was it changed?
* We determined that `data->h264_stream_supported` is `true`, therefore, [this pipeline](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/blob/e8125ee363c4e77e11b15398a8b77f4e8a5791a5/samples/kvs_gstreamer_sample.cpp#L845) was getting created.
* `autovideosrc` has [ANY pads](https://gstreamer.freedesktop.org/documentation/autodetect/autovideosrc.html?gi-language=c#src), so, when [data.h264_stream_supported being determined](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/blob/e8125ee363c4e77e11b15398a8b77f4e8a5791a5/samples/kvs_gstreamer_sample.cpp#L448-L450), [the intersection](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/blob/e8125ee363c4e77e11b15398a8b77f4e8a5791a5/samples/kvs_gstreamer_sample.cpp#L432) will always return `true`. `autovideosrc`'s pads do not accurately reflect the available elements on the device, as that is determined during the application runtime. Both this [if statement](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/blob/e8125ee363c4e77e11b15398a8b77f4e8a5791a5/samples/kvs_gstreamer_sample.cpp#L447C26-L447C26) and [this if statement](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/blob/e8125ee363c4e77e11b15398a8b77f4e8a5791a5/samples/kvs_gstreamer_sample.cpp#L449) return `true` with `autovideosrc`.
* Neither `autovideosrc`, `videotestsrc` or [`avfvideosrc`](https://gstreamer.freedesktop.org/documentation/applemedia/avfvideosrc.html?gi-language=c#src) output `video/x-h264`, therefore it cannot be directly linked to [`h264parse`](https://gstreamer.freedesktop.org/documentation/videoparsersbad/h264parse.html?gi-language=c#src).
  * You can confirm this by using the following: `gst-launch-1.0 <src element> ! capsfilter name=filter caps="video/x-h264" ! fakesink` and seeing "`WARNING: erroneous pipeline: could not link <src element> to filter`". The application should be choosing to construct the [top pipeline with the encoder element](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/blob/4c4afff63f3371a69be2472bb0bee654ef09abd3/samples/kvs_gstreamer_sample.cpp#L836-L842), rather than [the bottom pipeline](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/blob/4c4afff63f3371a69be2472bb0bee654ef09abd3/samples/kvs_gstreamer_sample.cpp#L844-L849).
* By switching `autovideosrc` to `videotestsrc`, the correct caps are advertised, and the sample application (using `gst_caps_can_intersect`) is able to choose the correct pipeline to construct.

### Testing
* Ran both samples in live source mode: `./kvs_gstreamer_sample demo-stream` and `./kvssink_gstreamer_sample demo-stream` and verified playback in the AWS management console.

<img width="1201" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/assets/14988194/fa0a2237-59c4-42e9-b806-737fca19fcf2">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
