### PR TITLE
No longer require building kvssink to build samples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DCMAKE_INSTALL_PREFIX=.
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_SAMPLES=FALSE -DCOMPILER_WARNINGS=TRUE -DCMAKE_INSTALL_PREFIX=.
           make
           make install
       - name: Configure AWS Credentials
@@ -60,7 +60,7 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
-          sh -c 'cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DCMAKE_INSTALL_PREFIX=. -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++;cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DCMAKE_INSTALL_PREFIX=. -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++'
+          sh -c 'cmake .. -DBUILD_TEST=TRUE -DBUILD_SAMPLES=FALSE -DCOMPILER_WARNINGS=TRUE -DCMAKE_INSTALL_PREFIX=. -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++;cmake .. -DBUILD_TEST=TRUE -DBUILD_SAMPLES=FALSE -DCOMPILER_WARNINGS=TRUE -DCMAKE_INSTALL_PREFIX=. -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++'
           make install
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
@@ -92,7 +92,7 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DCMAKE_INSTALL_PREFIX=.
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_SAMPLES=FALSE -DCMAKE_INSTALL_PREFIX=.
           make
           make install
       - name: Configure AWS Credentials
@@ -239,7 +239,7 @@ jobs:
   #     - name: Build repository
   #       run: |
   #         mkdir build && cd build
-  #         cmake .. -DBUILD_TEST=TRUE -DMEMORY_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
+  #         cmake .. -DBUILD_TEST=TRUE -DBUILD_SAMPLES=FALSE -DMEMORY_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
   #         make
   #         ulimit -c unlimited -S
   #         timeout --signal=SIGABRT 150m ./tst/producerTest --gtest_break_on_failure
@@ -359,7 +359,7 @@ jobs:
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic64 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_SAMPLES=FALSE -DBUILD_OPENSSL_PLATFORM=linux-generic64 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
           make
           make install
           file libKinesisVideoProducer.so
@@ -382,7 +382,7 @@ jobs:
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-aarch64 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_SAMPLES=FALSE -DBUILD_OPENSSL_PLATFORM=linux-aarch64 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
           make
           make install
           file libKinesisVideoProducer.so
@@ -405,7 +405,7 @@ jobs:
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic32 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_SAMPLES=FALSE -DBUILD_OPENSSL_PLATFORM=linux-generic32 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
           make
           make install
           file libKinesisVideoProducer.so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,12 +247,13 @@ if(BUILD_GSTREAMER_PLUGIN)
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
-    
 endif()
 
 if(BUILD_SAMPLES)
-  add_executable(kvssink_gstreamer_sample samples/kvssink_gstreamer_sample.cpp)
-  target_link_libraries(kvssink_gstreamer_sample ${LOG4CPLUS_LIBRARIES} ${GST_APP_LIBRARIES} kvspic)
+  if(BUILD_GSTREAMER_PLUGIN)
+    add_executable(kvssink_gstreamer_sample samples/kvssink_gstreamer_sample.cpp)
+    target_link_libraries(kvssink_gstreamer_sample ${LOG4CPLUS_LIBRARIES} ${GST_APP_LIBRARIES} kvspic)
+  endif()
 
   add_executable(kvs_gstreamer_sample samples/kvs_gstreamer_sample.cpp)
   target_link_libraries(kvs_gstreamer_sample ${LOG4CPLUS_LIBRARIES} ${GST_APP_LIBRARIES} KinesisVideoProducer kvspic)
@@ -265,15 +266,6 @@ if(BUILD_SAMPLES)
 
   add_executable(kvs_gstreamer_file_uploader_sample samples/kvs_gstreamer_file_uploader_sample.cpp)
   target_link_libraries(kvs_gstreamer_file_uploader_sample ${LOG4CPLUS_LIBRARIES} ${GST_APP_LIBRARIES})
-
-  if(BUILD_GSTREAMER_PLUGIN)
-    if(BUILD_STATIC)
-      add_library(gstkvssink STATIC ${GST_PLUGIN_SOURCE_FILES})
-    else()
-      add_library(gstkvssink MODULE ${GST_PLUGIN_SOURCE_FILES})
-    endif()
-    target_link_libraries(gstkvssink PRIVATE ${LOG4CPLUS_LIBRARIES} ${GST_APP_LIBRARIES} KinesisVideoProducer)
-  endif()  
 endif()
 
 if(BUILD_TEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(KINESIS_VIDEO_PRODUCER_CPP_VERSION ${KINESIS_VIDEO_PRODUCER_CPP_MAJOR_VERSIO
 
 # User Flags
 option(BUILD_GSTREAMER_PLUGIN "Build kvssink GStreamer plugin" OFF)
-optoin(BUILD_SAMPLES "Whether to build the samples" ON)
+option(BUILD_SAMPLES "Whether to build the samples" ON)
 option(BUILD_JNI "Build C++ wrapper for JNI to expose the functionality to Java/Android" OFF)
 option(BUILD_STATIC "Build with static linkage" OFF)
 option(ADD_MUCLIBC "Add -muclibc c flag" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,7 @@ if(BUILD_GSTREAMER_PLUGIN)
   include_directories(${GST_APP_INCLUDE_DIRS})
   link_directories(${GST_APP_LIBRARY_DIRS})
   include_directories(${OPEN_SRC_INSTALL_PREFIX}/include)
-  
+
   if(BUILD_STATIC)
     add_library(gstkvssink STATIC ${GST_PLUGIN_SOURCE_FILES})
   else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(KINESIS_VIDEO_PRODUCER_CPP_VERSION ${KINESIS_VIDEO_PRODUCER_CPP_MAJOR_VERSIO
 
 # User Flags
 option(BUILD_GSTREAMER_PLUGIN "Build kvssink GStreamer plugin" OFF)
+optoin(BUILD_SAMPLES "Whether to build the samples" ON)
 option(BUILD_JNI "Build C++ wrapper for JNI to expose the functionality to Java/Android" OFF)
 option(BUILD_STATIC "Build with static linkage" OFF)
 option(ADD_MUCLIBC "Add -muclibc c flag" OFF)
@@ -228,13 +229,12 @@ if(BUILD_JNI)
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 endif()
 
-
 if(BUILD_GSTREAMER_PLUGIN)
   pkg_check_modules(GST_APP REQUIRED gstreamer-app-1.0)
   include_directories(${GST_APP_INCLUDE_DIRS})
   link_directories(${GST_APP_LIBRARY_DIRS})
   include_directories(${OPEN_SRC_INSTALL_PREFIX}/include)
-
+  
   if(BUILD_STATIC)
     add_library(gstkvssink STATIC ${GST_PLUGIN_SOURCE_FILES})
   else()
@@ -242,6 +242,15 @@ if(BUILD_GSTREAMER_PLUGIN)
   endif()
   target_link_libraries(gstkvssink PRIVATE ${LOG4CPLUS_LIBRARIES} ${GST_APP_LIBRARIES} KinesisVideoProducer)
 
+  install(
+    TARGETS gstkvssink
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+    
+endif()
+
+if(BUILD_SAMPLES)
   add_executable(kvssink_gstreamer_sample samples/kvssink_gstreamer_sample.cpp)
   target_link_libraries(kvssink_gstreamer_sample ${LOG4CPLUS_LIBRARIES} ${GST_APP_LIBRARIES} kvspic)
 
@@ -257,12 +266,14 @@ if(BUILD_GSTREAMER_PLUGIN)
   add_executable(kvs_gstreamer_file_uploader_sample samples/kvs_gstreamer_file_uploader_sample.cpp)
   target_link_libraries(kvs_gstreamer_file_uploader_sample ${LOG4CPLUS_LIBRARIES} ${GST_APP_LIBRARIES})
 
-  install(
-    TARGETS gstkvssink
-    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
-  
+  if(BUILD_GSTREAMER_PLUGIN)
+    if(BUILD_STATIC)
+      add_library(gstkvssink STATIC ${GST_PLUGIN_SOURCE_FILES})
+    else()
+      add_library(gstkvssink MODULE ${GST_PLUGIN_SOURCE_FILES})
+    endif()
+    target_link_libraries(gstkvssink PRIVATE ${LOG4CPLUS_LIBRARIES} ${GST_APP_LIBRARIES} KinesisVideoProducer)
+  endif()  
 endif()
 
 if(BUILD_TEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,12 +229,16 @@ if(BUILD_JNI)
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 endif()
 
-if(BUILD_GSTREAMER_PLUGIN)
+if(BUILD_GSTREAMER_PLUGIN OR BUILD_SAMPLES)
+  # Find GStreamer.
   pkg_check_modules(GST_APP REQUIRED gstreamer-app-1.0)
   include_directories(${GST_APP_INCLUDE_DIRS})
   link_directories(${GST_APP_LIBRARY_DIRS})
   include_directories(${OPEN_SRC_INSTALL_PREFIX}/include)
+endif()
 
+if(BUILD_GSTREAMER_PLUGIN)
+  # Build kvssink.
   if(BUILD_STATIC)
     add_library(gstkvssink STATIC ${GST_PLUGIN_SOURCE_FILES})
   else()


### PR DESCRIPTION
*What was changed?*
BUILD_GSTREAMER_PLUGIN is no longer required to be ON for non-kvssink samples to be built. Added new flag BUILD_SAMPLES which defaults to ON to control the building of samples.

NOTE: GStreamer installation is still required for all samples.

*Why was it changed?*
To allow for the building of non-kvssink samples without the need for building kvssink.

*How was it changed?*
By removing the sample targets from the BUILD_GSTREAMER_PLUGIN conditional and adding the to a BUILD_SAMPLES conditional.

*What testing was done for the changes?*
The CI will pass, and testing will be done locally on Mac.

<br> 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
