### PR TITLE
Adding sample checks & DTS generation for multistream sample

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           role-duration-seconds: 10800
       - name: Run tests
         run: |
-          cd build  
+          cd build
           ./tst/producerTest
 
   mac-os-build-gcc:
@@ -73,10 +73,10 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           role-duration-seconds: 10800
       - name: Run tests
-        run: |  
+        run: |
           cd build
           ./tst/producerTest
-  
+
   linux-gcc-code-coverage:
     runs-on: ubuntu-20.04
     env:
@@ -88,7 +88,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
       - name: Install dependencies
-        run: |  
+        run: |
           sudo apt clean && sudo apt update
           sudo apt install -y libunwind-dev
           sudo apt-get install -y libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
@@ -115,7 +115,7 @@ jobs:
           cd build
           for test_file in $(find CMakeFiles/KinesisVideoProducer.dir gstkvssink.dir KinesisVideoProducerJNI.dir -name '*.gcno'); do gcov $test_file; done
           bash <(curl -s https://codecov.io/bash)
-  
+
   address-sanitizer:
     runs-on: ubuntu-20.04
     permissions:
@@ -189,7 +189,7 @@ jobs:
           timeout --signal=SIGABRT 60m ./tst/producerTest
 
   # memory-sanitizer:
-  #   runs-on: ubuntu-20.04 
+  #   runs-on: ubuntu-20.04
   #   permissions:
   #     id-token: write
   #     contents: read
@@ -237,9 +237,9 @@ jobs:
   #         mkdir build && cd build
   #         cmake .. -DBUILD_TEST=TRUE -DTHREAD_SANITIZER=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE
   #         make
-  #         ulimit -c unlimited -S 
+  #         ulimit -c unlimited -S
   #         timeout --signal=SIGABRT 20m ./tst/producerTest
-  
+
   ubuntu-gcc:
     runs-on: ubuntu-20.04
     env:
@@ -312,7 +312,7 @@ jobs:
       - name: Run tests
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\producer\open-source\local\lib;D:\producer\open-source\local\bin'
-          & "D:\producer\build\tst\producerTest.exe" 
+          & "D:\producer\build\tst\producerTest.exe"
 
   arm64-cross-compilation:
     runs-on: ubuntu-20.04

--- a/.github/workflows/raspberry-pi.yaml
+++ b/.github/workflows/raspberry-pi.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     permissions:
       id-token: write
@@ -70,7 +70,7 @@ jobs:
               make -j$(nproc)
 
               export GST_PLUGIN_PATH=$(pwd)
-          
+
               set +e  # Disable exit on error for the timeout command
               timeout --preserve-status --signal=SIGINT --kill-after=15s 30s \
                 gst-launch-1.0 -v videotestsrc is-live=true \
@@ -81,10 +81,10 @@ jobs:
                 ! kvssink stream-name="cpp-producer-rpi-${{ matrix.os }}"
               EXIT_CODE=$?
               set -e  # Re-enable exit on error
-          
+
               # 0: Process exited after interrupt with code 0
               # 1: Process exited with error code 1
-              # 137: Process killed by SIGKILL (if the --kill-after timeout is reached) 
+              # 137: Process killed by SIGKILL (if the --kill-after timeout is reached)
               echo "Command exited with code: $EXIT_CODE"
               if [ $EXIT_CODE -ne 0 ]; then
                 echo "Command did not exit gracefully after interrupt."

--- a/.github/workflows/raspberry-pi.yaml
+++ b/.github/workflows/raspberry-pi.yaml
@@ -18,10 +18,10 @@ jobs:
         include:
           # Debian 11
           - os: bullseye
-            image: ghcr.io/dtcooper/raspberrypi-os:python3.12-bullseye
+            image: ghcr.io/dtcooper/raspberrypi-os:python3.12-bullseye@sha256:72311cfece0656c91407b4fd982f5aaf0eded0fee477de58281e82ab67f4478f
           # Debian 12
           - os: bookworm
-            image: ghcr.io/dtcooper/raspberrypi-os:python3.12-bookworm
+            image: ghcr.io/dtcooper/raspberrypi-os:python3.12-bookworm@sha256:0632946b7dc03ec3d9f7aeef9df4287affb3d6fe413f0e5dfd11c2b73466a845
       fail-fast: false
 
     name: Build on ${{ matrix.os }}
@@ -61,7 +61,7 @@ jobs:
                 gstreamer1.0-tools gstreamer1.0-omx-generic \
                 libcurl4-openssl-dev libgstreamer1.0-dev \
                 libgstreamer-plugins-base1.0-dev liblog4cplus-dev \
-                libssl-dev pkg-config
+                libssl-dev pkg-config openssl
 
               mkdir -p build
               cd build

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -124,11 +124,11 @@ jobs:
         run: |
           # Equivalent to set -x
           Set-PSDebug -Trace 1
-          
+
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\producer\open-source\local\lib;D:\producer\open-source\local\bin;D:\gstreamer\1.0\msvc_x86_64\bin'
-          
+
           mkdir D:\producer\debug_output
-          
+
           Invoke-WebRequest -Uri https://awsj-iot-handson.s3-ap-northeast-1.amazonaws.com/kvs-workshop/sample.mp4 -OutFile sample.mp4
           dir
           $exePath = Join-Path $PWD ${{ matrix.sample.name }}.exe
@@ -139,14 +139,14 @@ jobs:
         working-directory: ./build/debug_output
         run: |
           shopt -s nullglob  # Ensure globbing works correctly and avoids errors when no files are found
-          
+
           ls -tlrh
           mkvfiles=(*.mkv)
           if [ ${#mkvfiles[@]} -eq 0 ]; then
             echo "No MKV files found in debug_output"
             exit 1
           fi
-          
+
           for file in "${mkvfiles[@]}"; do
             echo "Verifying $file with mkvinfo (verbose and hexdump):"
             mkvinfo -v -X "$file"
@@ -171,15 +171,16 @@ jobs:
           }
 
   multistream-sample:
-    name: Multistream sample on Mac
-    runs-on: macos-13
+    name: Multistream sample on Ubuntu 22.04
+    runs-on: ubuntu-latest
+    container: public.ecr.aws/ubuntu/ubuntu:22.04_stable
     timeout-minutes: 30
 
     env:
       AWS_KVS_LOG_LEVEL: 2
       KVS_DEBUG_DUMP_DATA_FILE_DIR: ${{ github.workspace }}/build/debug_output
       GST_PLUGIN_PATH: ${{ github.workspace }}/build
-      DEBIAN_FRONTEND: noninteractive
+      KVS_STREAM_NAME_BASE: demo-stream-producer-cpp-ubuntu-22.04-ci-kvs_gstreamer_multistream_sample
 
     permissions:
       id-token: write
@@ -191,14 +192,31 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install gstreamer log4cplus mkvtoolnix coreutils
-          brew install --cask docker
+          apt-get update
+          apt-get install -y git cmake build-essential pkg-config libssl-dev libcurl4-openssl-dev \
+            liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+            gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-ugly gstreamer1.0-tools curl mkvtoolnix libgstrtspserver-1.0
+
+      - name: Build GST RTSP Server Test Launch Sample
+        run: |
+          set -x
+          git clone --no-checkout --filter=blob:none --depth=1 -b 1.22 https://gitlab.freedesktop.org/gstreamer/gstreamer.git
+          cd gstreamer
+          git sparse-checkout init cone
+          git sparse-checkout set "subprojects/gst-rtsp-server/examples/test-launch.c"
+          git checkout
+          cd subprojects/gst-rtsp-server/examples
+          gcc -o test-launch test-launch.c `pkg-config --cflags --libs gstreamer-rtsp-server-1.0`
+          mv ./test-launch $GITHUB_WORKSPACE
+          cd $GITHUB_WORKSPACE
+          rm -rf gstreamer
 
       - name: Build samples
         run: |
           mkdir build && cd build
           mkdir -p $KVS_DEBUG_DUMP_DATA_FILE_DIR
-          cmake .. -DBUILD_GSTREAMER_PLUGIN=ON -DBUILD_DEPENDENCIES=OFF
+          cmake .. -DBUILD_GSTREAMER_PLUGIN=ON -DBUILD_DEPENDENCIES=OFF -DALIGNED_MEMORY_MODEL=ON
           make -j$(nproc)
 
       - name: Configure AWS Credentials
@@ -214,32 +232,32 @@ jobs:
         run: |
           set -x
 
-          open -a /Applications/Docker.app --args --unattended --accept-license
-          echo "We are waiting for Docker to be up and running. It can take over 2 minutes..."
-          while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do sleep 1; done
+          export PIPELINE_8554="videotestsrc is-live=true \
+            ! textoverlay text=rtsp://127.0.0.1:8554/test \
+            ! video/x-raw,height=480,width=640,framerate=10/1 \
+            ! x264enc tune=zerolatency bitrate=512 key-int-max=25 \
+            ! h264parse \
+            ! rtph264pay name=pay0 pt=96"
+          export PIPELINE_8555="videotestsrc is-live=true \
+            ! textoverlay text=rtsp://127.0.0.1:8555/test \
+            ! video/x-raw,height=480,width=640,framerate=10/1 \
+            ! x264enc tune=zerolatency bitrate=512 key-int-max=25 \
+            ! h264parse \
+            ! rtph264pay name=pay0 pt=96"
 
-          sudo ln -s ~/.docker/run/docker.sock /var/run/docker.sock
-          
-          docker run -d --rm -it -e RTSP_PROTOCOLS=tcp -p 8554:8554 bluenviron/mediamtx:latest
-          docker run -d --rm -it -e RTSP_PROTOCOLS=tcp -p 8555:8554 bluenviron/mediamtx:latest
-          
-          (
-            ffmpeg -re -f lavfi -i "testsrc=size=640x480:rate=10" -vcodec libx264 -x264-params keyint=25 -f rtsp rtsp://localhost:8554/mystream
-          ) &
-          (
-            ffmpeg -re -f lavfi -i "testsrc=size=640x480:rate=10" -vcodec libx264 -x264-params keyint=25 -f rtsp rtsp://localhost:8555/mystream
-          ) &
-          
-          echo "rtsp://0.0.0.0:8554/mystream" > rtsp-urls.txt
-          echo "rtsp://0.0.0.0:8555/mystream" >> rtsp-urls.txt
-          
+          "$GITHUB_WORKSPACE"/test-launch -p 8554 "${PIPELINE_8554}" &
+          "$GITHUB_WORKSPACE"/test-launch -p 8555 "${PIPELINE_8555}" &
+
+          echo "rtsp://127.0.0.1:8554/test" > rtsp-urls.txt
+          echo "rtsp://127.0.0.1:8555/test" >> rtsp-urls.txt
+
           sleep 10
-          gst-discoverer-1.0 rtsp://0.0.0.0:8554/mystream
-          gst-discoverer-1.0 rtsp://0.0.0.0:8555/mystream
-          
+          gst-discoverer-1.0 "rtsp://127.0.0.1:8554/test"
+          gst-discoverer-1.0 "rtsp://127.0.0.1:8555/test"
+
           set +e  # Disable exit on error for the timeout command
-          gtimeout --preserve-status --signal=SIGINT --kill-after=15s 30s \
-            ./kvs_gstreamer_multistream_sample demo-stream-producer-cpp-macos-13-ci-kvs_gstreamer_multistream_sample rtsp-urls.txt
+          timeout --preserve-status --signal=SIGINT --kill-after=15s 30s \
+            ./kvs_gstreamer_multistream_sample "${KVS_STREAM_NAME_BASE}" rtsp-urls.txt
           EXIT_CODE=$?
           set -e  # Re-enable exit on error
 
@@ -265,21 +283,22 @@ jobs:
             exit 1
           fi
           
+          # Since there are 2 streams, check for the presence of two different prefixed MKV files
           found_0=0
           found_1=0
         
           for file in "${mkvfiles[@]}"; do
-            if [[ "$file" == demo-stream-producer-cpp-macos-13-ci-kvs_gstreamer_multistream_sample_0* ]]; then
+            if [[ "$file" == ${KVS_STREAM_NAME_BASE}_0* ]]; then
               found_0=1
-            elif [[ "$file" == demo-stream-producer-cpp-macos-13-ci-kvs_gstreamer_multistream_sample_1* ]]; then
+            elif [[ "$file" == ${KVS_STREAM_NAME_BASE}_1* ]]; then
               found_1=1
             fi
           done
         
           if [ $found_0 -eq 0 ] || [ $found_1 -eq 0 ]; then
             echo "Expected at least one file starting with each prefix:"
-            echo "  - demo-stream-producer-cpp-macos-13-ci-kvs_gstreamer_multistream_sample_0"
-            echo "  - demo-stream-producer-cpp-macos-13-ci-kvs_gstreamer_multistream_sample_1"
+            echo "  - ${KVS_STREAM_NAME_BASE}_0"
+            echo "  - ${KVS_STREAM_NAME_BASE}_1"
             exit 1
           fi
           

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -1,0 +1,290 @@
+name: Producer CPP Sample Checks
+
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
+    branches:
+      - develop
+      - master
+
+jobs:
+  sample-checks:
+    name: ${{ matrix.runner.id }} - ${{ matrix.sample.name }}
+
+    strategy:
+      matrix:
+        sample:
+          - name: kvs_gstreamer_audio_video_sample
+            args: -f sample.mp4
+          - name: kvs_gstreamer_file_uploader_sample
+            args: sample.mp4 0 audio-video
+          - name: kvs_gstreamer_sample
+            args: sample.mp4
+          - name: kvssink_gstreamer_sample
+            args: sample.mp4
+        runner:
+          - id: macos-13
+            image: macos-13
+
+          - id: ubuntu-22.04
+            image: ubuntu-latest
+            docker: public.ecr.aws/ubuntu/ubuntu:22.04_stable
+
+          - id: ubuntu-20.04
+            image: ubuntu-latest
+            docker: public.ecr.aws/ubuntu/ubuntu:20.04_stable
+
+          - id: windows-2022
+            image: windows-2022
+
+      fail-fast: false
+
+    runs-on: ${{ matrix.runner.image }}
+    container: ${{ matrix.runner.docker || '' }}
+    timeout-minutes: 30
+
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+      KVS_DEBUG_DUMP_DATA_FILE_DIR: ${{ github.workspace }}/build/debug_output
+      DEBIAN_FRONTEND: noninteractive
+      GST_PLUGIN_PATH: ${{ github.workspace }}/build
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install gstreamer log4cplus mkvtoolnix
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          apt-get update
+          apt-get install -y git cmake build-essential pkg-config libssl-dev libcurl4-openssl-dev \
+            liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+            gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-ugly gstreamer1.0-tools curl mkvtoolnix
+
+      - name: Install dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          choco install nasm strawberryperl pkgconfiglite mkvtoolnix
+          choco install gstreamer --version=1.22.8
+          choco install gstreamer-devel --version=1.22.8
+
+      - name: Build samples (Linux & Mac)
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        run: |
+          mkdir build && cd build
+          mkdir -p $KVS_DEBUG_DUMP_DATA_FILE_DIR
+          cmake .. -DBUILD_GSTREAMER_PLUGIN=ON -DBUILD_DEPENDENCIES=OFF
+          make -j$(nproc)
+
+      - name: Build samples (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\producer\open-source\local\lib;D:\producer\open-source\local\bin'
+          mkdir D:\producer
+          Move-Item -Path "D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\*" -Destination "D:\producer"
+          cd D:\producer
+          git config --system core.longpaths true
+          dir
+          .github\build_windows.bat
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+
+      - name: Run ${{ matrix.sample.name }} (Linux & Mac)
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        working-directory: ./build
+        run: |
+          curl -fsSL -o sample.mp4 https://awsj-iot-handson.s3-ap-northeast-1.amazonaws.com/kvs-workshop/sample.mp4
+          ./${{ matrix.sample.name }} demo-stream-producer-cpp-${{ matrix.runner.id }}-ci-${{ matrix.sample.name }} ${{ matrix.sample.args }}
+
+      - name: Run ${{ matrix.sample.name }} (Windows)
+        if: runner.os == 'Windows'
+        env:
+          GST_PLUGIN_PATH: D:\producer\build
+          KVS_DEBUG_DUMP_DATA_FILE_DIR: D:\producer\debug_output
+        working-directory: D:\producer\build
+        run: |
+          # Equivalent to set -x
+          Set-PSDebug -Trace 1
+          
+          $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\producer\open-source\local\lib;D:\producer\open-source\local\bin;D:\gstreamer\1.0\msvc_x86_64\bin'
+          
+          mkdir D:\producer\debug_output
+          
+          Invoke-WebRequest -Uri https://awsj-iot-handson.s3-ap-northeast-1.amazonaws.com/kvs-workshop/sample.mp4 -OutFile sample.mp4
+          dir
+          $exePath = Join-Path $PWD ${{ matrix.sample.name }}.exe
+          & $exePath demo-stream-producer-cpp-${{ matrix.runner.id }}-ci-${{ matrix.sample.name }} ${{ matrix.sample.args }}
+
+      - name: Verify MKV dump (Mac & Linux)
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        working-directory: ./build/debug_output
+        run: |
+          shopt -s nullglob  # Ensure globbing works correctly and avoids errors when no files are found
+          
+          ls -tlrh
+          mkvfiles=(*.mkv)
+          if [ ${#mkvfiles[@]} -eq 0 ]; then
+            echo "No MKV files found in debug_output"
+            exit 1
+          fi
+          
+          for file in "${mkvfiles[@]}"; do
+            echo "Verifying $file with mkvinfo (verbose and hexdump):"
+            mkvinfo -v -X "$file"
+          done
+        shell: bash
+
+      - name: Verify MKV dump (Windows)
+        if: runner.os == 'Windows'
+        working-directory: D:\producer\build
+        run: |
+          $env:Path += ";C:\Program Files\MKVToolNix"
+          dir D:\producer\debug_output
+          $mkvFiles = Get-ChildItem -Path "D:\producer\debug_output" -Filter *.mkv
+          if ($mkvFiles.Count -eq 0) {
+            Write-Error "No MKV files found in D:\producer\build\debug_output"
+            exit 1
+          }
+          # Run mkvinfo on each MKV file
+          foreach ($file in $mkvFiles) {
+            Write-Output "Verifying $($file.FullName) with mkvinfo (verbose and hexdump):"
+            mkvinfo.exe -v -X "$($file.FullName)"
+          }
+
+  multistream-sample:
+    name: Multistream sample on Mac
+    runs-on: macos-13
+    timeout-minutes: 30
+
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+      KVS_DEBUG_DUMP_DATA_FILE_DIR: ${{ github.workspace }}/build/debug_output
+      GST_PLUGIN_PATH: ${{ github.workspace }}/build
+      DEBIAN_FRONTEND: noninteractive
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          brew install gstreamer log4cplus mkvtoolnix coreutils
+          brew install --cask docker
+
+      - name: Build samples
+        run: |
+          mkdir build && cd build
+          mkdir -p $KVS_DEBUG_DUMP_DATA_FILE_DIR
+          cmake .. -DBUILD_GSTREAMER_PLUGIN=ON -DBUILD_DEPENDENCIES=OFF
+          make -j$(nproc)
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+
+      - name: Run multistream sample
+        working-directory: ./build
+        run: |
+          set -x
+
+          open -a /Applications/Docker.app --args --unattended --accept-license
+          echo "We are waiting for Docker to be up and running. It can take over 2 minutes..."
+          while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do sleep 1; done
+
+          sudo ln -s ~/.docker/run/docker.sock /var/run/docker.sock
+          
+          docker run -d --rm -it -e RTSP_PROTOCOLS=tcp -p 8554:8554 bluenviron/mediamtx:latest
+          docker run -d --rm -it -e RTSP_PROTOCOLS=tcp -p 8555:8554 bluenviron/mediamtx:latest
+          
+          (
+            ffmpeg -re -f lavfi -i "testsrc=size=640x480:rate=10" -vcodec libx264 -x264-params keyint=25 -f rtsp rtsp://localhost:8554/mystream
+          ) &
+          (
+            ffmpeg -re -f lavfi -i "testsrc=size=640x480:rate=10" -vcodec libx264 -x264-params keyint=25 -f rtsp rtsp://localhost:8555/mystream
+          ) &
+          
+          echo "rtsp://0.0.0.0:8554/mystream" > rtsp-urls.txt
+          echo "rtsp://0.0.0.0:8555/mystream" >> rtsp-urls.txt
+          
+          sleep 10
+          gst-discoverer-1.0 rtsp://0.0.0.0:8554/mystream
+          gst-discoverer-1.0 rtsp://0.0.0.0:8555/mystream
+          
+          set +e  # Disable exit on error for the timeout command
+          gtimeout --preserve-status --signal=SIGINT --kill-after=15s 30s \
+            ./kvs_gstreamer_multistream_sample demo-stream-producer-cpp-macos-13-ci-kvs_gstreamer_multistream_sample rtsp-urls.txt
+          EXIT_CODE=$?
+          set -e  # Re-enable exit on error
+
+          # 130 (128 + 2): Process killed by SIGINT
+          # 137: Process killed by SIGKILL (if the --kill-after timeout is reached) 
+          echo "Command exited with code: $EXIT_CODE"
+          if [ $EXIT_CODE -ne 130 ]; then
+            echo "Command did not exit gracefully after interrupt."
+            exit 1
+          fi
+
+        shell: bash
+
+      - name: Verify MKV dump
+        working-directory: ./build/debug_output
+        run: |
+          shopt -s nullglob  # Ensure globbing works correctly and avoids errors when no files are found
+          
+          ls -tlrh
+          mkvfiles=(*.mkv)
+          if [ ${#mkvfiles[@]} -eq 0 ]; then
+            echo "No MKV files found in debug_output"
+            exit 1
+          fi
+          
+          found_0=0
+          found_1=0
+        
+          for file in "${mkvfiles[@]}"; do
+            if [[ "$file" == demo-stream-producer-cpp-macos-13-ci-kvs_gstreamer_multistream_sample_0* ]]; then
+              found_0=1
+            elif [[ "$file" == demo-stream-producer-cpp-macos-13-ci-kvs_gstreamer_multistream_sample_1* ]]; then
+              found_1=1
+            fi
+          done
+        
+          if [ $found_0 -eq 0 ] || [ $found_1 -eq 0 ]; then
+            echo "Expected at least one file starting with each prefix:"
+            echo "  - demo-stream-producer-cpp-macos-13-ci-kvs_gstreamer_multistream_sample_0"
+            echo "  - demo-stream-producer-cpp-macos-13-ci-kvs_gstreamer_multistream_sample_1"
+            exit 1
+          fi
+          
+          for file in "${mkvfiles[@]}"; do
+            echo "Verifying $file with mkvinfo (verbose and hexdump):"
+            mkvinfo -v -X "$file"
+          done
+        shell: bash

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -134,7 +134,7 @@ jobs:
           $exePath = Join-Path $PWD ${{ matrix.sample.name }}.exe
           & $exePath demo-stream-producer-cpp-${{ matrix.runner.id }}-ci-${{ matrix.sample.name }} ${{ matrix.sample.args }}
 
-      - name: Verify MKV dump (Mac & Linux)
+      - name: Verify MKV dump exists (Mac & Linux)
         if: runner.os == 'Linux' || runner.os == 'macOS'
         working-directory: ./build/debug_output
         run: |
@@ -153,7 +153,7 @@ jobs:
           done
         shell: bash
 
-      - name: Verify MKV dump (Windows)
+      - name: Verify MKV dump exists (Windows)
         if: runner.os == 'Windows'
         working-directory: D:\producer\build
         run: |
@@ -271,7 +271,7 @@ jobs:
 
         shell: bash
 
-      - name: Verify MKV dump
+      - name: Verify MKV dump exists
         working-directory: ./build/debug_output
         run: |
           shopt -s nullglob  # Ensure globbing works correctly and avoids errors when no files are found

--- a/samples/kvs_gstreamer_audio_video_sample.cpp
+++ b/samples/kvs_gstreamer_audio_video_sample.cpp
@@ -1011,7 +1011,7 @@ int main(int argc, char *argv[]) {
 
     if (argc < 2) {
         LOG_ERROR(
-                "Usage: AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kinesis_video_gstreamer_audio_video_sample_app my-stream-name /path/to/file"
+                "Usage: AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kinesis_video_gstreamer_audio_video_sample_app my-stream-name -f /path/to/file"
                         "AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kinesis_video_gstreamer_audio_video_sample_app my-stream-name");
         return 1;
     }

--- a/samples/kvs_gstreamer_multistream_sample.cpp
+++ b/samples/kvs_gstreamer_multistream_sample.cpp
@@ -261,6 +261,7 @@ static GstFlowReturn on_new_sample(GstElement *sink, CustomData *data) {
 
         buffer->pts += data->producer_start_time_map[stream_handle_key] - data->first_pts_map[stream_handle_key];
 
+        // Construct a monotonically increasing DTS if GStreamer doesn't provide one
         if (!GST_BUFFER_DTS_IS_VALID(buffer)) {
             buffer->dts = data->last_dts_map[stream_handle_key] + DEFAULT_FRAME_DURATION_MS * HUNDREDS_OF_NANOS_IN_A_MILLISECOND * DEFAULT_TIME_UNIT_IN_NANOS;
         }

--- a/samples/kvs_gstreamer_multistream_sample.cpp
+++ b/samples/kvs_gstreamer_multistream_sample.cpp
@@ -53,6 +53,7 @@ LOGGER_TAG("com.amazonaws.kinesis.video.gstreamer");
 #define DEFAULT_BUFFER_SIZE (1 * 1024 * 1024)
 #define DEFAULT_STORAGE_SIZE (128 * 1024 * 1024)
 #define DEFAULT_ROTATION_TIME_SECONDS 3600
+#define DEFAULT_FRAME_DURATION_MS 2
 
 namespace com { namespace amazonaws { namespace kinesis { namespace video {
 
@@ -180,6 +181,7 @@ typedef struct _CustomData {
     // Pts of first frame
     map<string, uint64_t> first_pts_map;
     map<string, uint64_t> producer_start_time_map;
+    map<string, uint64_t> last_dts_map;
 } CustomData;
 
 void create_kinesis_video_frame(Frame *frame, const nanoseconds &pts, const nanoseconds &dts, FRAME_FLAGS flags,
@@ -258,6 +260,12 @@ static GstFlowReturn on_new_sample(GstElement *sink, CustomData *data) {
         }
 
         buffer->pts += data->producer_start_time_map[stream_handle_key] - data->first_pts_map[stream_handle_key];
+
+        if (!GST_BUFFER_DTS_IS_VALID(buffer)) {
+            buffer->dts = data->last_dts_map[stream_handle_key] + DEFAULT_FRAME_DURATION_MS * HUNDREDS_OF_NANOS_IN_A_MILLISECOND * DEFAULT_TIME_UNIT_IN_NANOS;
+        }
+
+        data->last_dts_map[stream_handle_key] = buffer->dts;
 
         if (false == put_frame(data->kinesis_video_stream_handles[stream_handle_key], data->frame_data_map[stream_handle_key], buffer_size, std::chrono::nanoseconds(buffer->pts),
                                std::chrono::nanoseconds(buffer->dts), kinesis_video_flags)) {
@@ -405,7 +413,8 @@ int gstreamer_init(int argc, char *argv[]) {
     data.frame_data_map = map<string, uint8_t*>();
     data.frame_data_size_map = map<string, UINT32>();
     data.first_pts_map = map<string, uint64_t>();
-    data.producer_start_time_map = map<string, uint64_t>();;
+    data.producer_start_time_map = map<string, uint64_t>();
+    data.last_dts_map = map<string, uint64_t>();;
 
     /* init GStreamer */
     gst_init(&argc, &argv);

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -1313,6 +1313,7 @@ gst_kvs_sink_handle_buffer (GstCollectPads * pads,
                 buf->pts = buf->dts;
             }
         } else if (!GST_BUFFER_DTS_IS_VALID(buf)) {
+            // Construct a monotonically increasing DTS if GStreamer doesn't provide one
             buf->dts = data->last_dts + DEFAULT_FRAME_DURATION_MS * HUNDREDS_OF_NANOS_IN_A_MILLISECOND * DEFAULT_TIME_UNIT_IN_NANOS;
         }
 


### PR DESCRIPTION
*Issue #, if available:*
- #1227

*Description of changes:*
This PR introduces the following improvements and fixes:

* CI Enhancements

  * Added a new GitHub Actions workflow to validate the execution of sample applications across multiple platforms (Linux, macOS, Windows).
  * Ensured proper dependency installation and runtime configuration for GStreamer-based samples.
  * MKV file validation using mkvinfo and the debug MKV dump flag to confirm successful video ingestion.

* Bug Fixes
  * Fixed an issue related to invalid DTS handling in the multi-stream sample application. The same logic [exists in `kvssink`](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/blob/7acf272672ced72bbbad85fe39d366deca57280e/src/gstreamer/gstkvssink.cpp#L1315-L1319), so I just ported those changes over to this sample. Verified locally and through the CI that the media can now be uploaded, and checked playback from the AWS console.
<img width="1087" alt="image" src="https://github.com/user-attachments/assets/49d35a38-200c-4c22-a4ee-0102c8eda258" />

  * Resolved minor inconsistencies in CI scripts (e.g., unnecessary trailing spaces, formatting issues).

* Implementation notes
  * Currently, the multi-stream sample is only set up for the Mac runner. Expansion to windows & linux can be done in a future PR.
  * The new workflow has been optimized for speed for quicker testing/feedback cycle. Below is the github-generated report of how long each job took in total:

<img width="957" alt="image" src="https://github.com/user-attachments/assets/7f41184f-df05-4812-b586-2620391d5523" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
