### PR TITLE
Fix KVSSINK State Transition Deadlock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
       id-token: write
       contents: read
     env:
-      CC: gcc
-      CXX: g++
+      CC: /usr/local/bin/gcc-13
+      CXX: /usr/local/bin/g++-13
       AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository
@@ -192,7 +192,7 @@ jobs:
           timeout --signal=SIGABRT 60m ./tst/producerTest
 
   # memory-sanitizer:
-  #   runs-on: ubuntu-20.04 
+  #   runs-on: ubuntu-20.04
   #   permissions:
   #     id-token: write
   #     contents: read
@@ -291,7 +291,7 @@ jobs:
         run: |
           choco install nasm strawberryperl
           choco install gstreamer --version=1.16.2
-          choco install gstreamer-devel --version=1.16.2 
+          choco install gstreamer-devel --version=1.16.2
       - name: Build repository
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   mac-os-build-clang:
-    runs-on: macos-11
+    runs-on: macos-12
     env:
       AWS_KVS_LOG_LEVEL: 2
       CC: /usr/bin/clang
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install dependencies
         run: |
-          brew install pkg-config openssl cmake gstreamer
+          brew install pkg-config cmake gstreamer
           brew unlink openssl
       - name: Build repository
         run: |
@@ -45,7 +45,36 @@ jobs:
         run: |
           cd build  
           ./tst/producerTest
-
+  mac-os-m1-build-clang:
+    runs-on: macos-13-xlarge
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          brew install pkg-config openssl cmake gstreamer
+          brew unlink openssl
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          sh -c 'cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DCMAKE_INSTALL_PREFIX=. -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++;cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DCMAKE_INSTALL_PREFIX=. -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++'
+          make install
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+      - name: Run tests
+        run: |
+          cd build  
+          ./tst/producerTest
   mac-os-build-gcc:
     runs-on: macos-12
     permissions:

--- a/CMake/Dependencies/libkvscproducer-CMakeLists.txt
+++ b/CMake/Dependencies/libkvscproducer-CMakeLists.txt
@@ -7,7 +7,7 @@ include(ExternalProject)
 # clone repo only
 ExternalProject_Add(libkvscproducer-download
 	GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-producer-c.git
-	GIT_TAG           5e8a5cfa0e2e12304983abbe0a9fa023b574ef9a
+	GIT_TAG           develop
 	SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvscproducer-src"
 	BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvscproducer-build"
 	CONFIGURE_COMMAND ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,11 @@ else()
 endif()
 
 if (WIN32)
-  set(PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
+  if(EXISTS "C:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
+    set(PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
+  else()
+     set(PKG_CONFIG_EXECUTABLE "D:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
+  endif()
 endif()
 
 ############# Enable Sanitizers ############

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -1606,9 +1606,18 @@ gst_kvs_sink_change_state(GstElement *element, GstStateChange transition) {
                 goto CleanUp;
             }
             break;
+
         case GST_STATE_CHANGE_READY_TO_PAUSED:
             gst_collect_pads_start (kvssink->collect);
             break;
+            
+        default:
+            break;
+    }
+
+    ret = GST_ELEMENT_CLASS (parent_class)->change_state(element, transition);
+
+    switch (transition) {
         case GST_STATE_CHANGE_PAUSED_TO_READY:
             LOG_INFO("Stopping kvssink for " << kvssink->stream_name);
             gst_collect_pads_stop (kvssink->collect);
@@ -1624,14 +1633,14 @@ gst_kvs_sink_change_state(GstElement *element, GstStateChange transition) {
             }
             LOG_INFO("Stopped kvssink for " << kvssink->stream_name);
             break;
+
         case GST_STATE_CHANGE_READY_TO_NULL:
             LOG_INFO("Pipeline state changed to NULL in kvssink");
             break;
+
         default:
             break;
     }
-
-    ret = GST_ELEMENT_CLASS (parent_class)->change_state(element, transition);
 
 CleanUp:
 


### PR DESCRIPTION
Move parent state transition to be in between upward and downward element transitions as per [GStreamer documentation](https://gstreamer.freedesktop.org/documentation/plugin-development/basics/states.html?gi-language=c#:~:text=Note%20that%20upwards,destroying%20allocated%20resources.).

Tested using `kvssink_gstreamer_sample` to successfully ingest stream and cleanly exit upon sigint with videotestsrc, filesrc, and rtspsrc sources.
