### PR TITLE
[PR #721] Install some files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,9 @@ include(Utilities)
 project(KinesisVideoProducerCpp)
 
 project(KinesisVideoProducerCpp VERSION 3.4.0)
-include(GNUInstallDirs)
 
 set(CMAKE_CXX_STANDARD 11)
+include(GNUInstallDirs)
 
 # User Flags
 option(BUILD_GSTREAMER_PLUGIN "Build kvssink GStreamer plugin" OFF)
@@ -216,6 +216,7 @@ install(
 if(BUILD_JNI)
   find_package(JNI REQUIRED)
   include_directories(${JNI_INCLUDE_DIRS})
+  
   install(
     DIRECTORY ${KINESIS_VIDEO_PRODUCER_CPP_SRC}/src/JNI/include
     DESTINATION .)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/pull/721

Tested this locally:
```
niyatim@88665a374cf5 test-to-path % tree
.
├── include
│   └── com
│       └── amazonaws
│           └── kinesis
│               └── video
│                   └── producer
│                       └── jni
│                           ├── JNICommon.h
│                           ├── KinesisVideoClientWrapper.h
│                           ├── Parameters.h
│                           ├── SyncMutex.h
│                           ├── TimedSemaphore.h
│                           └── com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni.h
├── lib
│   ├── libKinesisVideoProducer.dylib
│   ├── libKinesisVideoProducerJNI.dylib
│   ├── libcproducer.1.5.1.dylib
│   ├── libcproducer.1.dylib -> libcproducer.1.5.1.dylib
│   ├── libcproducer.dylib -> libcproducer.1.dylib
│   └── libgstkvssink.so
└── src
    ├── Auth.cpp
    ├── Auth.h
    ├── CMakeLists.txt
    ├── CachingEndpointOnlyCallbackProvider.cpp
    ├── CachingEndpointOnlyCallbackProvider.h
    ├── CallbackProvider.cpp
    ├── CallbackProvider.h
    ├── ClientCallbackProvider.h
    ├── DefaultCallbackProvider.cpp
    ├── DefaultCallbackProvider.h
    ├── DefaultDeviceInfoProvider.cpp
    ├── DefaultDeviceInfoProvider.h
    ├── DeviceInfoProvider.h
    ├── GetTime.cpp
    ├── GetTime.h
    ├── JNI
    │   ├── com
    │   │   └── amazonaws
    │   │       └── kinesis
    │   │           └── video
    │   │               └── producer
    │   │                   └── jni
    │   │                       ├── KinesisVideoClientWrapper.cpp
    │   │                       ├── NativeProducerInterface.cpp
    │   │                       └── Parameters.cpp
    │   └── include
    │       └── com
    │           └── amazonaws
    │               └── kinesis
    │                   └── video
    │                       └── producer
    │                           └── jni
    │                               ├── JNICommon.h
    │                               ├── KinesisVideoClientWrapper.h
    │                               ├── Parameters.h
    │                               ├── SyncMutex.h
    │                               ├── TimedSemaphore.h
    │                               └── com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni.h
    ├── KinesisVideoProducer.cpp
    ├── KinesisVideoProducer.h
    ├── KinesisVideoProducerMetrics.h
    ├── KinesisVideoStream.cpp
    ├── KinesisVideoStream.h
    ├── KinesisVideoStreamMetrics.h
    ├── Logger.h
    ├── StreamCallbackProvider.h
    ├── StreamDefinition.cpp
    ├── StreamDefinition.h
    ├── StreamTags.cpp
    ├── StreamTags.h
    ├── ThreadSafeMap.h
    ├── common
    │   ├── PutFrameHelper.cpp
    │   └── PutFrameHelper.h
    ├── credential-providers
    │   ├── IotCertCredentialProvider.cpp
    │   ├── IotCertCredentialProvider.h
    │   ├── RotatingCredentialProvider.cpp
    │   └── RotatingCredentialProvider.h
    └── gstreamer
        ├── KvsSinkClientCallbackProvider.cpp
        ├── KvsSinkClientCallbackProvider.h
        ├── KvsSinkDeviceInfoProvider.cpp
        ├── KvsSinkDeviceInfoProvider.h
        ├── KvsSinkStreamCallbackProvider.cpp
        ├── KvsSinkStreamCallbackProvider.h
        ├── Util
        │   ├── KvsSinkUtil.cpp
        │   └── KvsSinkUtil.h
        ├── gstkvssink.cpp
        └── gstkvssink.h

28 directories, 65 files
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
