### PR TITLE
[DRAFT] Put frame return error codes support start stop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ open-source/libusrsctp
 open-source/libwebsockets
 open-source/local
 open-source/libautoconf
+open-source
 outputs
 tags
 dependency

--- a/src/KinesisVideoStream.cpp
+++ b/src/KinesisVideoStream.cpp
@@ -19,17 +19,17 @@ KinesisVideoStream::KinesisVideoStream(const KinesisVideoProducer& kinesis_video
     }
 }
 
-bool KinesisVideoStream::putFrame(KinesisVideoFrame& frame) const {
-    if (debug_dump_frame_info_) {
+STATUS KinesisVideoStream::putFrame(KinesisVideoFrame& frame) const {
+ //   if (debug_dump_frame_info_) {
         LOG_DEBUG("[" << this->stream_name_ << "] pts: " << frame.presentationTs << ", dts: " << frame.decodingTs << ", duration: " << frame.duration << ", size: " << frame.size << ", trackId: " << frame.trackId
                           << ", isKey: " << CHECK_FRAME_FLAG_KEY_FRAME(frame.flags));
-    }
+ //   }
 
     assert(0 != stream_handle_);
     STATUS status = putKinesisVideoFrame(stream_handle_, &frame);
     if (STATUS_FAILED(status)) {
         LOG_ERROR("Put frame for " << this->stream_name_ << " failed with 0x" << std::hex << status);
-        return false;
+        return status;
     }
 
     // Print metrics on every key-frame
@@ -60,9 +60,7 @@ bool KinesisVideoStream::putFrame(KinesisVideoFrame& frame) const {
             LOG_ERROR("Failed to get metrics. Error: " << err.what());
         }
     }
-
-    // Even if metrics fail, we do not want to return false for putFrame. We just log the error
-    return true;
+    return status;
 }
 
 bool KinesisVideoStream::start(const std::string& hexEncodedCodecPrivateData, uint64_t trackId) {

--- a/src/KinesisVideoStream.h
+++ b/src/KinesisVideoStream.h
@@ -60,7 +60,7 @@ public:
      * @param frame The frame to be packaged and streamed.
      * @return true if the encoder accepted the frame and false otherwise.
      */
-    bool putFrame(KinesisVideoFrame& frame) const;
+    STATUS putFrame(KinesisVideoFrame& frame) const;
 
     /**
      * Gets the stream metrics.

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -1211,13 +1211,16 @@ void create_kinesis_video_frame(Frame *frame, const nanoseconds &pts, const nano
     frame->trackId = static_cast<UINT64>(track_id);
 }
 
-bool put_frame(shared_ptr<KvsSinkCustomData> data, void *frame_data, size_t len, const nanoseconds &pts,
+STATUS
+put_frame(std::shared_ptr<KvsSinkCustomData> data, void *frame_data, size_t len, const nanoseconds &pts,
           const nanoseconds &dts, FRAME_FLAGS flags, uint64_t track_id, uint32_t index) {
 
+    STATUS put_frame_status = STATUS_SUCCESS;
     Frame frame;
+
     create_kinesis_video_frame(&frame, pts, dts, flags, frame_data, len, track_id, index);
-    bool ret = data->kinesis_video_stream->putFrame(frame);
-    if(data->get_metrics && ret) {
+    put_frame_status = data->kinesis_video_stream->putFrame(frame);
+    if(data->get_metrics && STATUS_SUCCEEDED(put_frame_status)) {
         if(CHECK_FRAME_FLAG_KEY_FRAME(flags)  || data->on_first_frame){
             KvsSinkMetric *kvs_sink_metric = new KvsSinkMetric();
             kvs_sink_metric->stream_metrics = data->kinesis_video_stream->getMetrics();
@@ -1229,7 +1232,7 @@ bool put_frame(shared_ptr<KvsSinkCustomData> data, void *frame_data, size_t len,
             delete kvs_sink_metric;
         }
     }
-    return ret;
+    return put_frame_status;
 }
 
 static GstFlowReturn
@@ -1247,6 +1250,7 @@ gst_kvs_sink_handle_buffer (GstCollectPads * pads,
     uint64_t track_id;
     FRAME_FLAGS kinesis_video_flags = FRAME_FLAG_NONE;
     GstMapInfo info;
+    STATUS put_frame_status = STATUS_SUCCESS;
 
     info.data = NULL;
     // eos reached
@@ -1356,9 +1360,9 @@ gst_kvs_sink_handle_buffer (GstCollectPads * pads,
             }
         }
 
-        put_frame(kvssink->data, info.data, info.size,
-                  std::chrono::nanoseconds(buf->pts),
-                  std::chrono::nanoseconds(buf->dts), kinesis_video_flags, track_id, data->frame_count);
+        put_frame_status = put_frame(data, info.data, info.size,
+                                     std::chrono::nanoseconds(buf->pts),
+                                     std::chrono::nanoseconds(buf->dts), kinesis_video_flags, track_id, data->frame_count);
         data->frame_count++;
     }
     else {
@@ -1372,6 +1376,11 @@ CleanUp:
 
     if (buf != NULL) {
         gst_buffer_unref (buf);
+    }
+
+    if (STATUS_FAILED(put_frame_status)) {
+        GST_ELEMENT_WARNING (kvssink, STREAM, FAILED, (NULL),
+                           ("put frame error occurred. Status: 0x%08x", put_frame_status));
     }
 
     return ret;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The `putKinesisVideoFrame` API in PIC returns a detailed `STATUS` code.  Unfortunately in Producer CPP the `KinesisVideoStream` class has a `putFrame` member function which unfortunately swallows the return STATUS code from the lower level PIC API and only returns a boolean.  Further in the current implementation of `kvssink` GStreamer element the boolean return code is completely ignored so we do not do anything at all when the putFrame call failed with some error.  In addition we do not properly handle GStreamer pipeline state transitions in the `kvssink` GStreamer element, in particular the underlying Producer SDK supports stopping a stream and then restreaming.  This requires support for more transitions inside the `gst_kvs_sink_change_state` function, specifically more case statements need to be added to support different types of `GstStateChange`, see [ref](https://api.gtkd.org/gstreamer.c.types.GstStateChange.html) for details about possible state transitions in a `GStreamer` pipeline.

- [X] `KinesisVideoStream::putFrame` should return a `STATUS`
- [X] `kvssink` GStreamer elements should not ignore the return status from the putFrame call.  When an error is received from `putFrame` a message should be placed on the GStreamer bus indicating 
- [ ] Complete support for different values of `GstStateChange` in `gst_kvs_sink_change_state`
- [ ] Explicit handler for receipt of EOS [need to validate if this is actually necessary]
- [ ] Test start / stop of pipeline transition between different states.  
- [ ] Test or Sample update to show how to use the new messages we put on the bus and how an application can properly respond to them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
