### PR TITLE
Add raspberry pi checks to the CI

### DIFF
--- a/.github/workflows/raspberry-pi.yaml
+++ b/.github/workflows/raspberry-pi.yaml
@@ -45,10 +45,6 @@ jobs:
 
       - name: Build and Test
         env:
-          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
           AWS_KVS_LOG_LEVEL: 2
         run: |
           docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace \

--- a/.github/workflows/raspberry-pi.yaml
+++ b/.github/workflows/raspberry-pi.yaml
@@ -78,7 +78,7 @@ jobs:
                 gst-launch-1.0 -v videotestsrc is-live=true \
                 ! video/x-raw,framerate=10/1,width=640,height=480 \
                 ! clockoverlay time-format="%a %B %d, %Y %I:%M:%S %p" \
-                ! x264enc bframes=0 key-int-max=10 \
+                ! x264enc bframes=0 key-int-max=10 tune=zerolatency \
                 ! h264parse \
                 ! kvssink stream-name="cpp-producer-rpi-${{ matrix.os }}"
               EXIT_CODE=$?

--- a/.github/workflows/raspberry-pi.yaml
+++ b/.github/workflows/raspberry-pi.yaml
@@ -16,8 +16,10 @@ jobs:
     strategy:
       matrix:
         include:
+          # Debian 11
           - os: bullseye
             image: ghcr.io/dtcooper/raspberrypi-os:python3.12-bullseye
+          # Debian 12
           - os: bookworm
             image: ghcr.io/dtcooper/raspberrypi-os:python3.12-bookworm
       fail-fast: false

--- a/.github/workflows/raspberry-pi.yaml
+++ b/.github/workflows/raspberry-pi.yaml
@@ -1,0 +1,95 @@
+name: Build and test on Virtualized Raspberry Pi OS
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        include:
+          - os: bullseye
+            image: ghcr.io/dtcooper/raspberrypi-os:python3.12-bullseye
+          - os: bookworm
+            image: ghcr.io/dtcooper/raspberrypi-os:python3.12-bookworm
+      fail-fast: false
+
+    name: Build on ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+
+      - name: Build and Test
+        env:
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+          AWS_KVS_LOG_LEVEL: 2
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace \
+            -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
+            -e AWS_SESSION_TOKEN -e AWS_REGION -e AWS_KVS_LOG_LEVEL \
+            --platform linux/arm64 \
+            ${{ matrix.image }} \
+            /bin/bash -c '
+              set -ex
+              apt-get update
+              apt-get install -y automake build-essential cmake git \
+                gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad \
+                gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly \
+                gstreamer1.0-tools gstreamer1.0-omx-generic \
+                libcurl4-openssl-dev libgstreamer1.0-dev \
+                libgstreamer-plugins-base1.0-dev liblog4cplus-dev \
+                libssl-dev pkg-config
+
+              mkdir -p build
+              cd build
+
+              cmake .. -DBUILD_GSTREAMER_PLUGIN=ON -DBUILD_DEPENDENCIES=OFF -DALIGNED_MEMORY_MODEL=ON
+              make -j$(nproc)
+
+              export GST_PLUGIN_PATH=$(pwd)
+          
+              set +e  # Disable exit on error for the timeout command
+              timeout --preserve-status --signal=SIGINT --kill-after=15s 30s \
+                gst-launch-1.0 -v videotestsrc is-live=true \
+                ! video/x-raw,framerate=10/1,width=640,height=480 \
+                ! clockoverlay time-format="%a %B %d, %Y %I:%M:%S %p" \
+                ! x264enc bframes=0 key-int-max=10 \
+                ! h264parse \
+                ! kvssink stream-name="cpp-producer-rpi-${{ matrix.os }}"
+              EXIT_CODE=$?
+              set -e  # Re-enable exit on error
+          
+              # 0: Process exited after interrupt with code 0
+              # 1: Process exited with error code 1
+              # 137: Process killed by SIGKILL (if the --kill-after timeout is reached) 
+              echo "Command exited with code: $EXIT_CODE"
+              if [ $EXIT_CODE -ne 0 ]; then
+                echo "Command did not exit gracefully after interrupt."
+                exit 1
+              fi
+            '


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*
This pull request introduces a new CI/CD pipeline for building and testing our application on ARM-based Raspberry Pi OS environments. The implementation leverages GitHub Actions and QEMU emulation to ensure compatibility and maintain build integrity across different Raspberry Pi OS versions.

Key Features:
1. Utilize QEMU emulation of ARM architecture on x86_64 GitHub runners. (Note: GitHub actions does not currently support linux-arm64)
2. Matrix build strategy: Simultaneously tests on both Debian 11 (Bullseye) and Debian 12 (Bookworm) Raspberry Pi OS versions.
3. Runs the sample GStreamer pipeline test with a 30-second timeout and appropriate error handling.

Security Considerations:
- Environment variable secrets are automatically obfuscated by GitHub actions to prevent accidental logging.

Testing:
- Verified successful building of the project and execution of the GStreamer pipeline (review the logging output of the runners).
- Confirmed proper handling of timeouts and exit codes.
- Checked the logs to confirm that aarch64-linux is indeed being used and not x86_84
  - The images have OpenSSL 1.1.1w and 3.0.15 installed respectively.

This implementation significantly enhances our ability to ensure code quality (reduce build issues) and compatibility across different Raspberry Pi OS versions, reducing manual effort required. Streamlining our development and deployment processes for ARM-based environments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
