### PR TITLE
Allow using prebuilt libkvscproducer through pkg-config (#1193)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(BUILD_JNI "Build C++ wrapper for JNI to expose the functionality to Java/
 option(BUILD_STATIC "Build with static linkage" OFF)
 option(ADD_MUCLIBC "Add -muclibc c flag" OFF)
 option(BUILD_DEPENDENCIES "Whether or not to build depending libraries from source" ON)
+option(BUILD_PRODUCER_C "Whether or not to build KVS Producer C library from source" ON)
 option(BUILD_OPENSSL_PLATFORM "If buildng OpenSSL what is the target platform" OFF)
 option(BUILD_LOG4CPLUS_HOST "Specify host-name for log4cplus for cross-compilation" OFF)
 
@@ -100,7 +101,7 @@ set(BUILD_COMMON_CURL
 find_package(Threads)
 find_package(PkgConfig REQUIRED)
 
-if(BUILD_DEPENDENCIES)
+if (BUILD_PRODUCER_C)
   set(DEPENDENCY_DOWNLOAD_PATH ${CMAKE_CURRENT_SOURCE_DIR}/dependency)
   if(NOT EXISTS ${DEPENDENCY_DOWNLOAD_PATH})
     file(MAKE_DIRECTORY ${DEPENDENCY_DOWNLOAD_PATH})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,17 +94,24 @@ set(BUILD_COMMON_LWS
 set(BUILD_COMMON_CURL
     TRUE
     CACHE BOOL "Build ProducerC with CURL Support" FORCE)
-set(DEPENDENCY_DOWNLOAD_PATH ${CMAKE_CURRENT_SOURCE_DIR}/dependency)
-if(NOT EXISTS ${DEPENDENCY_DOWNLOAD_PATH})
-  file(MAKE_DIRECTORY ${DEPENDENCY_DOWNLOAD_PATH})
-endif()
-fetch_repo(kvscproducer)
-add_subdirectory(${DEPENDENCY_DOWNLOAD_PATH}/libkvscproducer/kvscproducer-src EXCLUDE_FROM_ALL)
 
 ############# find dependent libraries ############
 
 find_package(Threads)
 find_package(PkgConfig REQUIRED)
+
+if(BUILD_DEPENDENCIES)
+  set(DEPENDENCY_DOWNLOAD_PATH ${CMAKE_CURRENT_SOURCE_DIR}/dependency)
+  if(NOT EXISTS ${DEPENDENCY_DOWNLOAD_PATH})
+    file(MAKE_DIRECTORY ${DEPENDENCY_DOWNLOAD_PATH})
+  endif()
+  fetch_repo(kvscproducer)
+  add_subdirectory(${DEPENDENCY_DOWNLOAD_PATH}/libkvscproducer/kvscproducer-src EXCLUDE_FROM_ALL)
+else()
+  pkg_check_modules(KVSCPRODUCER REQUIRED libcproducer)
+  include_directories(${KVSCPRODUCER_INCLUDE_DIRS})
+  link_directories(${KVSCPRODUCER_LIBRARY_DIRS})
+endif()
 
 if (OPEN_SRC_INSTALL_PREFIX)
   find_package(CURL REQUIRED PATHS ${OPEN_SRC_INSTALL_PREFIX})

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ You can pass the following options to `cmake ..`.
 * `-DBUILD_GSTREAMER_PLUGIN` -- Build kvssink GStreamer plugin
 * `-DBUILD_JNI` -- Build C++ wrapper for JNI to expose the functionality to Java/Android
 * `-DBUILD_DEPENDENCIES` -- Build depending libraries from source
+* `-DBUILD_PRODUCER_C` -- Build KVS Producer C library from source. Default is ON.
 * `-DBUILD_TEST=TRUE` -- Build unit/integration tests, may be useful for confirm support for your device. `./tst/producerTest`
 * `-DCODE_COVERAGE` --  Enable coverage reporting
 * `-DCOMPILER_WARNINGS` -- Enable all compiler warnings


### PR DESCRIPTION
*Issue #, if available:*
Original PR: https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/pull/1193

*Description of changes:*
(aside from original PR changes)
- Introduced a new CMake option to control the building of the KVS Producer C dependency library. Before, the library was always built from source (regardless of the value of the BUILD_DEPENDENCIES option). Now, whether it is built from source or found using pkg-config can be controlled with the new option.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
