### PR TITLE
Rpi CI: Downgrade qemu to v7

### DIFF
--- a/.github/workflows/raspberry-pi.yaml
+++ b/.github/workflows/raspberry-pi.yaml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -61,13 +63,13 @@ jobs:
                 gstreamer1.0-tools gstreamer1.0-omx-generic \
                 libcurl4-openssl-dev libgstreamer1.0-dev \
                 libgstreamer-plugins-base1.0-dev liblog4cplus-dev \
-                libssl-dev pkg-config openssl
+                libssl-dev pkg-config
 
               mkdir -p build
               cd build
 
               cmake .. -DBUILD_GSTREAMER_PLUGIN=ON -DBUILD_DEPENDENCIES=OFF -DALIGNED_MEMORY_MODEL=ON
-              make -j$(nproc)
+              make
 
               export GST_PLUGIN_PATH=$(pwd)
 


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*
- Downgrade to Qemu 7, as per https://github.com/docker/setup-qemu-action/issues/198 and https://github.com/tonistiigi/binfmt/issues/240.
- From the logs of the actions run of the pull request that added this, https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/pull/1222, the Qemu version it used was `qemu-v7.0.0-28`. The most recent runs are using `qemu-v9.2.0-51`.

```
/usr/bin/docker image inspect docker.io/tonistiigi/binfmt:latest
  [
      {
          "Id": "sha256:354472a378935adfe74a19600b89bd9ada7bb058306fff23b3d6613405852faf",
          "RepoTags": [
              "tonistiigi/binfmt:latest"
          ],
          "RepoDigests": [
              "tonistiigi/binfmt@sha256:66e11bea77a5ea9d6f0fe79b57cd2b189b5d15b93a2bdb925be22949232e4e55"
          ],
          "Parent": "",
          "Comment": "buildkit.dockerfile.v0",
          "Created": "2022-08-02T19:13:20.178433831Z",
          "DockerVersion": "",
          "Author": "",
          "Config": {
              "Hostname": "",
              "Domainname": "",
              "User": "",
              "AttachStdin": false,
              "AttachStdout": false,
              "AttachStderr": false,
              "Tty": false,
              "OpenStdin": false,
              "StdinOnce": false,
              "Env": [
                  "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                  "QEMU_PRESERVE_ARGV0=1"
              ],
              "Cmd": null,
              "Image": "",
              "Volumes": {
                  "/tmp": {}
              },
              "WorkingDir": "/",
              "Entrypoint": [
                  "/usr/bin/binfmt"
              ],
              "OnBuild": null,
              "Labels": {
                  "org.opencontainers.image.created": "2022-08-02T18:32:39.936Z",
                  "org.opencontainers.image.description": "Cross-platform emulator collection distributed with Docker images",
                  "org.opencontainers.image.licenses": "MIT",
                  "org.opencontainers.image.revision": "a161c41c7aeaf3ef1c5b97f91aa02a12cca73432",
                  "org.opencontainers.image.source": "https://github.com/tonistiigi/binfmt",
                  "org.opencontainers.image.title": "Binfmt",
                  "org.opencontainers.image.url": "https://github.com/tonistiigi/binfmt",
                  "org.opencontainers.image.version": "qemu-v7.0.0-28" <---------------------------------
              }
          },
          "Architecture": "amd64",
          "Os": "linux",
          "Size": 60182964,
          "GraphDriver": {
              "Data": {
                  "LowerDir": "/var/lib/docker/overlay2/e280275756b7d1a681087e6f0032f24c67d3ceac3b214cae1cadfac95ccfc74f/diff",
                  "MergedDir": "/var/lib/docker/overlay2/ff95d8d303fd77cf282d67afc39022dc1d35add[154](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/actions/runs/12683874801/job/35351644521#step:3:157)bd8297313febb73e6a2c96/merged",
                  "UpperDir": "/var/lib/docker/overlay2/ff95d8d303fd77cf282d67afc39022dc1d35add154bd8297313febb73e6a2c96/diff",
                  "WorkDir": "/var/lib/docker/overlay2/ff95d8d303fd77cf282d67afc39022dc1d35add154bd8297313febb73e6a2c96/work"
              },
              "Name": "overlay2"
          },
          "RootFS": {
              "Type": "layers",
              "Layers": [
                  "sha256:4c67e4044f8c0fe3e3efaf76f2a3d5d3d866f8ef2e8a9da756949d90e576baa0",
                  "sha256:949acf1cb73a60306e050836deb85a26fe23e226f6bcc499872b057efbf22dd1"
              ]
          },
          "Metadata": {
              "LastTagTime": "0001-01-01T00:00:00Z"
          }
      }
  ]
```
- The recent upgrade to Qemu 9 resulted in a segmentation fault during installation:
```
Setting up gir1.2-gst-plugins-base-1.0:arm64 (1.18.4-2+deb11u3) ...
Setting up libgstreamer-plugins-base1.0-dev:arm64 (1.18.4-2+deb11u3) ...
Processing triggers for libglib2.0-0:arm64 (2.66.8-1+deb11u5) ...
Processing triggers for libc-bin (2.31-13+rpt2+rpi1+deb11u11) ...
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
Segmentation fault (core dumped)
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
Segmentation fault (core dumped)
dpkg: error processing package libc-bin (--configure):
 installed libc-bin package post-installation script subprocess returned error exit status 139
Setting up glib-networking:arm64 (2.66.0-2) ...
Setting up libsoup2.4-1:arm64 (2.72.0-2+deb11u1) ...
Setting up gstreamer1.0-plugins-good:arm64 (1.18.4-2+deb11u2+rpt1) ...
Setting up libgssdp-1.2-0:arm64 (1.2.3-2) ...
Setting up libgupnp-1.2-0:arm64 (1.2.4-1) ...
Setting up libgupnp-igd-1.0-4:arm64 (1.2.0-1) ...
Setting up libnice10:arm64 (0.1.16-1) ...
Setting up gstreamer1.0-plugins-bad:arm64 (1.18.4-3+deb11u4) ...
Errors were encountered while processing:
 libc-bin
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

- Hardcode version of the `raspberrypi-os` docker image as well to avoid future breaking changes. The version used from logs of the original actions job is:
```
Digest: sha256:b01fce1a51e15fe4238e773a582fd1b60da5d7aa62b847f8b2640f910a83fc24
Status: Downloaded newer image for ghcr.io/dtcooper/raspberrypi-os:python3.12-bookworm
```

- Remove `-j N` to resolve intermittent segfault when compiling.
- Remove `openssl` install added in the previous pull request, it's not needed since the logs mention that openssl is already installed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
