### PR TITLE
add support for CN region (#934)

### DIFF
--- a/src/DefaultCallbackProvider.cpp
+++ b/src/DefaultCallbackProvider.cpp
@@ -421,6 +421,10 @@ DefaultCallbackProvider::DefaultCallbackProvider(
                              + "."
                              + region_
                              + CONTROL_PLANE_URI_POSTFIX;
+        // If region is in CN, add CN region uri postfix
+        if(region_.rfind("cn-", 0) == 0) {
+            control_plane_uri_ += ".cn";
+        }
     }
 
     getStreamCallbacks();

--- a/src/DefaultCallbackProvider.cpp
+++ b/src/DefaultCallbackProvider.cpp
@@ -422,7 +422,7 @@ DefaultCallbackProvider::DefaultCallbackProvider(
                              + region_
                              + CONTROL_PLANE_URI_POSTFIX;
         // If region is in CN, add CN region uri postfix
-        if(region_.rfind("cn-", 0) == 0) {
+        if (region_.rfind("cn-", 0) == 0) {
             control_plane_uri_ += ".cn";
         }
     }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/issues/1043

*What changed*
Support for .cn domain names had been added to the master branch and subsequent releases but somehow had not been merged back into develop.