### PR TITLE
Bump GStreamer Version in Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,8 +322,8 @@ jobs:
       - name: Install dependencies
         run: |
           choco install nasm strawberryperl
-          choco install gstreamer --version=1.16.3
-          choco install gstreamer-devel --version=1.16.3
+          choco install gstreamer
+          choco install gstreamer-devel
       - name: Build repository
         run: |
           $env:Path += ";C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;C:\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;C:\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,8 +322,8 @@ jobs:
       - name: Install dependencies
         run: |
           choco install nasm strawberryperl
-          choco install gstreamer
-          choco install gstreamer-devel
+          choco install gstreamer --version=1.22.8
+          choco install gstreamer-devel --version=1.22.8
       - name: Build repository
         run: |
           $env:Path += ";C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;C:\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;C:\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,8 +322,8 @@ jobs:
       - name: Install dependencies
         run: |
           choco install nasm strawberryperl
-          choco install gstreamer --version=1.16.2
-          choco install gstreamer-devel --version=1.16.2
+          choco install gstreamer --version=1.16.3
+          choco install gstreamer-devel --version=1.16.3
       - name: Build repository
         run: |
           $env:Path += ";C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;C:\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\lib;C:\amazon-kinesis-video-streams-producer-sdk-cpp\open-source\local\bin"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,10 +123,10 @@ message("LOG4CPLUS_INCLUDE_DIR is ${LOG4CPLUS_INCLUDE_DIR}")
 message("LOG4CPLUS_LIBRARIES is ${LOG4CPLUS_LIBRARIES}")
 
 if (WIN32)
-  if(EXISTS "C:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
-    set(PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
+  if(EXISTS "C:\\gstreamer\\1.0\\msvc_x86_64\\bin\\pkg-config.exe")
+    set(PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\msvc_x86_64\\bin\\pkg-config.exe")
   else()
-    set(PKG_CONFIG_EXECUTABLE "D:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
+    set(PKG_CONFIG_EXECUTABLE "D:\\gstreamer\\1.0\\msvc_x86_64\\bin\\pkg-config.exe")
   endif()
 endif()
 


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Updated GStreamer version installed on Windows CI runner from 1.16.2 to the latest 1.22.8
- Updated pkg-config.exe path as there is a folder name change in between the GStreamer versions

*Why was it changed?*
- The 1.16.2 version is now missing from their site: https://gstreamer.freedesktop.org/data/pkg/windows/
- 1.16.3 is present, and the base package successfully downloaded, but not the gstreamer-devel package. The latest version 1.22.8, however, is working.

*How was it changed?*
- Changed the version number is the CI install step
- Modified the path of where to find pkg-config for Windows in the CMakeLists

*What testing was done for the changes?*
- The CI was run to verify all are passing

<br>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
