### PR TITLE
Kvssink no credentials found error message

### DIFF
--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -366,8 +366,10 @@ void kinesis_video_producer_init(GstKvsSink *kvssink)
                                                     session_token_str,
                                                     std::chrono::seconds(DEFAULT_ROTATION_PERIOD_SECONDS)));
         credential_provider.reset(new StaticCredentialProvider(*kvssink->credentials_));
-    } else {
+    } else if (kvssink->credential_file_path != nullptr && static_cast<bool>(std::ifstream(kvssink->credential_file_path))) {
         credential_provider.reset(new RotatingCredentialProvider(kvssink->credential_file_path));
+    } else {
+        throw runtime_error("Could not find any AWS credentials!");
     }
 
     // Handle env for providing CP URL

--- a/src/gstreamer/gstkvssink.h
+++ b/src/gstreamer/gstkvssink.h
@@ -36,6 +36,7 @@
 #include <string.h>
 #include <mutex>
 #include <atomic>
+#include <fstream>
 #include <gst/base/gstcollectpads.h>
 #include <unordered_set>
 


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/discussions/976

*Background:*
When you run `kvssink`, and it was not able to find any credentials, it fails with this code:
> Failed to init kvs producer. Error: Unable to create Rotating Credential provider. Error status: 0x15000022
Which is:
- STATUS_FILE_CREDENTIAL_PROVIDER_OPEN_FILE_FAILED

It will fallback to the file credentials and fail: https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/examples-gstreamer-plugin-parameters.html#credentials-to-kvssink

Logic should be revised to have a better error message. 

*Description of changes:*
- Change to have a better error message.
- In kvssink, check if the credentials file exists. If so, try the file credentials provider. Otherwise, print a proper error.

Testing with gst-parse-launch-1.0:

```
[INFO ] [05-02-2025 23:15:31:074.995 UTC] Logger config being used: ../kvs_log_configuration
ERROR: from element /GstPipeline:pipeline0/GstKvsSink:kvssink0: Could not initialize supporting library.
Additional debug info:
/Users/me/Downloads/amazon-kinesis-video-streams-producer-sdk-cpp/src/gstreamer/gstkvssink.cpp(1642): gst_kvs_sink_change_state (): /GstPipeline:pipeline0/GstKvsSink:kvssink0:
Failed to init kvs producer. Error: Could not find any AWS credentials!
ERROR: pipeline doesn't want to preroll.
Failed to set pipeline to PAUSED.
Setting pipeline to NULL ...
Freeing pipeline ...
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
