### PR TITLE
Fix readme link to kvs_log_configuration and build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Set up the desired log level. The log levels currently available with `log4cplus
 5. `ERROR`   
 6. `FATAL`   
 
-To set a log level, update the log level value [here](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/blob/master/samples/kvs_log_configuration#L1)
+To set a log level, update the log level value [here](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/blob/master/kvs_log_configuration#L1)
 
 Note: The default log level is `DEBUG`
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <h4 align="center"> Amazon Kinesis Video Streams | Secure Video Ingestion for Analysis &amp; Storage </h4>
 
 <p align="center">
-  <a href="https://travis-ci.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp"> <img src="https://travis-ci.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp.svg?branch=master" alt="Build Status"> </a>
+  <a href="https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/actions/workflows/ci.yml"> <img src="https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/actions/workflows/ci.yml/badge.svg"> </a>
   <a href="https://codecov.io/gh/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp"> <img src="https://codecov.io/gh/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/branch/master/graph/badge.svg" alt="Coverage Status"> </a>
 </p>
 


### PR DESCRIPTION
Removes extra `/sample/` directory from path to **kvs_log_configuration**.
Adds @niyatim23's changes to fix build badge in readme.

<br>
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
