### PR TITLE
Fix GCC and Windows CI Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,7 @@ jobs:
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin'
           git config --system core.longpaths true
           Dir -Recurse D:\gstreamer\1.0
-          $env:PKG_CONFIG_PATH = 'C:\gstreamer\1.0\msvc_x86_64\lib\pkgconfig'
+          $env:PKG_CONFIG_PATH = 'D:\gstreamer\1.0\x86_64\lib\pkgconfig'
           gci env:
           pkg-config --cflags --libs gstreamer-1.0
           .github/build_windows.bat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,7 @@ jobs:
           choco install nasm strawberryperl
           choco install gstreamer --version=1.16.2
           choco install gstreamer-devel --version=1.16.2
+          Import-Module "$env:ChocolateyInstall/helpers/chocolateyInstaller.psm1"
           refreshenv
       - name: Build repository
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,9 +296,9 @@ jobs:
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin'
           git config --system core.longpaths true
-          Dir -Recurse D:\gstreamer\1.0
+          # Dir -Recurse D:\gstreamer\1.0
           $env:PKG_CONFIG_PATH = 'D:\gstreamer\1.0\x86_64\lib\pkgconfig'
-          gci env:
+          # gci env:
           pkg-config --cflags --libs gstreamer-1.0
           .github/build_windows.bat
       - name: Configure AWS Credentials

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,8 +296,8 @@ jobs:
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin'
           git config --system core.longpaths true
-          Dir -Recurse C:\gstreamer\1.0\x86_64\lib\pkgconfig
-          $env:PKG_CONFIG_PATH = 'C:\gstreamer\1.0\x86_64\lib\pkgconfig'
+          Dir -Recurse C:\gstreamer\1.0\msvc_x86_64\lib\pkgconfig
+          $env:PKG_CONFIG_PATH = 'C:\gstreamer\1.0\msvc_x86_64\lib\pkgconfig'
           gci env:
           pkg-config --cflags --libs gstreamer-1.0
           .github/build_windows.bat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,7 @@ jobs:
         run: |
           choco install nasm strawberryperl
           choco install gstreamer --version=1.16.2
+          choco install gstreamer-devel --version=1.16.2
       - name: Build repository
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,10 +291,6 @@ jobs:
         run: |
           choco install nasm strawberryperl
           choco install gstreamer --version=1.16.2
-          choco install gstreamer-devel --version=1.16.2
-          Import-Module "$env:ChocolateyInstall/helpers/chocolateyInstaller.psm1"
-          Update-SessionEnvironment
-          gst-launch-1.0 --gst-version
       - name: Build repository
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,8 @@ jobs:
         run: |
           choco install nasm strawberryperl
           choco install gstreamer --version=1.16.2
-          choco install gstreamer-devel --version=1.16.2 
+          choco install gstreamer-devel --version=1.16.2
+          refreshenv
       - name: Build repository
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
       id-token: write
       contents: read
     env:
-      CC: gcc
-      CXX: g++
+      CC: /usr/local/bin/gcc-13
+      CXX: /usr/local/bin/g++-13
       AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin'
           git config --system core.longpaths true
-          Dir -Recurse C:\gstreamer\1.0\msvc_x86_64\lib\pkgconfig
+          Dir -Recurse C:\gstreamer\1.0
           $env:PKG_CONFIG_PATH = 'C:\gstreamer\1.0\msvc_x86_64\lib\pkgconfig'
           gci env:
           pkg-config --cflags --libs gstreamer-1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,8 +296,8 @@ jobs:
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin'
           git config --system core.longpaths true
-          setx PKG_CONFIG_PATH "C:\gstreamer\1.0\x86_64\lib\pkgconfig"
-          set
+          $env:PKG_CONFIG_PATH = 'C:\gstreamer\1.0\x86_64\lib\pkgconfig'
+          gci env:
           pkg-config --cflags --libs gstreamer-1.0
           .github/build_windows.bat
       - name: Configure AWS Credentials

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,7 @@ jobs:
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin'
           git config --system core.longpaths true
+          export PKG_CONFIG_PATH=C:\gstreamer\1.0\x86_64\lib\pkgconfig
           pkg-config --cflags --libs gstreamer-1.0
           .github/build_windows.bat
       - name: Configure AWS Credentials

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,186 +10,186 @@ on:
       - master
 
 jobs:
-  mac-os-build-clang:
-    runs-on: macos-11
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-      CC: /usr/bin/clang
-      CXX: /usr/bin/clang++
-      LDFLAGS: -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
-      CPATH: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Install dependencies
-        run: |
-          brew install pkg-config openssl cmake gstreamer
-          brew unlink openssl
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DCMAKE_INSTALL_PREFIX=.
-          make
-          make install
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
-      - name: Run tests
-        run: |
-          cd build  
-          ./tst/producerTest
+#   mac-os-build-clang:
+#     runs-on: macos-11
+#     env:
+#       AWS_KVS_LOG_LEVEL: 2
+#       CC: /usr/bin/clang
+#       CXX: /usr/bin/clang++
+#       LDFLAGS: -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
+#       CPATH: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/
+#     permissions:
+#       id-token: write
+#       contents: read
+#     steps:
+#       - name: Clone repository
+#         uses: actions/checkout@v3
+#       - name: Install dependencies
+#         run: |
+#           brew install pkg-config openssl cmake gstreamer
+#           brew unlink openssl
+#       - name: Build repository
+#         run: |
+#           mkdir build && cd build
+#           cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DCMAKE_INSTALL_PREFIX=.
+#           make
+#           make install
+#       - name: Configure AWS Credentials
+#         uses: aws-actions/configure-aws-credentials@v1-node16
+#         with:
+#           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+#           aws-region: ${{ secrets.AWS_REGION }}
+#           role-duration-seconds: 10800
+#       - name: Run tests
+#         run: |
+#           cd build  
+#           ./tst/producerTest
 
-  mac-os-build-gcc:
-    runs-on: macos-12
-    permissions:
-      id-token: write
-      contents: read
-    env:
-      CC: /usr/local/bin/gcc-13
-      CXX: /usr/local/bin/g++-13
-      AWS_KVS_LOG_LEVEL: 2
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Install dependencies
-        run: |
-          brew install pkg-config openssl cmake gstreamer log4cplus
-          brew unlink openssl
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DCMAKE_INSTALL_PREFIX=.
-          make
-          make install
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
-      - name: Run tests
-        run: |  
-          cd build
-          ./tst/producerTest
+#   mac-os-build-gcc:
+#     runs-on: macos-12
+#     permissions:
+#       id-token: write
+#       contents: read
+#     env:
+#       CC: /usr/local/bin/gcc-13
+#       CXX: /usr/local/bin/g++-13
+#       AWS_KVS_LOG_LEVEL: 2
+#     steps:
+#       - name: Clone repository
+#         uses: actions/checkout@v3
+#       - name: Install dependencies
+#         run: |
+#           brew install pkg-config openssl cmake gstreamer log4cplus
+#           brew unlink openssl
+#       - name: Build repository
+#         run: |
+#           mkdir build && cd build
+#           cmake .. -DBUILD_TEST=TRUE -DCMAKE_INSTALL_PREFIX=.
+#           make
+#           make install
+#       - name: Configure AWS Credentials
+#         uses: aws-actions/configure-aws-credentials@v1-node16
+#         with:
+#           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+#           aws-region: ${{ secrets.AWS_REGION }}
+#           role-duration-seconds: 10800
+#       - name: Run tests
+#         run: |  
+#           cd build
+#           ./tst/producerTest
   
-  linux-gcc-code-coverage:
-    runs-on: ubuntu-20.04
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Install dependencies
-        run: |  
-          sudo apt clean && sudo apt update
-          sudo apt install -y libunwind-dev
-          sudo apt-get install -y libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE -DCMAKE_INSTALL_PREFIX=.
-          make
-          make install
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
-      - name: Run tests
-        run: |
-          cd build
-          ulimit -c unlimited -S
-          timeout --signal=SIGABRT 60m ./tst/producerTest
-      - name: Code coverage
-        run: |
-          cd build
-          for test_file in $(find CMakeFiles/KinesisVideoProducer.dir gstkvssink.dir KinesisVideoProducerJNI.dir -name '*.gcno'); do gcov $test_file; done
-          bash <(curl -s https://codecov.io/bash)
+#   linux-gcc-code-coverage:
+#     runs-on: ubuntu-20.04
+#     env:
+#       AWS_KVS_LOG_LEVEL: 2
+#     permissions:
+#       id-token: write
+#       contents: read
+#     steps:
+#       - name: Clone repository
+#         uses: actions/checkout@v3
+#       - name: Install dependencies
+#         run: |  
+#           sudo apt clean && sudo apt update
+#           sudo apt install -y libunwind-dev
+#           sudo apt-get install -y libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
+#       - name: Build repository
+#         run: |
+#           mkdir build && cd build
+#           cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE -DCMAKE_INSTALL_PREFIX=.
+#           make
+#           make install
+#       - name: Configure AWS Credentials
+#         uses: aws-actions/configure-aws-credentials@v1-node16
+#         with:
+#           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+#           aws-region: ${{ secrets.AWS_REGION }}
+#           role-duration-seconds: 10800
+#       - name: Run tests
+#         run: |
+#           cd build
+#           ulimit -c unlimited -S
+#           timeout --signal=SIGABRT 60m ./tst/producerTest
+#       - name: Code coverage
+#         run: |
+#           cd build
+#           for test_file in $(find CMakeFiles/KinesisVideoProducer.dir gstkvssink.dir KinesisVideoProducerJNI.dir -name '*.gcno'); do gcov $test_file; done
+#           bash <(curl -s https://codecov.io/bash)
   
-  address-sanitizer:
-    runs-on: ubuntu-20.04
-    permissions:
-      id-token: write
-      contents: read
-    env:
-      CC: clang
-      CXX: clang++
-      AWS_KVS_LOG_LEVEL: 2
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt install -y libunwind-dev
-          sudo apt-get install -y libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE -DCMAKE_INSTALL_PREFIX=.
-          make
-          make install
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
-      - name: Run tests
-        run: |
-          cd build
-          ulimit -c unlimited -S
-          timeout --signal=SIGABRT 60m ./tst/producerTest
+#   address-sanitizer:
+#     runs-on: ubuntu-20.04
+#     permissions:
+#       id-token: write
+#       contents: read
+#     env:
+#       CC: clang
+#       CXX: clang++
+#       AWS_KVS_LOG_LEVEL: 2
+#     steps:
+#       - name: Clone repository
+#         uses: actions/checkout@v3
+#       - name: Install dependencies
+#         run: |
+#           sudo apt clean && sudo apt update
+#           sudo apt install -y libunwind-dev
+#           sudo apt-get install -y libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
+#       - name: Build repository
+#         run: |
+#           mkdir build && cd build
+#           cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE -DCMAKE_INSTALL_PREFIX=.
+#           make
+#           make install
+#       - name: Configure AWS Credentials
+#         uses: aws-actions/configure-aws-credentials@v1-node16
+#         with:
+#           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+#           aws-region: ${{ secrets.AWS_REGION }}
+#           role-duration-seconds: 10800
+#       - name: Run tests
+#         run: |
+#           cd build
+#           ulimit -c unlimited -S
+#           timeout --signal=SIGABRT 60m ./tst/producerTest
 
-  undefined-behavior-sanitizer:
-    runs-on: ubuntu-20.04
-    permissions:
-      id-token: write
-      contents: read
-    env:
-      CC: clang
-      CXX: clang++
-      AWS_KVS_LOG_LEVEL: 2
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt install -y libunwind-dev
-          sudo apt-get install -y libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE -DCMAKE_INSTALL_PREFIX=.
-          make
-          make install
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
-      - name: Run tests
-        run: |
-          cd build
-          ulimit -c unlimited -S
-          timeout --signal=SIGABRT 60m ./tst/producerTest
+#   undefined-behavior-sanitizer:
+#     runs-on: ubuntu-20.04
+#     permissions:
+#       id-token: write
+#       contents: read
+#     env:
+#       CC: clang
+#       CXX: clang++
+#       AWS_KVS_LOG_LEVEL: 2
+#     steps:
+#       - name: Clone repository
+#         uses: actions/checkout@v3
+#       - name: Install dependencies
+#         run: |
+#           sudo apt clean && sudo apt update
+#           sudo apt install -y libunwind-dev
+#           sudo apt-get install -y libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
+#       - name: Build repository
+#         run: |
+#           mkdir build && cd build
+#           cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE -DCMAKE_INSTALL_PREFIX=.
+#           make
+#           make install
+#       - name: Configure AWS Credentials
+#         uses: aws-actions/configure-aws-credentials@v1-node16
+#         with:
+#           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+#           aws-region: ${{ secrets.AWS_REGION }}
+#           role-duration-seconds: 10800
+#       - name: Run tests
+#         run: |
+#           cd build
+#           ulimit -c unlimited -S
+#           timeout --signal=SIGABRT 60m ./tst/producerTest
 
   # memory-sanitizer:
   #   runs-on: ubuntu-20.04 
@@ -243,39 +243,39 @@ jobs:
   #         ulimit -c unlimited -S 
   #         timeout --signal=SIGABRT 20m ./tst/producerTest
   
-  ubuntu-gcc:
-    runs-on: ubuntu-20.04
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt install -y libunwind-dev
-          sudo apt-get install -y libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE -DCMAKE_INSTALL_PREFIX=.
-          make
-          make install
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
-      - name: Run tests
-        run: |
-          cd build
-          ulimit -c unlimited -S
-          timeout --signal=SIGABRT 60m ./tst/producerTest
+  # ubuntu-gcc:
+  #   runs-on: ubuntu-20.04
+  #   env:
+  #     AWS_KVS_LOG_LEVEL: 2
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt clean && sudo apt update
+  #         sudo apt install -y libunwind-dev
+  #         sudo apt-get install -y libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
+  #     - name: Build repository
+  #       run: |
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE -DCMAKE_INSTALL_PREFIX=.
+  #         make
+  #         make install
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v1-node16
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #         role-duration-seconds: 10800
+  #     - name: Run tests
+  #       run: |
+  #         cd build
+  #         ulimit -c unlimited -S
+  #         timeout --signal=SIGABRT 60m ./tst/producerTest
   
   windows-msvc:
     runs-on: windows-2022
@@ -296,6 +296,7 @@ jobs:
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin'
           git config --system core.longpaths true
+          pkg-config --cflags --libs gstreamer-1.0
           .github/build_windows.bat
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
@@ -309,103 +310,103 @@ jobs:
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin'
           & "D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\build\tst\producerTest.exe" 
 
-  arm64-cross-compilation:
-    runs-on: ubuntu-20.04
-    env:
-      CC: aarch64-linux-gnu-gcc
-      CXX: aarch64-linux-gnu-g++
-    steps:
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt install -y libunwind-dev
-          sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
-          sudo apt-get install libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Build Repository
-        run: |
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic64 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
-          make
-          make install
-          file libKinesisVideoProducer.so
+  # arm64-cross-compilation:
+  #   runs-on: ubuntu-20.04
+  #   env:
+  #     CC: aarch64-linux-gnu-gcc
+  #     CXX: aarch64-linux-gnu-g++
+  #   steps:
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt clean && sudo apt update
+  #         sudo apt install -y libunwind-dev
+  #         sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
+  #         sudo apt-get install libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Build Repository
+  #       run: |
+  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic64 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
+  #         make
+  #         make install
+  #         file libKinesisVideoProducer.so
 
-  linux-aarch64-cross-compilation:
-    runs-on: ubuntu-20.04
-    env:
-      CC: aarch64-linux-gnu-gcc
-      CXX: aarch64-linux-gnu-g++
-    steps:
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt install -y libunwind-dev
-          sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
-          sudo apt-get install libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Build Repository
-        run: |
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-aarch64 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
-          make
-          make install
-          file libKinesisVideoProducer.so
+  # linux-aarch64-cross-compilation:
+  #   runs-on: ubuntu-20.04
+  #   env:
+  #     CC: aarch64-linux-gnu-gcc
+  #     CXX: aarch64-linux-gnu-g++
+  #   steps:
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt clean && sudo apt update
+  #         sudo apt install -y libunwind-dev
+  #         sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
+  #         sudo apt-get install libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Build Repository
+  #       run: |
+  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-aarch64 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
+  #         make
+  #         make install
+  #         file libKinesisVideoProducer.so
 
-  arm32-cross-compilation:
-    runs-on: ubuntu-20.04
-    env:
-      CC: arm-linux-gnueabi-gcc
-      CXX: arm-linux-gnueabi-g++
-    steps:
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt install -y libunwind-dev
-          sudo apt-get -y install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi binutils-arm-linux-gnueabi
-          sudo apt-get install libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Build Repository
-        run: |
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic32 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
-          make
-          make install
-          file libKinesisVideoProducer.so
+  # arm32-cross-compilation:
+  #   runs-on: ubuntu-20.04
+  #   env:
+  #     CC: arm-linux-gnueabi-gcc
+  #     CXX: arm-linux-gnueabi-g++
+  #   steps:
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt clean && sudo apt update
+  #         sudo apt install -y libunwind-dev
+  #         sudo apt-get -y install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi binutils-arm-linux-gnueabi
+  #         sudo apt-get install libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Build Repository
+  #       run: |
+  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic32 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
+  #         make
+  #         make install
+  #         file libKinesisVideoProducer.so
 
-  linux-build-gcc-static:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt install -y libunwind-dev
-          sudo apt-get install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DBUILD_GSTREAMER_PLUGIN=ON -DBUILD_STATIC=ON
-          make
+  # linux-build-gcc-static:
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt clean && sudo apt update
+  #         sudo apt install -y libunwind-dev
+  #         sudo apt-get install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
+  #     - name: Build repository
+  #       run: |
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_GSTREAMER_PLUGIN=ON -DBUILD_STATIC=ON
+  #         make
 
-  linux-build-gcc-shared:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt install -y libunwind-dev
-          sudo apt-get install libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DBUILD_DEPENDENCIES=OFF -DBUILD_GSTREAMER_PLUGIN=ON -DBUILD_STATIC=OFF -DBUILD_SHARED_LIBS=ON
-          make
+  # linux-build-gcc-shared:
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt clean && sudo apt update
+  #         sudo apt install -y libunwind-dev
+  #         sudo apt-get install libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
+  #     - name: Build repository
+  #       run: |
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_DEPENDENCIES=OFF -DBUILD_GSTREAMER_PLUGIN=ON -DBUILD_STATIC=OFF -DBUILD_SHARED_LIBS=ON
+  #         make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin'
           git config --system core.longpaths true
-          Dir -Recurse C:\gstreamer\1.0
+          Dir -Recurse D:\gstreamer\1.0
           $env:PKG_CONFIG_PATH = 'C:\gstreamer\1.0\msvc_x86_64\lib\pkgconfig'
           gci env:
           pkg-config --cflags --libs gstreamer-1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,10 +296,6 @@ jobs:
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin'
           git config --system core.longpaths true
-          # Dir -Recurse D:\gstreamer\1.0
-          $env:PKG_CONFIG_PATH = 'D:\gstreamer\1.0\x86_64\lib\pkgconfig'
-          # gci env:
-          pkg-config --cflags --libs gstreamer-1.0
           .github/build_windows.bat
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,8 @@ jobs:
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin'
           git config --system core.longpaths true
-          SET PKG_CONFIG_PATH=C:\gstreamer\1.0\x86_64\lib\pkgconfig
+          setx PKG_CONFIG_PATH "C:\gstreamer\1.0\x86_64\lib\pkgconfig"
+          set
           pkg-config --cflags --libs gstreamer-1.0
           .github/build_windows.bat
       - name: Configure AWS Credentials

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin'
           git config --system core.longpaths true
-          export PKG_CONFIG_PATH=C:\gstreamer\1.0\x86_64\lib\pkgconfig
+          SET PKG_CONFIG_PATH=C:\gstreamer\1.0\x86_64\lib\pkgconfig
           pkg-config --cflags --libs gstreamer-1.0
           .github/build_windows.bat
       - name: Configure AWS Credentials

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,7 +293,8 @@ jobs:
           choco install gstreamer --version=1.16.2
           choco install gstreamer-devel --version=1.16.2
           Import-Module "$env:ChocolateyInstall/helpers/chocolateyInstaller.psm1"
-          refreshenv
+          Update-SessionEnvironment
+          gst-launch-1.0 --gst-version
       - name: Build repository
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,189 +10,189 @@ on:
       - master
 
 jobs:
-#   mac-os-build-clang:
-#     runs-on: macos-11
-#     env:
-#       AWS_KVS_LOG_LEVEL: 2
-#       CC: /usr/bin/clang
-#       CXX: /usr/bin/clang++
-#       LDFLAGS: -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
-#       CPATH: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/
-#     permissions:
-#       id-token: write
-#       contents: read
-#     steps:
-#       - name: Clone repository
-#         uses: actions/checkout@v3
-#       - name: Install dependencies
-#         run: |
-#           brew install pkg-config openssl cmake gstreamer
-#           brew unlink openssl
-#       - name: Build repository
-#         run: |
-#           mkdir build && cd build
-#           cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DCMAKE_INSTALL_PREFIX=.
-#           make
-#           make install
-#       - name: Configure AWS Credentials
-#         uses: aws-actions/configure-aws-credentials@v1-node16
-#         with:
-#           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-#           aws-region: ${{ secrets.AWS_REGION }}
-#           role-duration-seconds: 10800
-#       - name: Run tests
-#         run: |
-#           cd build  
-#           ./tst/producerTest
+  mac-os-build-clang:
+    runs-on: macos-11
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+      CC: /usr/bin/clang
+      CXX: /usr/bin/clang++
+      LDFLAGS: -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
+      CPATH: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          brew install pkg-config openssl cmake gstreamer
+          brew unlink openssl
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DCMAKE_INSTALL_PREFIX=.
+          make
+          make install
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+      - name: Run tests
+        run: |
+          cd build  
+          ./tst/producerTest
 
-#   mac-os-build-gcc:
-#     runs-on: macos-12
-#     permissions:
-#       id-token: write
-#       contents: read
-#     env:
-#       CC: /usr/local/bin/gcc-13
-#       CXX: /usr/local/bin/g++-13
-#       AWS_KVS_LOG_LEVEL: 2
-#     steps:
-#       - name: Clone repository
-#         uses: actions/checkout@v3
-#       - name: Install dependencies
-#         run: |
-#           brew install pkg-config openssl cmake gstreamer log4cplus
-#           brew unlink openssl
-#       - name: Build repository
-#         run: |
-#           mkdir build && cd build
-#           cmake .. -DBUILD_TEST=TRUE -DCMAKE_INSTALL_PREFIX=.
-#           make
-#           make install
-#       - name: Configure AWS Credentials
-#         uses: aws-actions/configure-aws-credentials@v1-node16
-#         with:
-#           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-#           aws-region: ${{ secrets.AWS_REGION }}
-#           role-duration-seconds: 10800
-#       - name: Run tests
-#         run: |  
-#           cd build
-#           ./tst/producerTest
+  mac-os-build-gcc:
+    runs-on: macos-12
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      CC: /usr/local/bin/gcc-13
+      CXX: /usr/local/bin/g++-13
+      AWS_KVS_LOG_LEVEL: 2
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          brew install pkg-config openssl cmake gstreamer log4cplus
+          brew unlink openssl
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DCMAKE_INSTALL_PREFIX=.
+          make
+          make install
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+      - name: Run tests
+        run: |  
+          cd build
+          ./tst/producerTest
   
-#   linux-gcc-code-coverage:
-#     runs-on: ubuntu-20.04
-#     env:
-#       AWS_KVS_LOG_LEVEL: 2
-#     permissions:
-#       id-token: write
-#       contents: read
-#     steps:
-#       - name: Clone repository
-#         uses: actions/checkout@v3
-#       - name: Install dependencies
-#         run: |  
-#           sudo apt clean && sudo apt update
-#           sudo apt install -y libunwind-dev
-#           sudo apt-get install -y libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
-#       - name: Build repository
-#         run: |
-#           mkdir build && cd build
-#           cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE -DCMAKE_INSTALL_PREFIX=.
-#           make
-#           make install
-#       - name: Configure AWS Credentials
-#         uses: aws-actions/configure-aws-credentials@v1-node16
-#         with:
-#           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-#           aws-region: ${{ secrets.AWS_REGION }}
-#           role-duration-seconds: 10800
-#       - name: Run tests
-#         run: |
-#           cd build
-#           ulimit -c unlimited -S
-#           timeout --signal=SIGABRT 60m ./tst/producerTest
-#       - name: Code coverage
-#         run: |
-#           cd build
-#           for test_file in $(find CMakeFiles/KinesisVideoProducer.dir gstkvssink.dir KinesisVideoProducerJNI.dir -name '*.gcno'); do gcov $test_file; done
-#           bash <(curl -s https://codecov.io/bash)
+  linux-gcc-code-coverage:
+    runs-on: ubuntu-20.04
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |  
+          sudo apt clean && sudo apt update
+          sudo apt install -y libunwind-dev
+          sudo apt-get install -y libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE -DCMAKE_INSTALL_PREFIX=.
+          make
+          make install
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+      - name: Run tests
+        run: |
+          cd build
+          ulimit -c unlimited -S
+          timeout --signal=SIGABRT 60m ./tst/producerTest
+      - name: Code coverage
+        run: |
+          cd build
+          for test_file in $(find CMakeFiles/KinesisVideoProducer.dir gstkvssink.dir KinesisVideoProducerJNI.dir -name '*.gcno'); do gcov $test_file; done
+          bash <(curl -s https://codecov.io/bash)
   
-#   address-sanitizer:
-#     runs-on: ubuntu-20.04
-#     permissions:
-#       id-token: write
-#       contents: read
-#     env:
-#       CC: clang
-#       CXX: clang++
-#       AWS_KVS_LOG_LEVEL: 2
-#     steps:
-#       - name: Clone repository
-#         uses: actions/checkout@v3
-#       - name: Install dependencies
-#         run: |
-#           sudo apt clean && sudo apt update
-#           sudo apt install -y libunwind-dev
-#           sudo apt-get install -y libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
-#       - name: Build repository
-#         run: |
-#           mkdir build && cd build
-#           cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE -DCMAKE_INSTALL_PREFIX=.
-#           make
-#           make install
-#       - name: Configure AWS Credentials
-#         uses: aws-actions/configure-aws-credentials@v1-node16
-#         with:
-#           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-#           aws-region: ${{ secrets.AWS_REGION }}
-#           role-duration-seconds: 10800
-#       - name: Run tests
-#         run: |
-#           cd build
-#           ulimit -c unlimited -S
-#           timeout --signal=SIGABRT 60m ./tst/producerTest
+  address-sanitizer:
+    runs-on: ubuntu-20.04
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      CC: clang
+      CXX: clang++
+      AWS_KVS_LOG_LEVEL: 2
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt install -y libunwind-dev
+          sudo apt-get install -y libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE -DCMAKE_INSTALL_PREFIX=.
+          make
+          make install
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+      - name: Run tests
+        run: |
+          cd build
+          ulimit -c unlimited -S
+          timeout --signal=SIGABRT 60m ./tst/producerTest
 
-#   undefined-behavior-sanitizer:
-#     runs-on: ubuntu-20.04
-#     permissions:
-#       id-token: write
-#       contents: read
-#     env:
-#       CC: clang
-#       CXX: clang++
-#       AWS_KVS_LOG_LEVEL: 2
-#     steps:
-#       - name: Clone repository
-#         uses: actions/checkout@v3
-#       - name: Install dependencies
-#         run: |
-#           sudo apt clean && sudo apt update
-#           sudo apt install -y libunwind-dev
-#           sudo apt-get install -y libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
-#       - name: Build repository
-#         run: |
-#           mkdir build && cd build
-#           cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE -DCMAKE_INSTALL_PREFIX=.
-#           make
-#           make install
-#       - name: Configure AWS Credentials
-#         uses: aws-actions/configure-aws-credentials@v1-node16
-#         with:
-#           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-#           aws-region: ${{ secrets.AWS_REGION }}
-#           role-duration-seconds: 10800
-#       - name: Run tests
-#         run: |
-#           cd build
-#           ulimit -c unlimited -S
-#           timeout --signal=SIGABRT 60m ./tst/producerTest
+  undefined-behavior-sanitizer:
+    runs-on: ubuntu-20.04
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      CC: clang
+      CXX: clang++
+      AWS_KVS_LOG_LEVEL: 2
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt install -y libunwind-dev
+          sudo apt-get install -y libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE -DCMAKE_INSTALL_PREFIX=.
+          make
+          make install
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+      - name: Run tests
+        run: |
+          cd build
+          ulimit -c unlimited -S
+          timeout --signal=SIGABRT 60m ./tst/producerTest
 
   # memory-sanitizer:
-  #   runs-on: ubuntu-20.04 
+  #   runs-on: ubuntu-20.04
   #   permissions:
   #     id-token: write
   #     contents: read
@@ -243,39 +243,39 @@ jobs:
   #         ulimit -c unlimited -S 
   #         timeout --signal=SIGABRT 20m ./tst/producerTest
   
-  # ubuntu-gcc:
-  #   runs-on: ubuntu-20.04
-  #   env:
-  #     AWS_KVS_LOG_LEVEL: 2
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Install dependencies
-  #       run: |
-  #         sudo apt clean && sudo apt update
-  #         sudo apt install -y libunwind-dev
-  #         sudo apt-get install -y libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
-  #     - name: Build repository
-  #       run: |
-  #         mkdir build && cd build
-  #         cmake .. -DBUILD_TEST=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE -DCMAKE_INSTALL_PREFIX=.
-  #         make
-  #         make install
-  #     - name: Configure AWS Credentials
-  #       uses: aws-actions/configure-aws-credentials@v1-node16
-  #       with:
-  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-  #         aws-region: ${{ secrets.AWS_REGION }}
-  #         role-duration-seconds: 10800
-  #     - name: Run tests
-  #       run: |
-  #         cd build
-  #         ulimit -c unlimited -S
-  #         timeout --signal=SIGABRT 60m ./tst/producerTest
+  ubuntu-gcc:
+    runs-on: ubuntu-20.04
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt install -y libunwind-dev
+          sudo apt-get install -y libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE -DCMAKE_INSTALL_PREFIX=.
+          make
+          make install
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+      - name: Run tests
+        run: |
+          cd build
+          ulimit -c unlimited -S
+          timeout --signal=SIGABRT 60m ./tst/producerTest
   
   windows-msvc:
     runs-on: windows-2022
@@ -309,103 +309,103 @@ jobs:
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin'
           & "D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\build\tst\producerTest.exe" 
 
-  # arm64-cross-compilation:
-  #   runs-on: ubuntu-20.04
-  #   env:
-  #     CC: aarch64-linux-gnu-gcc
-  #     CXX: aarch64-linux-gnu-g++
-  #   steps:
-  #     - name: Install dependencies
-  #       run: |
-  #         sudo apt clean && sudo apt update
-  #         sudo apt install -y libunwind-dev
-  #         sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
-  #         sudo apt-get install libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Build Repository
-  #       run: |
-  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-  #         mkdir build && cd build
-  #         cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic64 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
-  #         make
-  #         make install
-  #         file libKinesisVideoProducer.so
+  arm64-cross-compilation:
+    runs-on: ubuntu-20.04
+    env:
+      CC: aarch64-linux-gnu-gcc
+      CXX: aarch64-linux-gnu-g++
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt install -y libunwind-dev
+          sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
+          sudo apt-get install libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Build Repository
+        run: |
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic64 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
+          make
+          make install
+          file libKinesisVideoProducer.so
 
-  # linux-aarch64-cross-compilation:
-  #   runs-on: ubuntu-20.04
-  #   env:
-  #     CC: aarch64-linux-gnu-gcc
-  #     CXX: aarch64-linux-gnu-g++
-  #   steps:
-  #     - name: Install dependencies
-  #       run: |
-  #         sudo apt clean && sudo apt update
-  #         sudo apt install -y libunwind-dev
-  #         sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
-  #         sudo apt-get install libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Build Repository
-  #       run: |
-  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-  #         mkdir build && cd build
-  #         cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-aarch64 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
-  #         make
-  #         make install
-  #         file libKinesisVideoProducer.so
+  linux-aarch64-cross-compilation:
+    runs-on: ubuntu-20.04
+    env:
+      CC: aarch64-linux-gnu-gcc
+      CXX: aarch64-linux-gnu-g++
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt install -y libunwind-dev
+          sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
+          sudo apt-get install libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Build Repository
+        run: |
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-aarch64 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
+          make
+          make install
+          file libKinesisVideoProducer.so
 
-  # arm32-cross-compilation:
-  #   runs-on: ubuntu-20.04
-  #   env:
-  #     CC: arm-linux-gnueabi-gcc
-  #     CXX: arm-linux-gnueabi-g++
-  #   steps:
-  #     - name: Install dependencies
-  #       run: |
-  #         sudo apt clean && sudo apt update
-  #         sudo apt install -y libunwind-dev
-  #         sudo apt-get -y install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi binutils-arm-linux-gnueabi
-  #         sudo apt-get install libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Build Repository
-  #       run: |
-  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-  #         mkdir build && cd build
-  #         cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic32 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
-  #         make
-  #         make install
-  #         file libKinesisVideoProducer.so
+  arm32-cross-compilation:
+    runs-on: ubuntu-20.04
+    env:
+      CC: arm-linux-gnueabi-gcc
+      CXX: arm-linux-gnueabi-g++
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt install -y libunwind-dev
+          sudo apt-get -y install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi binutils-arm-linux-gnueabi
+          sudo apt-get install libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Build Repository
+        run: |
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic32 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
+          make
+          make install
+          file libKinesisVideoProducer.so
 
-  # linux-build-gcc-static:
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Install dependencies
-  #       run: |
-  #         sudo apt clean && sudo apt update
-  #         sudo apt install -y libunwind-dev
-  #         sudo apt-get install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
-  #     - name: Build repository
-  #       run: |
-  #         mkdir build && cd build
-  #         cmake .. -DBUILD_GSTREAMER_PLUGIN=ON -DBUILD_STATIC=ON
-  #         make
+  linux-build-gcc-static:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt install -y libunwind-dev
+          sudo apt-get install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_GSTREAMER_PLUGIN=ON -DBUILD_STATIC=ON
+          make
 
-  # linux-build-gcc-shared:
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Install dependencies
-  #       run: |
-  #         sudo apt clean && sudo apt update
-  #         sudo apt install -y libunwind-dev
-  #         sudo apt-get install libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
-  #     - name: Build repository
-  #       run: |
-  #         mkdir build && cd build
-  #         cmake .. -DBUILD_DEPENDENCIES=OFF -DBUILD_GSTREAMER_PLUGIN=ON -DBUILD_STATIC=OFF -DBUILD_SHARED_LIBS=ON
-  #         make
+  linux-build-gcc-shared:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt install -y libunwind-dev
+          sudo apt-get install libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_DEPENDENCIES=OFF -DBUILD_GSTREAMER_PLUGIN=ON -DBUILD_STATIC=OFF -DBUILD_SHARED_LIBS=ON
+          make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,7 @@ jobs:
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin'
           git config --system core.longpaths true
+          Dir -Recurse C:\gstreamer\1.0\x86_64\lib\pkgconfig
           $env:PKG_CONFIG_PATH = 'C:\gstreamer\1.0\x86_64\lib\pkgconfig'
           gci env:
           pkg-config --cflags --libs gstreamer-1.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ else()
 endif()
 
 if (WIN32)
-  set(PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\x86_64\\lib\\pkg-config.exe")
+  set(PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\msvc_x86_64\\lib\\pkg-config.exe")
 endif()
 
 ############# Enable Sanitizers ############

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,10 +126,6 @@ else()
   set(Log4cplus ${LOG4CPLUS_LIBRARIES})
 endif()
 
-if (WIN32)
-  set(PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
-endif()
-
 ############# Enable Sanitizers ############
 if(${CMAKE_C_COMPILER_ID} MATCHES "GNU|Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
@@ -212,7 +208,7 @@ endif()
 
 
 if(BUILD_GSTREAMER_PLUGIN)
-  pkg_check_modules(GST_APP REQUIRED gstreamer-1.0)
+  pkg_check_modules(GST_APP REQUIRED gstreamer-app-1.0)
   include_directories(${GST_APP_INCLUDE_DIRS})
   link_directories(${GST_APP_LIBRARY_DIRS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,11 @@ else()
 endif()
 
 if (WIN32)
-  set(PKG_CONFIG_EXECUTABLE "D:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
+  if(EXISTS "C:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
+    set(PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
+  else()
+     set(PKG_CONFIG_EXECUTABLE "D:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
+  endif()
 endif()
 
 ############# Enable Sanitizers ############

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,8 +127,8 @@ else()
 endif()
 
 if (WIN32)
-  set(PKG_CONFIG_PATH "D:\\gstreamer\\1.0\\x86_64\\lib\\pkgconfig")
-  # set(PKG_CONFIG_EXECUTABLE "D:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
+  # set(PKG_CONFIG_PATH "D:\\gstreamer\\1.0\\x86_64\\lib\\pkgconfig")
+  set(PKG_CONFIG_EXECUTABLE "D:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
 endif()
 
 ############# Enable Sanitizers ############

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,11 @@ else()
   set(Log4cplus ${LOG4CPLUS_LIBRARIES})
 endif()
 
+if (WIN32)
+  set(PKG_CONFIG_PATH "D:\\gstreamer\\1.0\\x86_64\\lib\\pkgconfig")
+  set(PKG_CONFIG_PATH "D:\\gstreamer\\1.0\\x86_64\\lib\\pkgconfig")
+  set(PKG_CONFIG_EXECUTABLE "D:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
+endif()
 
 ############# Enable Sanitizers ############
 if(${CMAKE_C_COMPILER_ID} MATCHES "GNU|Clang")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,8 +128,7 @@ endif()
 
 if (WIN32)
   set(PKG_CONFIG_PATH "D:\\gstreamer\\1.0\\x86_64\\lib\\pkgconfig")
-  set(PKG_CONFIG_PATH "D:\\gstreamer\\1.0\\x86_64\\lib\\pkgconfig")
-  set(PKG_CONFIG_EXECUTABLE "D:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
+  # set(PKG_CONFIG_EXECUTABLE "D:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
 endif()
 
 ############# Enable Sanitizers ############

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ else()
 endif()
 
 if (WIN32)
-  set(PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
+  set(PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\x86_64\\lib\\pkg-config")
 endif()
 
 ############# Enable Sanitizers ############

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ else()
 endif()
 
 if (WIN32)
-  set(PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\msvc_x86_64\\lib\\pkg-config")
+  set(PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\x86_64\\lib\\pkg-config.exe")
 endif()
 
 ############# Enable Sanitizers ############

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ else()
 endif()
 
 if (WIN32)
-  set(PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\x86_64\\lib\\pkg-config")
+  set(PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\msvc_x86_64\\lib\\pkg-config")
 endif()
 
 ############# Enable Sanitizers ############

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ else()
 endif()
 
 if (WIN32)
-  set(PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\msvc_x86_64\\lib\\pkg-config.exe")
+  set(PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
 endif()
 
 ############# Enable Sanitizers ############
@@ -212,7 +212,7 @@ endif()
 
 
 if(BUILD_GSTREAMER_PLUGIN)
-  pkg_check_modules(GST_APP REQUIRED gstreamer-app-1.0)
+  pkg_check_modules(GST_APP REQUIRED gstreamer-1.0)
   include_directories(${GST_APP_INCLUDE_DIRS})
   link_directories(${GST_APP_LIBRARY_DIRS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,6 @@ else()
 endif()
 
 if (WIN32)
-  # set(PKG_CONFIG_PATH "D:\\gstreamer\\1.0\\x86_64\\lib\\pkgconfig")
   set(PKG_CONFIG_EXECUTABLE "D:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ else()
   set(Log4cplus ${LOG4CPLUS_LIBRARIES})
 endif()
 
+
 ############# Enable Sanitizers ############
 if(${CMAKE_C_COMPILER_ID} MATCHES "GNU|Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")

--- a/README.md
+++ b/README.md
@@ -205,7 +205,6 @@ By default, the samples run in near realtime mode. To set offline mode, set stre
 `GST_DEBUG_BIN_TO_DOT_FILE(<gst-bin-object>, GST_DEBUG_GRAPH_SHOW_ALL, <file-name>);`
 For example, if the application created a pipeline object `GstPipeline* pipeline = gst_pipeline_new("test-pipeline")`, and you would like to see the visualized pipeline with filename pipeline, add:
 `GST_DEBUG_BIN_TO_DOT_FILE((GstBin*) pipeline, GST_DEBUG_GRAPH_SHOW_ALL, "pipeline");`. Also ensure to set the path to where you would like the file to be stored. `export GST_DEBUG_DUMP_DOT_DIR=.`. The file generated would be a `.dot` format. Convert to PDF to check the visualized pipeline. Also, this requires `graphviz` to be installed. So make sure to install that.
-* On Windows, if you run into a cmake error `A required package was not found` when Checking for module `gstreamer-app-1.0`, try changing the drive partition from 'D:' to 'C:' in following CMakeLists.txt line `set(PKG_CONFIG_EXECUTABLE "D:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")`.
 
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ By default, the samples run in near realtime mode. To set offline mode, set stre
 `GST_DEBUG_BIN_TO_DOT_FILE(<gst-bin-object>, GST_DEBUG_GRAPH_SHOW_ALL, <file-name>);`
 For example, if the application created a pipeline object `GstPipeline* pipeline = gst_pipeline_new("test-pipeline")`, and you would like to see the visualized pipeline with filename pipeline, add:
 `GST_DEBUG_BIN_TO_DOT_FILE((GstBin*) pipeline, GST_DEBUG_GRAPH_SHOW_ALL, "pipeline");`. Also ensure to set the path to where you would like the file to be stored. `export GST_DEBUG_DUMP_DOT_DIR=.`. The file generated would be a `.dot` format. Convert to PDF to check the visualized pipeline. Also, this requires `graphviz` to be installed. So make sure to install that.
+* On Windows, if you run into a cmake error `A required package was not found` when Checking for module `gstreamer-app-1.0`, try changing the drive partition from 'D:' to 'C:' in following CMakeLists.txt line `set(PKG_CONFIG_EXECUTABLE "D:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")`.
 
 
 ## FAQ


### PR DESCRIPTION
### Mac GCC CI Test ###
Changed to using a direct and versioned compiler path - just pointing to "gcc" and "g++" will map to CLANG compiler on Mac.

<br>

### Windows MSVC CI Test ###
Updated PKG_CONFIG_EXECUTABLE to reflect current Chocolatey GSTreamer install path - it is  in D: drive now, not C: drive.

<br>
<br>
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
