### PR TITLE
Fix memory leak in failed DefaultCallbackProvider constructor

### DIFF
--- a/src/DefaultCallbackProvider.cpp
+++ b/src/DefaultCallbackProvider.cpp
@@ -406,7 +406,8 @@ DefaultCallbackProvider::DefaultCallbackProvider(
         : region_(region),
           service_(std::string(KINESIS_VIDEO_SERVICE_NAME)),
           control_plane_uri_(control_plane_uri),
-          cert_path_(cert_path) {
+          cert_path_(cert_path)
+          resources_(new CallbackProviderResources()) {
     STATUS retStatus = STATUS_SUCCESS;
     client_callback_provider_ = std::move(client_callback_provider);
     stream_callback_provider_ = std::move(stream_callback_provider);
@@ -439,20 +440,16 @@ DefaultCallbackProvider::DefaultCallbackProvider(
             STRING_TO_PCHAR(cert_path),
             STRING_TO_PCHAR (user_agent_name),
             STRING_TO_PCHAR(custom_user_agent_),
-            &client_callbacks_))) {
+            &resources_->client_callbacks_))) {
         std::stringstream status_strstrm;
         status_strstrm << std::hex << retStatus;
         LOG_AND_THROW("Unable to create default callback provider. Error status: 0x" + status_strstrm.str());
     }
-    auth_callbacks_ = credentials_provider_->getCallbacks(client_callbacks_);
-    addStreamCallbacks(client_callbacks_, &stream_callbacks_);
-    addProducerCallbacks(client_callbacks_, &producer_callbacks_);
-    setPlatformCallbacks(client_callbacks_, &platform_callbacks_);
-    createContinuousRetryStreamCallbacks(client_callbacks_, &pContinuoutsRetryStreamCallbacks);
-}
-
-DefaultCallbackProvider::~DefaultCallbackProvider() {
-    freeCallbacksProvider(&client_callbacks_);
+    auth_callbacks_ = credentials_provider_->getCallbacks(resources_->client_callbacks_);
+    addStreamCallbacks(resources_->client_callbacks_, &stream_callbacks_);
+    addProducerCallbacks(resources_->client_callbacks_, &producer_callbacks_);
+    setPlatformCallbacks(resources_->client_callbacks_, &platform_callbacks_);
+    createContinuousRetryStreamCallbacks(resources_->client_callbacks_, &pContinuoutsRetryStreamCallbacks);
 }
 
 StreamCallbacks DefaultCallbackProvider::getStreamCallbacks() {
@@ -493,7 +490,7 @@ PlatformCallbacks DefaultCallbackProvider::getPlatformCallbacks() {
 }
 
 DefaultCallbackProvider::callback_t DefaultCallbackProvider::getCallbacks() {
-    return *client_callbacks_;
+    return *resources_->client_callbacks_;
 }
 
 GetStreamingTokenFunc DefaultCallbackProvider::getStreamingTokenCallback() {

--- a/src/DefaultCallbackProvider.h
+++ b/src/DefaultCallbackProvider.h
@@ -72,7 +72,7 @@ public:
             API_CALL_CACHE_TYPE api_call_caching,
             uint64_t caching_update_period);
 
-    virtual ~DefaultCallbackProvider();
+    ~DefaultCallbackProvider() = default;
 
     callback_t getCallbacks() override;
 
@@ -443,7 +443,19 @@ protected:
     /**
      * Stores all callbacks from PIC
      */
-    PClientCallbacks client_callbacks_;
+    class CallbackProviderResources {
+    public:
+        CallbackProviderResources() : client_callbacks_(nullptr) {}
+        ~CallbackProviderResources() {
+            if (client_callbacks_ != nullptr) {
+                freeCallbacksProvider(&client_callbacks_);
+            }
+        }
+  
+        PClientCallbacks client_callbacks_;
+    };
+  
+    std::unique_ptr<CallbackProviderResources> resources_;
 
     /**
      * Stores all auth callbacks from C++


### PR DESCRIPTION
*Description of changes:*

I noticed a leak in memory in our application and was able to trace it to the KVS C++ Producer Library.
This situation was mainly occuring when the producer could not reach the internet. 

Our application is long-living, and will restart the pipeline with kvssink if it fails very quickly, so in times of internet outage we cycle through instances of kvssink fairly quickly.

![img](https://github.com/user-attachments/assets/d6c7db04-e544-4c26-b3c8-c261c105f796)

As is visible in the graph, at the time this dump was taken, KVS Producer was responsible for 30GB of memory coming from createCurlApiCallbacks. On investigation, I was able trace this back to the DefaultCallbackProvider not freeing memory allocated to PClientCallbacks instance when the constructor failed. 

This issue was fixed by transitioning the PClientCallbacks instance to a separate RAII instance that will automatically free when the DefaultCallbackProvider instance goes out of scope. 

This change has been running in a test environment with the triggering conditions for 4 days and we have seen the leak resolved.

<img width="1675" alt="Screenshot 2024-08-05 at 5 25 59 PM" src="https://github.com/user-attachments/assets/1e1f0bc1-2c11-4650-9fc0-0401e6077c2e">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
