### PR TITLE
Fix typos in '.cpp' files in 'samples' directory

### DIFF
--- a/samples/kvs_gstreamer_sample.cpp
+++ b/samples/kvs_gstreamer_sample.cpp
@@ -684,7 +684,7 @@ int gstreamer_live_source_init(int argc, char* argv[], CustomData *data, GstElem
 
     GstElement *source_filter, *filter, *appsink, *h264parse, *encoder, *source, *video_convert;
 
-    /* create the elemnents */
+    /* create the elements */
     /*
        gst-launch-1.0 v4l2src device=/dev/video0 ! video/x-raw,format=I420,width=1280,height=720,framerate=15/1 ! x264enc pass=quant bframes=0 ! video/x-h264,profile=baseline,format=I420,width=1280,height=720,framerate=15/1 ! matroskamux ! filesink location=test.mkv
      */
@@ -817,7 +817,7 @@ int gstreamer_live_source_init(int argc, char* argv[], CustomData *data, GstElem
     gst_caps_unref(src_caps);
     gst_object_unref(srcpad);
 
-    /* create the elemnents needed for the corresponding pipeline */
+    /* create the elements needed for the corresponding pipeline */
     if (!data->h264_stream_supported) {
         video_convert = gst_element_factory_make("videoconvert", "video_convert");
 

--- a/samples/kvssink_gstreamer_sample.cpp
+++ b/samples/kvssink_gstreamer_sample.cpp
@@ -330,7 +330,7 @@ int gstreamer_live_source_init(int argc, char *argv[], CustomData *data, GstElem
 
     GstElement *source_filter, *filter, *kvssink, *h264parse, *encoder, *source, *video_convert;
 
-    /* create the elemnents */
+    /* create the elements */
     source_filter = gst_element_factory_make("capsfilter", "source_filter");
     if (!source_filter) {
         LOG_ERROR("Failed to create capsfilter (1)");
@@ -461,7 +461,7 @@ int gstreamer_live_source_init(int argc, char *argv[], CustomData *data, GstElem
     gst_caps_unref(src_caps);
     gst_object_unref(srcpad);
 
-    /* create the elemnents needed for the corresponding pipeline */
+    /* create the elements needed for the corresponding pipeline */
     if (!data->h264_stream_supported) {
         video_convert = gst_element_factory_make("videoconvert", "video_convert");
 


### PR DESCRIPTION
Issue #, if available:
Not an issue but this is a newer version of a previous pull request (#1169) that I deleted (made a new fork because I had forked only the master branch by accident) so I can create a branch off the "develop" branch and merge into it.
Description of changes:
Fixed typos in the "samples/kvs_gstreamer_sample.cpp" and the "samples/kvssink_gstreamer_sample.cpp" files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.