### PR TITLE
Fix un-initialized JNI ClientInfo members 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,7 @@ jobs:
           Move-Item -Path "D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\*" -Destination "C:\amazon-kinesis-video-streams-producer-sdk-cpp"
       - name: Install dependencies
         run: |
+          choco install pkgconfiglite
           choco install nasm strawberryperl
           choco install gstreamer --version=1.22.8
           choco install gstreamer-devel --version=1.22.8

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,5 @@ open-source/
 outputs
 tags
 dependency
-
 .vs
+.vscode/

--- a/src/JNI/com/amazonaws/kinesis/video/producer/jni/KinesisVideoClientWrapper.cpp
+++ b/src/JNI/com/amazonaws/kinesis/video/producer/jni/KinesisVideoClientWrapper.cpp
@@ -1013,6 +1013,9 @@ BOOL KinesisVideoClientWrapper::setCallbacks(JNIEnv* env, jobject thiz)
     mClientCallbacks.clientShutdownFn = NULL;
     mClientCallbacks.streamShutdownFn = NULL;
 
+    // TODO: Currently we set the shutdown callbacks to NULL.
+    // We need to expose these in the near future
+
     // Extract the method IDs for the callbacks and set a global reference
     jclass thizCls = env->GetObjectClass(thiz);
     if (thizCls == NULL) {

--- a/src/JNI/com/amazonaws/kinesis/video/producer/jni/KinesisVideoClientWrapper.cpp
+++ b/src/JNI/com/amazonaws/kinesis/video/producer/jni/KinesisVideoClientWrapper.cpp
@@ -25,6 +25,9 @@ KinesisVideoClientWrapper::KinesisVideoClientWrapper(JNIEnv* env,
         CHECK_EXT(FALSE, "Couldn't retrieve the JavaVM reference.");
     }
 
+    // Null-initialize the clientInfo struct
+    MEMSET(&mDeviceInfo.clientInfo, 0, sizeof(mDeviceInfo.clientInfo));
+
     // Set the callbacks
     if (!setCallbacks(env, thiz)) {
         throwNativeException(env, EXCEPTION_NAME, "Failed to set the callbacks.", STATUS_INVALID_ARG);

--- a/src/JNI/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
+++ b/src/JNI/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
@@ -158,6 +158,7 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
     STATUS retStatus = STATUS_SUCCESS;
     jmethodID methodId = NULL;
     const char *retChars;
+    jobject kvsRetryStrategyCallbacks = NULL;
 
     CHECK(env != NULL && clientInfo != NULL && pClientInfo != NULL);
 
@@ -256,7 +257,6 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
         CHK_JVM_EXCEPTION(env);
     }
     
-    jobject kvsRetryStrategyCallbacks = NULL;
     methodId = env->GetMethodID(cls, "getKvsRetryStrategyCallbacks", "()Lcom/amazonaws/kinesisvideo/producer/KvsRetryStrategyCallbacks;");
     if (methodId == NULL) {
         DLOGW("Couldn't find method id getKvsRetryStrategyCallbacks");
@@ -281,16 +281,16 @@ VOID setKvsRetryStrategyCallbacks(JNIEnv *env, jobject kvsRetryStrategyCallbacks
         goto CleanUp;
     }
 
-    jclass cls = env->GetObjectClass(kvsRetryStrategyCallbacks);
+    cls = env->GetObjectClass(kvsRetryStrategyCallbacks);
     if (cls == NULL) {
         DLOGW("Failed to create Java kvsRetryStrategyCallbacks class.");
         nullSetCallbacks = TRUE;
         goto CleanUp;
     }
 
-.   /* *** */
+    /* *** */
     /* NOTE: All kvsRetryStrategyCallbacks must be set to NULL in order for PIC to set them to the default callbacks.*/
-.   /* *** */
+    /* *** */
 
     methodId = env->GetMethodID(cls, "createRetryStrategyFn", "(Lcom/amazonaws/kinesisvideo/producer/KvsRetryStrategyCallbacks;)V");
     if (methodId == NULL) {

--- a/src/JNI/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
+++ b/src/JNI/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
@@ -256,7 +256,7 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
         DLOGW("Couldn't find method id getMetricLoggingPeriod");
         pClientInfo->metricLoggingPeriod = 0;
     } else {
-        pClientInfo->metricLoggingPeriod = (jobject) env->CallObjectMethod(clientInfo, methodId);
+        pClientInfo->metricLoggingPeriod = env->CallLongMethod(clientInfo, methodId);
         CHK_JVM_EXCEPTION(env);
     }
 
@@ -265,7 +265,7 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
         DLOGW("Couldn't find method id getReservedCallbackPeriod");
         pClientInfo->reservedCallbackPeriod = 0;
     } else {
-        pClientInfo->reservedCallbackPeriod = (jobject) env->CallObjectMethod(clientInfo, methodId);
+        pClientInfo->reservedCallbackPeriod = env->CallLongMethod(clientInfo, methodId);
         CHK_JVM_EXCEPTION(env);
     }
 

--- a/src/JNI/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
+++ b/src/JNI/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
@@ -291,7 +291,7 @@ CleanUp:
     return STATUS_FAILED(retStatus) ? FALSE : TRUE;
 }
 
-VOID setKvsRetryStrategy(JNIEnv *env, jobject kvsRetryStrategyCallbacks, PKvsRetryStrategy pKvsRetryStrategy)
+VOID setKvsRetryStrategy(JNIEnv *env, jobject kvsRetryStrategy, PKvsRetryStrategy pKvsRetryStrategy)
 {
     jmethodID methodId = NULL;
     jclass cls = NULL;
@@ -312,7 +312,7 @@ VOID setKvsRetryStrategy(JNIEnv *env, jobject kvsRetryStrategyCallbacks, PKvsRet
     methodId = env->GetMethodID(cls, "getRetryStrategy", "()Lcom/amazonaws/kinesisvideo/producer/RetryStrategy");
     if (methodId == NULL) {
         DLOGW("Couldn't find method id getRetryStrategy, setting pRetryStrategy to null.");
-        pkvsRetryStrategy->pRetryStrategy = NULL;
+        pKvsRetryStrategy->pRetryStrategy = NULL;
     } else {
         // Set to Java class or member once we implement Java support.
     }
@@ -320,7 +320,7 @@ VOID setKvsRetryStrategy(JNIEnv *env, jobject kvsRetryStrategyCallbacks, PKvsRet
     methodId = env->GetMethodID(cls, "getRetryStrategyConfig", "()Lcom/amazonaws/kinesisvideo/producer/RetryStrategyConfig");
     if (methodId == NULL) {
         DLOGW("Couldn't find method id getRetryStrategyConfig, setting pRetryStrategyConfig to null.");
-        pkvsRetryStrategy->pRetryStrategyConfig = NULL;
+        pKvsRetryStrategy->pRetryStrategyConfig = NULL;
     } else {
         // Set to Java class or member once we implement Java support.
     }
@@ -328,7 +328,7 @@ VOID setKvsRetryStrategy(JNIEnv *env, jobject kvsRetryStrategyCallbacks, PKvsRet
     methodId = env->GetMethodID(cls, "getretryStrategyType", "()Lcom/amazonaws/kinesisvideo/producer/RetryStrategyType");
     if (methodId == NULL) {
         DLOGW("Couldn't find method id getretryStrategyType, setting retryStrategyType to EXPONENTIAL_BACKOFF_WAIT.");
-        pkvsRetryStrategy->pRetryStrategy = KVS_RETRY_STRATEGY_EXPONENTIAL_BACKOFF_WAIT;
+        pKvsRetryStrategy->pRetryStrategy = NULL;
     } else {
         // Set to Java class or member once we implement Java support.
     }
@@ -337,9 +337,9 @@ VOID setKvsRetryStrategy(JNIEnv *env, jobject kvsRetryStrategyCallbacks, PKvsRet
 CleanUp:
     if (nullKvsRetryStrategy) {
         DLOGI("Setting kvsRetryStrategy members to NULL/default values.");
-        pkvsRetryStrategy->pRetryStrategy = NULL;
-        pkvsRetryStrategy->pRetryStrategyConfig = NULL;
-        pkvsRetryStrategy->pRetryStrategy = KVS_RETRY_STRATEGY_EXPONENTIAL_BACKOFF_WAIT;
+        pKvsRetryStrategy->pRetryStrategy = NULL;
+        pKvsRetryStrategy->pRetryStrategyConfig = NULL;
+        pKvsRetryStrategy->pRetryStrategy = NULL;
     }
 }
 

--- a/src/JNI/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
+++ b/src/JNI/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
@@ -312,7 +312,6 @@ BOOL setKvsRetryStrategy(JNIEnv *env, jobject kvsRetryStrategy, PKvsRetryStrateg
         CHK_JVM_EXCEPTION(env);
     }
 
-    // TODO: Test with logs that this is getting the value from Java, play around with the value.
     methodId = env->GetMethodID(cls, "getRetryStrategyType", "()I");
     if (methodId == NULL) {
         DLOGW("Couldn't find method id getRetryStrategyType, setting retryStrategyType to EXPONENTIAL_BACKOFF_WAIT.");

--- a/src/JNI/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
+++ b/src/JNI/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
@@ -172,7 +172,6 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
     pClientInfo->kvsRetryStrategyCallbacks.freeRetryStrategyFn = NULL;
     pClientInfo->kvsRetryStrategyCallbacks.executeRetryStrategyFn = NULL;
 
-
     // Load ClientInfo
     jclass cls = env->GetObjectClass(clientInfo);
     if (cls == NULL) {

--- a/src/JNI/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
+++ b/src/JNI/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
@@ -316,7 +316,7 @@ VOID setKvsRetryStrategy(JNIEnv *env, jobject kvsRetryStrategy, PKvsRetryStrateg
         DLOGW("Couldn't find method id getRetryStrategy, setting pRetryStrategy to null.");
         pKvsRetryStrategy->pRetryStrategy = NULL;
     } else {
-        // Set to Java class or member once we implement Java support.
+        pKvsRetryStrategy->pRetryStrategy = env->CallLongMethod(kvsRetryStrategy, methodId);
     }
     
     methodId = env->GetMethodID(cls, "getRetryStrategyConfig", "()Lcom/amazonaws/kinesisvideo/producer/RetryStrategyConfig");
@@ -324,7 +324,7 @@ VOID setKvsRetryStrategy(JNIEnv *env, jobject kvsRetryStrategy, PKvsRetryStrateg
         DLOGW("Couldn't find method id getRetryStrategyConfig, setting pRetryStrategyConfig to null.");
         pKvsRetryStrategy->pRetryStrategyConfig = NULL;
     } else {
-        // Set to Java class or member once we implement Java support.
+        pKvsRetryStrategy->pRetryStrategyConfig = env->CallLongMethod(kvsRetryStrategy, methodId);
     }
 
     methodId = env->GetMethodID(cls, "getretryStrategyType", "()Lcom/amazonaws/kinesisvideo/producer/RetryStrategyType");
@@ -332,7 +332,7 @@ VOID setKvsRetryStrategy(JNIEnv *env, jobject kvsRetryStrategy, PKvsRetryStrateg
         DLOGW("Couldn't find method id getretryStrategyType, setting retryStrategyType to EXPONENTIAL_BACKOFF_WAIT.");
         pKvsRetryStrategy->pRetryStrategy = NULL;
     } else {
-        // Set to Java class or member once we implement Java support.
+        pKvsRetryStrategy->pRetryStrategy = env->CallObjectMethod(kvsRetryStrategy, methodId);
     }
 
 
@@ -366,18 +366,20 @@ VOID setKvsRetryStrategyCallbacks(JNIEnv *env, jobject kvsRetryStrategyCallbacks
     }
 
     /* *** */
-    /* NOTE: All kvsRetryStrategyCallbacks must be set to NULL in order for PIC to set them to the default callbacks.*/
+    /* NOTE: If ANY of the kvsRetryStrategyCallbacks are NULL, then they will ALL be set to defaults in PIC. */
+    /*          So, below, if any are NULL, we will set them all to NULL in cleanup */
     /* *** */
 
     methodId = env->GetMethodID(cls, "createRetryStrategyFn", "(Lcom/amazonaws/kinesisvideo/producer/KvsRetryStrategyCallbacks;)V");
     if (methodId == NULL) {
         DLOGW("Couldn't find method id createRetryStrategyFn, setting to NULL");
-        pKvsRetryStrategyCallbacks->createRetryStrategyFn = NULL;
         nullSetCallbacks = TRUE;
         goto CleanUp;
     } else {
-        // Set to Java-provided callback once we implement Java callback invocation and support setting KvsRetryStrategyCallbacks
+        // Use Java-provided callback once we implement Java callback invocation and support setting KvsRetryStrategyCallbacks
         // from the Producer Java SDK.
+        nullSetCallbacks = TRUE;
+        goto CleanUp;
     }
 
     methodId = env->GetMethodID(cls, "getCurrentRetryAttemptNumberFn", "(Lcom/amazonaws/kinesisvideo/producer/KvsRetryStrategyCallbacks;I)V");
@@ -386,8 +388,10 @@ VOID setKvsRetryStrategyCallbacks(JNIEnv *env, jobject kvsRetryStrategyCallbacks
         nullSetCallbacks = TRUE;
         goto CleanUp;
     } else {
-        // Set to Java-provided callback once we implement Java callback invocation and support setting KvsRetryStrategyCallbacks
+        // Use Java-provided callback once we implement Java callback invocation and support setting KvsRetryStrategyCallbacks
         // from the Producer Java SDK.
+        nullSetCallbacks = TRUE;
+        goto CleanUp;
     }
 
     methodId = env->GetMethodID(cls, "freeRetryStrategyFn", "(Lcom/amazonaws/kinesisvideo/producer/KvsRetryStrategyCallbacks;)V");
@@ -396,8 +400,10 @@ VOID setKvsRetryStrategyCallbacks(JNIEnv *env, jobject kvsRetryStrategyCallbacks
         nullSetCallbacks = TRUE;
         goto CleanUp;
     } else {
-        // Set to Java-provided callback once we implement Java callback invocation and support setting KvsRetryStrategyCallbacks
+        // Use Java-provided callback once we implement Java callback invocation and support setting KvsRetryStrategyCallbacks
         // from the Producer Java SDK.
+        nullSetCallbacks = TRUE;
+        goto CleanUp;
     }
     
     methodId = env->GetMethodID(cls, "executeRetryStrategyFn", "(Lcom/amazonaws/kinesisvideo/producer/KvsRetryStrategyCallbacks;J)V");
@@ -406,8 +412,10 @@ VOID setKvsRetryStrategyCallbacks(JNIEnv *env, jobject kvsRetryStrategyCallbacks
         nullSetCallbacks = TRUE;
         goto CleanUp;
     } else {
-        // Set to Java-provided callback once we implement Java callback invocation and support setting KvsRetryStrategyCallbacks
+        // Use Java-provided callback once we implement Java callback invocation and support setting KvsRetryStrategyCallbacks
         // from the Producer Java SDK.
+        nullSetCallbacks = TRUE;
+        goto CleanUp;
     }
 
 CleanUp:

--- a/src/JNI/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
+++ b/src/JNI/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
@@ -161,6 +161,18 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
 
     CHECK(env != NULL && clientInfo != NULL && pClientInfo != NULL);
 
+    // Initialize Java-unused members. These will be set to default values in PIC.
+    pClientInfo->kvsRetryStrategy.pRetryStrategy = NULL;
+    pClientInfo->kvsRetryStrategy.pRetryStrategyConfig = NULL;
+    pClientInfo->kvsRetryStrategy.retryStrategyType = KVS_RETRY_STRATEGY_DISABLED;
+    pClientInfo->metricLoggingPeriod = 0;
+    pClientInfo->reservedCallbackPeriod = 0;
+    pClientInfo->kvsRetryStrategyCallbacks.createRetryStrategyFn = NULL;
+    pClientInfo->kvsRetryStrategyCallbacks.getCurrentRetryAttemptNumberFn = NULL;
+    pClientInfo->kvsRetryStrategyCallbacks.freeRetryStrategyFn = NULL;
+    pClientInfo->kvsRetryStrategyCallbacks.executeRetryStrategyFn = NULL;
+
+
     // Load ClientInfo
     jclass cls = env->GetObjectClass(clientInfo);
     if (cls == NULL) {

--- a/src/JNI/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
+++ b/src/JNI/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
@@ -297,6 +297,8 @@ VOID setKvsRetryStrategy(JNIEnv *env, jobject kvsRetryStrategy, PKvsRetryStrateg
     jclass cls = NULL;
     BOOL nullKvsRetryStrategy = FALSE;
 
+    CHECK(env != NULL && pKvsRetryStrategy != NULL);
+
     if (kvsRetryStrategy == NULL) {
         nullKvsRetryStrategy = TRUE;
         goto CleanUp;
@@ -348,6 +350,8 @@ VOID setKvsRetryStrategyCallbacks(JNIEnv *env, jobject kvsRetryStrategyCallbacks
     jmethodID methodId = NULL;
     jclass cls = NULL;
     BOOL nullSetCallbacks = FALSE;
+
+    CHECK(env != NULL && pKvsRetryStrategyCallbacks != NULL);
 
     if (kvsRetryStrategyCallbacks == NULL) {
         nullSetCallbacks = TRUE;

--- a/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/Parameters.h
+++ b/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/Parameters.h
@@ -17,7 +17,6 @@ BOOL setStreamDataBuffer(JNIEnv* env, jobject dataBuffer, UINT32 offset, PBYTE* 
 BOOL releaseStreamDataBuffer(JNIEnv* env, jobject dataBuffer, UINT32 offset, PBYTE pBuffer);
 BOOL setTags(JNIEnv *env, jobjectArray tagArray, PTag* ppTags, PUINT32 pTagCount);
 VOID releaseTags(PTag tags);
-BOOL setKvsRetryStrategyCallbacks(JNIEnv *env, jobject kvsRetryStrategyCallbacks, PKvsRetryStrategyCallbacks pKvsRetryStrategyCallbacks);
 BOOL setKvsRetryStrategy(JNIEnv *env, jobject kvsRetryStrategyCallbacks, PKvsRetryStrategy pKvsRetryStrategy);
 
 #endif // __KINESIS_VIDEO_PARAMETERS_CONVERSION_H__

--- a/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/Parameters.h
+++ b/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/Parameters.h
@@ -17,7 +17,7 @@ BOOL setStreamDataBuffer(JNIEnv* env, jobject dataBuffer, UINT32 offset, PBYTE* 
 BOOL releaseStreamDataBuffer(JNIEnv* env, jobject dataBuffer, UINT32 offset, PBYTE pBuffer);
 BOOL setTags(JNIEnv *env, jobjectArray tagArray, PTag* ppTags, PUINT32 pTagCount);
 VOID releaseTags(PTag tags);
-VOID setKvsRetryStrategyCallbacks(JNIEnv *env, jobject kvsRetryStrategyCallbacks, PKvsRetryStrategyCallbacks pKvsRetryStrategyCallbacks);
-VOID setKvsRetryStrategy(JNIEnv *env, jobject kvsRetryStrategyCallbacks, PKvsRetryStrategy pKvsRetryStrategy);
+BOOL setKvsRetryStrategyCallbacks(JNIEnv *env, jobject kvsRetryStrategyCallbacks, PKvsRetryStrategyCallbacks pKvsRetryStrategyCallbacks);
+BOOL setKvsRetryStrategy(JNIEnv *env, jobject kvsRetryStrategyCallbacks, PKvsRetryStrategy pKvsRetryStrategy);
 
 #endif // __KINESIS_VIDEO_PARAMETERS_CONVERSION_H__

--- a/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/Parameters.h
+++ b/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/Parameters.h
@@ -18,5 +18,6 @@ BOOL releaseStreamDataBuffer(JNIEnv* env, jobject dataBuffer, UINT32 offset, PBY
 BOOL setTags(JNIEnv *env, jobjectArray tagArray, PTag* ppTags, PUINT32 pTagCount);
 VOID releaseTags(PTag tags);
 VOID setKvsRetryStrategyCallbacks(JNIEnv *env, jobject kvsRetryStrategyCallbacks, PKvsRetryStrategyCallbacks pKvsRetryStrategyCallbacks);
+VOID setKvsRetryStrategy(JNIEnv *env, jobject kvsRetryStrategyCallbacks, PKvsRetryStrategy pKvsRetryStrategy);
 
 #endif // __KINESIS_VIDEO_PARAMETERS_CONVERSION_H__

--- a/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/Parameters.h
+++ b/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/Parameters.h
@@ -17,4 +17,6 @@ BOOL setStreamDataBuffer(JNIEnv* env, jobject dataBuffer, UINT32 offset, PBYTE* 
 BOOL releaseStreamDataBuffer(JNIEnv* env, jobject dataBuffer, UINT32 offset, PBYTE pBuffer);
 BOOL setTags(JNIEnv *env, jobjectArray tagArray, PTag* ppTags, PUINT32 pTagCount);
 VOID releaseTags(PTag tags);
+VOID setKvsRetryStrategyCallbacks(JNIEnv *env, jobject kvsRetryStrategyCallbacks, PKvsRetryStrategyCallbacks pKvsRetryStrategyCallbacks);
+
 #endif // __KINESIS_VIDEO_PARAMETERS_CONVERSION_H__


### PR DESCRIPTION
### *What was changed?*
The previously un-initialized `pClientInfo` members in the JNI are now initialized to NULL values.

### *Why was it changed?*
The `kvsRetryStrategyCallbacks` function pointers not being initialized as NULL was causing the function pointers to not be assigned in the PIC layer which was then causing a segmentation fault in the Producer C layer when running the Java Producer SDK.

Here in PIC, at least one of the `pKvsRetryStrategyCallbacks` function pointers must be NULL in order for `setupDefaultKvsRetryStrategyParameters` to be called to setup the default callbacks, 

```
if (pKvsRetryStrategyCallbacks->createRetryStrategyFn == NULL || pKvsRetryStrategyCallbacks->freeRetryStrategyFn == NULL ||
pKvsRetryStrategyCallbacks->executeRetryStrategyFn == NULL || pKvsRetryStrategyCallbacks->getCurrentRetryAttemptNumberFn == NULL) {
        CHK_STATUS(setupDefaultKvsRetryStrategyParameters(pKinesisVideoClient));
}
```

but the function pointers were never explicitly initialized as NULL in the JNI, so they would usually all be junk, non-null values,

```
[testing] createRetryStrategyFn: 0xb33300b20100b3
[testing] freeRetryStrategyFn: 0x180062000000
[testing] executeRetryStrategyFn: 0x22001c0011001b00
[testing] getCurrentRetryAttemptNumberFn: 0x960001000000b174
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGBUS (0xa) at pc=0x00b33300b20100b3, pid=17942, tid=10243
```
causing the seg-fault to occur when the undefined `createRetryStrategyFn` is invoked in the below Producer C code,
```
CHK_STATUS(pKvsRetryStrategyCallbacks->createRetryStrategyFn(&(pKinesisVideoClient->deviceInfo.clientInfo.kvsRetryStrategy)));
```
and when the app did work, all the pointers happened to be NULL:

```
[testing] createRetryStrategyFn: 0x0
[testing] freeRetryStrategyFn: 0x0
[testing] executeRetryStrategyFn: 0x0
[testing] getCurrentRetryAttemptNumberFn: 0x0
[testing] Calling setupDefaultKvsRetryStrategyParameters
```

### *How was it changed?*
Carefully, and by initializing previously un-initialized `pClientInfo` members in the JNI to NULL values.

### *What testing was done for the changes?*
The Java sample successfully ran ~10 times using the outputted Producer CPP JNI with no issues. Previously, the application would seg-fault every ~5/6 runs.

<br> 
<br> 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
