### PR TITLE
Fix KVSSINK State Transition Deadlock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   mac-os-build-clang:
-    runs-on: macos-13
+    runs-on: macos-12
     env:
       AWS_KVS_LOG_LEVEL: 2
       CC: /usr/bin/clang

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   mac-os-build-clang:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       AWS_KVS_LOG_LEVEL: 2
       CC: /usr/bin/clang

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -1614,6 +1614,9 @@ gst_kvs_sink_change_state(GstElement *element, GstStateChange transition) {
     }
 
     ret = GST_ELEMENT_CLASS (parent_class)->change_state(element, transition);
+    if (ret == GST_STATE_CHANGE_FAILURE) {
+        goto CleanUp;
+    }
 
     switch (transition) {
         case GST_STATE_CHANGE_PAUSED_TO_READY:

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -1609,6 +1609,13 @@ gst_kvs_sink_change_state(GstElement *element, GstStateChange transition) {
         case GST_STATE_CHANGE_READY_TO_PAUSED:
             gst_collect_pads_start (kvssink->collect);
             break;
+        default:
+            break;
+    }
+
+    ret = GST_ELEMENT_CLASS (parent_class)->change_state(element, transition);
+
+    switch (transition) {
         case GST_STATE_CHANGE_PAUSED_TO_READY:
             LOG_INFO("Stopping kvssink for " << kvssink->stream_name);
             gst_collect_pads_stop (kvssink->collect);
@@ -1630,8 +1637,6 @@ gst_kvs_sink_change_state(GstElement *element, GstStateChange transition) {
         default:
             break;
     }
-
-    ret = GST_ELEMENT_CLASS (parent_class)->change_state(element, transition);
 
 CleanUp:
 


### PR DESCRIPTION
Move parent state transition to be in between upward and downward element transitions as per [GStreamer documentation](https://gstreamer.freedesktop.org/documentation/plugin-development/basics/states.html?gi-language=c#:~:text=Note%20that%20upwards,destroying%20allocated%20resources.).

Tested using `kvssink_gstreamer_sample` to successfully ingest stream and cleanly exit upon sigint with videotestsrc, filesrc, and rtspsrc sources.


<br>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
