### PR TITLE
Install libcproducer.dylib and libgstkvssink.so through CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,12 @@ install(
     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
+install(
+    TARGETS cproducer
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+
 if(BUILD_JNI)
   find_package(JNI REQUIRED)
   include_directories(${JNI_INCLUDE_DIRS})
@@ -232,6 +238,13 @@ if(BUILD_GSTREAMER_PLUGIN)
 
   add_executable(kvs_gstreamer_file_uploader_sample samples/kvs_gstreamer_file_uploader_sample.cpp)
   target_link_libraries(kvs_gstreamer_file_uploader_sample ${GST_APP_LIBRARIES})
+
+  install(
+    TARGETS gstkvssink
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+  
 endif()
 
 if(BUILD_TEST)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/issues/1086

*Description of changes:*

What was changed?
The _CMake_ file has install steps for _libcproducer_ and _libgstkvssink_

Why was it changed?
We have manually copy all the dependencies needed to run the Producer despite running `cmake` with `-DCMAKE_INSTALL_PREFIX`. Currently we have to manually copy out these files to appropriate locations. We won't have to do that anymore after this fix

How was it changed?
Added installation steps in the main _CMake_ file

What testing was done for the changes?
Run `cmake .. -DCMAKE_INSTALL_PREFIX=/path/to/test-cmake-install -DBUILD_GSTREAMER_PLUGIN=ON` and check that 
```
niyatim@88665a374cf5 test-cmake-install % ls lib
libKinesisVideoProducer.dylib	libgstkvssink.so
libcproducer.dylib
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
