### PR TITLE
Adding WSL checks for kvssink and samples

### DIFF
--- a/.github/workflows/kvssink.yml
+++ b/.github/workflows/kvssink.yml
@@ -365,6 +365,7 @@ jobs:
 
           if [[ $EXIT_CODE -ne 0 ]]; then
             echo "gst-launch-1.0 exited with status: $EXIT_CODE"
+            exit $EXIT_CODE
           fi
 
       - name: Verify MKV dump in WSL

--- a/.github/workflows/kvssink.yml
+++ b/.github/workflows/kvssink.yml
@@ -131,7 +131,7 @@ jobs:
             echo "No MKV files found in debug_output"
             exit 1
           fi
-          
+
           for file in "${mkvfiles[@]}"; do
             echo "Verifying $file with mkvinfo (verbose and hexdump):"
             mkvinfo -v -X "$file"
@@ -165,7 +165,7 @@ jobs:
             gstreamer1.0-tools \
             libcurl4-openssl-dev libgstreamer1.0-dev \
             libgstreamer-plugins-base1.0-dev liblog4cplus-dev \
-            libssl-dev pkg-config mkvtoolnix 
+            libssl-dev pkg-config mkvtoolnix
 
       - name: Setup build directory
         run: |
@@ -253,10 +253,10 @@ jobs:
         working-directory: D:\producer\build\
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\producer\open-source\local\lib;D:\producer\open-source\local\bin;D:\gstreamer\1.0\msvc_x86_64\bin'
-          
+
           # Create the debug directory (equivalent to mkdir -p)
           New-Item -ItemType Directory -Path "D:\producer\build\debug_output" -Force
-          
+
           # Stream for 15 seconds (450 frames @ 30 fps)
           gst-launch-1.0.exe videotestsrc is-live=true num-buffers=450 ! video/x-raw,framerate=30/1,width=640,height=480 ! videoconvert ! x264enc tune=zerolatency key-int-max=45 ! h264parse ! kvssink stream-name="demo-stream"
       - name: Verify MKV dump
@@ -275,3 +275,107 @@ jobs:
             Write-Output "Verifying $($file.FullName) with mkvinfo (verbose and hexdump):"
             mkvinfo.exe -v -X "$($file.FullName)"
           }
+
+  wsl-debug-dump-dir:
+    runs-on: windows-2022
+    env:
+      AWS_KVS_LOG_LEVEL: 1
+    strategy:
+      matrix:
+        image:
+          - Ubuntu-22.04
+          - Ubuntu-24.04
+      fail-fast: false
+    defaults:
+      run:
+        shell: wsl-bash {0}  # Automatically uses wsl-bash for each run step
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: Vampire/setup-wsl@v4
+        with:
+          distribution: ${{ matrix.image }}
+          additional-packages: |
+            automake
+            build-essential
+            cmake
+            git
+            gstreamer1.0-plugins-base-apps
+            gstreamer1.0-plugins-bad
+            gstreamer1.0-plugins-good
+            gstreamer1.0-plugins-ugly
+            gstreamer1.0-tools
+            libcurl4-openssl-dev
+            libgstreamer1.0-dev
+            libgstreamer-plugins-base1.0-dev
+            liblog4cplus-dev
+            libssl-dev
+            pkg-config
+            mkvtoolnix
+          use-cache: 'false' # Cache entry for Ubuntu 22.04 and 24.04 are the same (conflict)
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Move repository in WSL
+        run: |
+          # Copy to ~/kvs-cpp-repo for simplicity
+          # Note: Can't move due to no permissions
+          REPO_NAME=$(basename ${{ github.repository }})
+          cp -r /mnt/d/a/$REPO_NAME/$REPO_NAME ~/kvs-cpp-repo
+
+      - name: Build kvssink in WSL
+        run: |
+          mkdir -p ~/kvs-cpp-repo/build
+          cd ~/kvs-cpp-repo/build
+          cmake .. -DBUILD_GSTREAMER_PLUGIN=ON -DALIGNED_MEMORY_MODEL=ON -DBUILD_DEPENDENCIES=OFF
+          make -j$(nproc)
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 900
+
+      - name: Run kvssink with dump dir in WSL
+        run: |
+          mkdir -p ~/kvs-cpp-repo/build/debug_output
+          export GST_PLUGIN_PATH=~/kvs-cpp-repo/build
+          export KVS_DEBUG_DUMP_DATA_FILE_DIR=~/kvs-cpp-repo/build/debug_output
+
+          set +e  # Disable exit on error for the timeout command
+          # Note: `env.` syntax to reference credentials to have GitHub Actions inject
+          # the secret values into these environment variables before the command runs,
+          # since the WSL shell doesn't have access to GitHub's environment variables
+          timeout --preserve-status --signal=SIGINT --kill-after=15s 30s \
+            gst-launch-1.0 videotestsrc is-live=true num-buffers=450 \
+              ! video/x-raw,framerate=30/1,width=640,height=480 \
+              ! videoconvert ! x264enc tune=zerolatency key-int-max=45 \
+              ! h264parse \
+              ! kvssink stream-name='demo-stream-cpp-kvssink-ci-wsl-videotestsrc-${{ matrix.image }}' \
+                  aws-region=${{ env.AWS_DEFAULT_REGION }} \
+                  access-key=${{ env.AWS_ACCESS_KEY_ID }} \
+                  secret-key=${{ env.AWS_SECRET_ACCESS_KEY }} \
+                  session-token=${{ env.AWS_SESSION_TOKEN }}
+          EXIT_CODE=$?
+          set -e  # Re-enable exit on error
+
+          if [[ $EXIT_CODE -ne 0 ]]; then
+            echo "gst-launch-1.0 exited with status: $EXIT_CODE"
+          fi
+
+      - name: Verify MKV dump in WSL
+        run: |
+          cd ~/kvs-cpp-repo/build/debug_output
+          mkvfiles=($(ls *.mkv 2>/dev/null))
+          if [ ${#mkvfiles[@]} -eq 0 ]; then
+            echo 'No MKV files found in debug_output'
+            exit 1
+          fi
+          for file in "${mkvfiles[@]}"; do
+            echo "Verifying $file with mkvinfo:"
+            mkvinfo -v -X "$file"
+          done

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -416,6 +416,7 @@ jobs:
           
           if [[ EXIT_CODE -ne 0 ]]; then
             echo "${{ matrix.sample.name }} exited with code: $EXIT_CODE"
+            exit $EXIT_CODE
           fi
 
       - name: Verify MKV dump exists (WSL)

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -262,7 +262,7 @@ jobs:
           set -e  # Re-enable exit on error
 
           # 130 (128 + 2): Process killed by SIGINT
-          # 137: Process killed by SIGKILL (if the --kill-after timeout is reached) 
+          # 137: Process killed by SIGKILL (if the --kill-after timeout is reached)
           echo "Command exited with code: $EXIT_CODE"
           if [ $EXIT_CODE -ne 130 ]; then
             echo "Command did not exit gracefully after interrupt."
@@ -275,18 +275,18 @@ jobs:
         working-directory: ./build/debug_output
         run: |
           shopt -s nullglob  # Ensure globbing works correctly and avoids errors when no files are found
-          
+
           ls -tlrh
           mkvfiles=(*.mkv)
           if [ ${#mkvfiles[@]} -eq 0 ]; then
             echo "No MKV files found in debug_output"
             exit 1
           fi
-          
+
           # Since there are 2 streams, check for the presence of two different prefixed MKV files
           found_0=0
           found_1=0
-        
+
           for file in "${mkvfiles[@]}"; do
             if [[ "$file" == ${KVS_STREAM_NAME_BASE}_0* ]]; then
               found_0=1
@@ -294,16 +294,143 @@ jobs:
               found_1=1
             fi
           done
-        
+
           if [ $found_0 -eq 0 ] || [ $found_1 -eq 0 ]; then
             echo "Expected at least one file starting with each prefix:"
             echo "  - ${KVS_STREAM_NAME_BASE}_0"
             echo "  - ${KVS_STREAM_NAME_BASE}_1"
             exit 1
           fi
-          
+
           for file in "${mkvfiles[@]}"; do
             echo "Verifying $file with mkvinfo (verbose and hexdump):"
             mkvinfo -v -X "$file"
           done
         shell: bash
+
+  wsl-sample-checks:
+    name: WSL ${{ matrix.image }} - ${{ matrix.sample.name }}
+
+    strategy:
+      matrix:
+        sample:
+          - name: kvs_gstreamer_audio_video_sample
+            args: -f sample.mp4
+          - name: kvs_gstreamer_file_uploader_sample
+            args: sample.mp4 0 audio-video
+          - name: kvs_gstreamer_sample
+            args: sample.mp4
+          - name: kvssink_gstreamer_sample
+            args: sample.mp4
+        image:
+          - Ubuntu-22.04
+          - Ubuntu-24.04
+
+      fail-fast: false
+
+    runs-on: windows-2022
+    timeout-minutes: 30
+
+    permissions:
+      id-token: write
+      contents: read
+
+    defaults:
+      run:
+        shell: wsl-bash {0}  # Automatically uses wsl-bash for each run step
+
+    steps:
+      - uses: Vampire/setup-wsl@v4
+        with:
+          distribution: ${{ matrix.image }}
+          additional-packages: |
+            automake
+            build-essential
+            cmake
+            git
+            gstreamer1.0-plugins-base-apps
+            gstreamer1.0-plugins-bad
+            gstreamer1.0-plugins-good
+            gstreamer1.0-plugins-ugly
+            gstreamer1.0-tools
+            libcurl4-openssl-dev
+            libgstreamer1.0-dev
+            libgstreamer-plugins-base1.0-dev
+            liblog4cplus-dev
+            libssl-dev
+            pkg-config
+            mkvtoolnix
+          use-cache: 'false' # Cache entry for Ubuntu 22.04 and 24.04 are the same (conflict)
+
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Move repository in WSL
+        run: |
+          # Copy to ~/kvs-cpp-repo for simplicity
+          # Note: Can't move due to no permissions
+          REPO_NAME=$(basename ${{ github.repository }})
+          cp -r /mnt/d/a/$REPO_NAME/$REPO_NAME ~/kvs-cpp-repo
+
+      - name: Build samples in WSL
+        run: |
+          mkdir -p ~/kvs-cpp-repo/build
+          cd ~/kvs-cpp-repo/build
+          cmake .. -DBUILD_GSTREAMER_PLUGIN=ON -DALIGNED_MEMORY_MODEL=ON -DBUILD_DEPENDENCIES=OFF
+          make -j$(nproc)
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 900
+
+      - name: Run ${{ matrix.sample.name }} (WSL)
+        run: |
+          cd ~/kvs-cpp-repo/build
+          export KVS_DEBUG_DUMP_DATA_FILE_DIR=~/kvs-cpp-repo/build/debug_output
+          mkdir "$KVS_DEBUG_DUMP_DATA_FILE_DIR"
+          export GST_PLUGIN_PATH=~/kvs-cpp-repo/build
+          export AWS_KVS_LOG_LEVEL=2
+
+          curl -fsSL -o sample.mp4 https://awsj-iot-handson.s3-ap-northeast-1.amazonaws.com/kvs-workshop/sample.mp4
+
+          # Note: `env.` syntax to reference credentials to have GitHub Actions inject
+          # the secret values into these environment variables before the command runs,
+          # since the WSL shell doesn't have access to GitHub's environment variables
+          export AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}
+          export AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
+          export AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
+          export AWS_DEFAULT_REGION=${{ env.AWS_DEFAULT_REGION }}
+          
+          set +e  # Disable exit on error for the timeout command
+          ./${{ matrix.sample.name }} demo-stream-producer-cpp-wsl-${{ matrix.image }}-ci-${{ matrix.sample.name }} ${{ matrix.sample.args }}
+          EXIT_CODE=$?
+          set -e  # Re-enable exit on error
+          
+          unset AWS_ACCESS_KEY_ID
+          unset AWS_SECRET_ACCESS_KEY
+          unset AWS_SESSION_TOKEN
+          
+          if [[ EXIT_CODE -ne 0 ]]; then
+            echo "${{ matrix.sample.name }} exited with code: $EXIT_CODE"
+          fi
+
+      - name: Verify MKV dump exists (WSL)
+        run: |
+          cd ~/kvs-cpp-repo/build/debug_output
+          shopt -s nullglob  # Ensure globbing works correctly and avoids errors when no files are found
+
+          ls -tlrh
+          mkvfiles=(*.mkv)
+          if [ ${#mkvfiles[@]} -eq 0 ]; then
+            echo "No MKV files found in debug_output"
+            exit 1
+          fi
+
+          for file in "${mkvfiles[@]}"; do
+            echo "Verifying $file with mkvinfo (verbose and hexdump):"
+            mkvinfo -v -X "$file"
+          done


### PR DESCRIPTION
*Issue #, if available:*
- No specific issue number
- Addresses report of kvssink functionality issues in WSL environment (#1223)

*What was changed?*
Added two GitHub Actions workflows to validate Kinesis Video Stream SDK functionality in Windows Subsystem for Linux (WSL):
- A WSL sample check workflow that tests multiple sample applications (8 jobs)
- A targeted kvssink debug verification workflow that validates proper MKV output generation (2 jobs)

Total: 10 combinations

*Why was it changed?*
To proactively validate WSL compatibility in Windows Subsystem for Linux (WSL) environments. This ensures the SDK meets customer expectations across development environments, including Windows+WSL setup.

*How was it changed?*
Implemented two GitHub Actions workflows that:
- Test on both Ubuntu 22.04 and 24.04 WSL distributions
- Build the C++ producer SDK with GStreamer plugin kvssink
- Execute sample applications (4) and the kvssink GStreamer element with AWS credentials
- Verify that the MKV debug dump can be generated and can be parsed by `mkvinfo`

*What testing was done for the changes?*
The changes themselves implement testing. The workflows have been executed and verified to pass in a forked environment, confirming:
- Successful building of the SDK in WSL Ubuntu 22.04 and 24.04 environments
- Proper execution of samples and kvssink
- MKV file generation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
