### PR TITLE
Ensure region for kvssink is set either through env or property

### DIFF
--- a/CMake/Dependencies/liblog4cplus-CMakeLists.txt
+++ b/CMake/Dependencies/liblog4cplus-CMakeLists.txt
@@ -28,7 +28,7 @@ include(ExternalProject)
 if (WIN32)
   ExternalProject_Add(project_log4cplus
       GIT_REPOSITORY    https://github.com/log4cplus/log4cplus
-      GIT_TAG           REL_2_0_6
+      GIT_TAG           REL_2_0_1
       PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
       TEST_COMMAND      ""
       CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX} -DLOG4CPLUS_BUILD_TESTING=0 -DLOG4CPLUS_BUILD_LOGGINGSERVER=0 -DUNICODE=0 -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
@@ -36,7 +36,7 @@ if (WIN32)
 else()
   ExternalProject_Add(project_log4cplus
        GIT_REPOSITORY    https://github.com/log4cplus/log4cplus
-       GIT_TAG           REL_2_0_6
+       GIT_TAG           REL_2_0_1
        PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
        CONFIGURE_COMMAND ${CONFIGURE_COMMAND}
        BUILD_COMMAND     ${MAKE_EXE}

--- a/CMake/Dependencies/liblog4cplus-CMakeLists.txt
+++ b/CMake/Dependencies/liblog4cplus-CMakeLists.txt
@@ -28,7 +28,7 @@ include(ExternalProject)
 if (WIN32)
   ExternalProject_Add(project_log4cplus
       GIT_REPOSITORY    https://github.com/log4cplus/log4cplus
-      GIT_TAG           REL_2_0_1
+      GIT_TAG           REL_2_0_6
       PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
       TEST_COMMAND      ""
       CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX} -DLOG4CPLUS_BUILD_TESTING=0 -DLOG4CPLUS_BUILD_LOGGINGSERVER=0 -DUNICODE=0 -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
@@ -36,7 +36,7 @@ if (WIN32)
 else()
   ExternalProject_Add(project_log4cplus
        GIT_REPOSITORY    https://github.com/log4cplus/log4cplus
-       GIT_TAG           REL_2_0_1
+       GIT_TAG           REL_2_0_6
        PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
        CONFIGURE_COMMAND ${CONFIGURE_COMMAND}
        BUILD_COMMAND     ${MAKE_EXE}

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -12,7 +12,15 @@ Define AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables with th
 export AWS_ACCESS_KEY_ID=YourAccessKeyId
 export AWS_SECRET_ACCESS_KEY=YourSecretAccessKey
 ```
-optionally, set `AWS_SESSION_TOKEN` if integrating with temporary token and `AWS_DEFAULT_REGION` for the region other than `us-west-2`
+optionally, set `AWS_SESSION_TOKEN` if integrating with temporary token.
+
+#### Setting region
+
+If using kvssink, the region can be set in 2 ways:
+1. Set `AWS_DEFAULT_REGION` to the desired region, or,
+2. Set the `aws-region` property.
+
+If `aws-region` and `AWS_DEFAULT_REGION` are set, the `aws-region` property would be used instead of the env.
 
 ###### Discovering audio and video devices available in your system.
 Run the `gst-device-monitor-1.0` command to identify available media devices in your system. An example output as follows:

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -6,7 +6,14 @@ Define AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables with th
 export AWS_ACCESS_KEY_ID=YourAccessKeyId
 export AWS_SECRET_ACCESS_KEY=YourSecretAccessKey
 ```
-optionally, set `AWS_SESSION_TOKEN` if integrating with temporary token and `AWS_DEFAULT_REGION` for the region other than `us-west-2`
+
+#### Setting region
+
+If using kvssink, the region can be set in 2 ways:
+1. Set `AWS_DEFAULT_REGION` to the desired region, or,
+2. Set the `aws-region` property.
+
+If `aws-region` and `AWS_DEFAULT_REGION` are set, the `aws-region` property would be used instead of the env.
 
 ###### Discovering available devices.
 Run the `gst-device-monitor-1.0` command to identify available media devices in your system. An example output as follows:
@@ -139,7 +146,7 @@ gst-launch-1.0 -v  souphttpsrc location="https://.../playlist.m3u8" ! hlsdemux n
 Change your current working directory to `build`. Launch the sample application with a stream name and a path to the file and it will start streaming.
 
 ```
-AWS_ACCESS_KEY_ID=YourAccessKeyId AWS_SECRET_ACCESS_KEY=YourSecretAccessKey ./kvs_gstreamer_audio_video_sample <my-stream> </path/to/file>
+AWS_ACCESS_KEY_ID=YourAccessKeyId AWS_SECRET_ACCESS_KEY=YourSecretAccessKey AWS_DEFAULT_REGION=YourRegion ./kvs_gstreamer_audio_video_sample <my-stream> </path/to/file>
 ```
 
 ##### Running the GStreamer sample application to stream audio and video from live source

--- a/docs/raspberry-pi.md
+++ b/docs/raspberry-pi.md
@@ -31,7 +31,14 @@ Define AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables with th
 export AWS_ACCESS_KEY_ID=YourAccessKeyId
 export AWS_SECRET_ACCESS_KEY=YourSecretAccessKey
 ```
-optionally, set `AWS_SESSION_TOKEN` if integrating with temporary token and `AWS_DEFAULT_REGION` for the region other than `us-west-2`
+
+#### Setting region
+
+If using kvssink, the region can be set in 2 ways:
+1. Set `AWS_DEFAULT_REGION` to the desired region, or,
+2. Set the `aws-region` property.
+
+If `aws-region` and `AWS_DEFAULT_REGION` are set, the `aws-region` property would be used instead of the env.
 
 ##### Set GST_PLUGIN_PATH in environment variables
 ```

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -53,6 +53,7 @@ Device found:
                 wasapi.device.description = "Speakers\ \(Conexant\ ISST\ Audio\)"
 ```
 
+
 Start sample application to send video stream to KVS using gstreamer plugin by executing the following command:
 
 1.  Before running the demo applications, set the environment by following the instructions below.
@@ -116,6 +117,12 @@ gst-launch-1.0 -v  filesrc location="YourAudioVideo.ts" ! tsdemux name=demux ! q
       set AWS_ACCESS_KEY_ID=YourAccessKeyId
       set AWS_SECRET_ACCESS_KEY=YourSecretAccessKey
       ```
+
+     *  If using kvssink, the region can be set in 2 ways:
+        1. Set `AWS_DEFAULT_REGION` to the desired region, or,
+        2. Set the `aws-region` property.
+
+        If `aws-region` and `AWS_DEFAULT_REGION` are set, the `aws-region` property would be used instead of the env.
 
       * Run the demo
           * **Example**:

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -318,9 +318,9 @@ void kinesis_video_producer_init(GstKvsSink *kvssink)
         session_token_str = string(kvssink->session_token);
     }
 
-    if(IS_EMPTY_STRING(kvssink->aws_region)) {
+    if (IS_EMPTY_STRING(kvssink->aws_region)) {
         if (nullptr == (default_region = getenv(DEFAULT_REGION_ENV_VAR))) {
-            LOG_AND_THROW("No region set. Either set with env AWS_DEFAULT_REGION or set kvssink property aws-region");
+            LOG_AND_THROW("No region set. Either set with env " << DEFAULT_REGION_ENV_VAR << " or set kvssink property aws-region");
         } else {
             region_str = string(default_region);
         }

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -105,7 +105,7 @@ GST_DEBUG_CATEGORY_STATIC (gst_kvs_sink_debug);
 #define DEFAULT_ACCESS_KEY "access_key"
 #define DEFAULT_SECRET_KEY "secret_key"
 #define DEFAULT_SESSION_TOKEN "session_token"
-#define DEFAULT_REGION "us-west-2"
+#define DEFAULT_REGION ""
 #define DEFAULT_ROTATION_PERIOD_SECONDS 3600
 #define DEFAULT_LOG_FILE_PATH "../kvs_log_configuration"
 #define DEFAULT_STORAGE_SIZE_MB 128
@@ -318,12 +318,15 @@ void kinesis_video_producer_init(GstKvsSink *kvssink)
         session_token_str = string(kvssink->session_token);
     }
 
-    if (nullptr == (default_region = getenv(DEFAULT_REGION_ENV_VAR))) {
-        region_str = string(kvssink->aws_region);
+    if(IS_EMPTY_STRING(kvssink->aws_region)) {
+        if (nullptr == (default_region = getenv(DEFAULT_REGION_ENV_VAR))) {
+            LOG_AND_THROW("No region set. Either set with env AWS_DEFAULT_REGION or set kvssink property aws-region");
+        } else {
+            region_str = string(default_region);
+        }
     } else {
-        region_str = string(default_region); // Use env var if both property and env var are available.
+        region_str = string(kvssink->aws_region);
     }
-
     unique_ptr<CredentialProvider> credential_provider;
 
     if (kvssink->iot_certificate) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Before this change, the SDK set the default region to us-west-2. Because of this, if the env is set and the property is set, we would pick the env value, which is not correct. We should not override the property value set in the pipeline and check for env only if the property is not exclusively set to a value. To ensure this, the PR changes the default value to an empty string and enforces a region setting instead of defaulting to us-west-2. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
