### PR TITLE
JNI Builds Enhancements & CMake Dependency Enhancements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,14 @@ jobs:
 
   mac-os-build-gcc:
     runs-on: macos-13
+    strategy:
+      matrix:
+        parallel-build:
+          - ON
+          - OFF
+
+      fail-fast: false
+
     permissions:
       id-token: write
       contents: read
@@ -62,10 +70,17 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DCMAKE_INSTALL_PREFIX=.
-          make
-          make install
+          cmake .. -DBUILD_TEST=TRUE -DCMAKE_INSTALL_PREFIX=. -DPARALLEL_BUILD=${{ matrix.parallel-build }}
+
+          if [[ "${{ matrix.parallel-build }}" == 'ON' ]]; then
+            make
+            make -j install
+          else
+            make
+            make install
+          fi
       - name: Configure AWS Credentials
+        if: ${{ matrix.parallel-build == 'ON' }} # Only need to run the tests once
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
@@ -73,6 +88,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           role-duration-seconds: 10800
       - name: Run tests
+        if: ${{ matrix.parallel-build == 'ON' }}
         run: |
           cd build
           ./tst/producerTest
@@ -242,6 +258,15 @@ jobs:
 
   ubuntu-gcc:
     runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        parallel-build:
+          - ON
+          - OFF
+
+      fail-fast: false
+
     env:
       AWS_KVS_LOG_LEVEL: 2
       CC: gcc
@@ -260,10 +285,16 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE -DCMAKE_INSTALL_PREFIX=.
-          make
-          make install
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_GSTREAMER_PLUGIN=TRUE -DBUILD_JNI=TRUE -DCMAKE_INSTALL_PREFIX=. -DPARALLEL_BUILD=${{ matrix.parallel-build }}
+          
+          if [[ "${{ matrix.parallel-build }}" == 'ON' ]]; then
+            make -j install
+          else
+            make install
+          fi
+
       - name: Configure AWS Credentials
+        if: ${{ matrix.parallel-build == 'ON' }} # Only need to run the tests once
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
@@ -271,6 +302,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           role-duration-seconds: 10800
       - name: Run tests
+        if: ${{ matrix.parallel-build == 'ON' }}
         run: |
           cd build
           ulimit -c unlimited -S

--- a/.github/workflows/jni.yml
+++ b/.github/workflows/jni.yml
@@ -1,0 +1,76 @@
+name: Producer CPP JNI Builds
+
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
+    branches:
+      - develop
+      - master
+
+jobs:
+  mac-os:
+    strategy:
+      matrix:
+        config:
+          - name: Intel x86_64
+            runner: macos-13
+          - name: Apple Silicon
+            runner: macos-15
+          - name: Ubuntu 22.04
+            runner: ubuntu-latest
+            container: public.ecr.aws/ubuntu/ubuntu:22.04_stable
+          - name: Ubuntu 20.04
+            runner: ubuntu-latest
+            container: public.ecr.aws/ubuntu/ubuntu:20.04_stable
+
+        java:
+          - 11
+          - 17
+          - 21
+
+      fail-fast: false
+
+    name: JNI ${{ matrix.config.name }} (Java ${{ matrix.java }})
+    runs-on: ${{ matrix.config.runner }}
+    container: ${{ matrix.config.container || '' }}
+
+    env:
+      DEBIAN_FRONTEND: noninteractive
+
+    steps:
+      - name: Setup XCode
+        if: ${{ runner.os == 'macOS' }}
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Install Dependencies (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          apt-get update
+          apt-get install -y git cmake build-essential
+
+      - name: Set up Java (JDK ${{ matrix.java }})
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: ${{ matrix.java }}
+
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Build JNI (CMake)
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_JNI_ONLY=ON
+
+          # Note: Dependencies on/off shouldn't make any difference since
+          # the only dependency for the JNI is PIC
+
+      - name: Build JNI (make)
+        working-directory: ./build
+        run: |
+          make -j

--- a/CMake/Dependencies/libautoconf-CMakeLists.txt
+++ b/CMake/Dependencies/libautoconf-CMakeLists.txt
@@ -7,6 +7,8 @@ find_program(MAKE_EXE NAMES make)
 include(ExternalProject)
 ExternalProject_Add(project_libautoconf
     URL               http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
+    GIT_SHALLOW       TRUE
+    GIT_PROGRESS      TRUE
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CONFIGURE_COMMAND ${CMAKE_CURRENT_BINARY_DIR}/build/src/project_libautoconf/configure --prefix=${OPEN_SRC_INSTALL_PREFIX}
     BUILD_COMMAND     ${MAKE_EXE} -j 4

--- a/CMake/Dependencies/libautomake-CMakeLists.txt
+++ b/CMake/Dependencies/libautomake-CMakeLists.txt
@@ -7,6 +7,8 @@ find_program(MAKE_EXE NAMES make)
 include(ExternalProject)
 ExternalProject_Add(project_libautomake
     URL               http://ftp.gnu.org/gnu/automake/automake-1.16.1.tar.gz
+    GIT_SHALLOW       TRUE
+    GIT_PROGRESS      TRUE
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CONFIGURE_COMMAND ${CMAKE_CURRENT_BINARY_DIR}/build/src/project_libautomake/configure --prefix=${OPEN_SRC_INSTALL_PREFIX}
     BUILD_COMMAND     ${MAKE_EXE} -j 4

--- a/CMake/Dependencies/libkvscproducer-CMakeLists.txt
+++ b/CMake/Dependencies/libkvscproducer-CMakeLists.txt
@@ -8,6 +8,8 @@ include(ExternalProject)
 ExternalProject_Add(libkvscproducer-download
 	GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-producer-c.git
 	GIT_TAG           v1.5.3
+    GIT_SHALLOW       TRUE
+    GIT_PROGRESS      TRUE
 	SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvscproducer-src"
 	BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvscproducer-build"
 	CONFIGURE_COMMAND ""

--- a/CMake/Dependencies/libkvspic-CMakeLists.txt
+++ b/CMake/Dependencies/libkvspic-CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.6.3)
+
+project(libkvspic-download LANGUAGES C)
+
+include(ExternalProject)
+
+# Normally, PIC is built through Producer-C
+# When building the JNI only, Producer-C is not used at all, meaning
+# that we need to download PIC directly.
+ExternalProject_Add(libkvspic-download
+	GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-pic.git
+	GIT_TAG           v1.2.0
+    GIT_SHALLOW       TRUE
+    GIT_PROGRESS      TRUE
+    SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-src"
+	BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-build"
+	CMAKE_ARGS
+	  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+	CONFIGURE_COMMAND ""
+	BUILD_COMMAND     ""
+	INSTALL_COMMAND   ""
+	TEST_COMMAND      ""
+)

--- a/CMake/Dependencies/liblog4cplus-CMakeLists.txt
+++ b/CMake/Dependencies/liblog4cplus-CMakeLists.txt
@@ -26,6 +26,8 @@ if (WIN32)
   ExternalProject_Add(project_log4cplus
       GIT_REPOSITORY    https://github.com/log4cplus/log4cplus
       GIT_TAG           REL_2_0_1
+      GIT_SHALLOW       TRUE
+      GIT_PROGRESS      TRUE
       PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
       TEST_COMMAND      ""
       CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX} -DLOG4CPLUS_BUILD_TESTING=0 -DLOG4CPLUS_BUILD_LOGGINGSERVER=0 -DUNICODE=0 -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
@@ -34,6 +36,8 @@ else()
   ExternalProject_Add(project_log4cplus
        GIT_REPOSITORY    https://github.com/log4cplus/log4cplus
        GIT_TAG           REL_2_0_1
+       GIT_SHALLOW       TRUE
+       GIT_PROGRESS      TRUE
        PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
        CONFIGURE_COMMAND ${CONFIGURE_COMMAND}
        BUILD_COMMAND     ${MAKE_EXE}

--- a/CMake/Utilities.cmake
+++ b/CMake/Utilities.cmake
@@ -9,7 +9,7 @@ function(fetch_repo lib_name)
     return()
   endif()
 
-  if (WIN32)
+  if (WIN32 OR NOT PARALLEL_BUILD)
     set(PARALLEL_BUILD "")  # No parallel build for Windows
   else()
     set(PARALLEL_BUILD "--parallel")  # Enable parallel builds for Unix-like systems
@@ -81,7 +81,7 @@ function(build_dependency lib_name)
 
   file(REMOVE_RECURSE ${KINESIS_VIDEO_OPEN_SOURCE_SRC}/lib${lib_name})
 
-  if (WIN32)
+  if (WIN32 OR NOT PARALLEL_BUILD)
     set(PARALLEL_BUILD "")  # No parallel build for Windows
   else()
     set(PARALLEL_BUILD "--parallel")  # Enable parallel builds for Unix-like systems

--- a/CMake/Utilities.cmake
+++ b/CMake/Utilities.cmake
@@ -1,11 +1,18 @@
 # only fetch target repo for add_subdirectory later
 function(fetch_repo lib_name)
   set(supported_libs
+      kvspic
       kvscproducer)
   list(FIND supported_libs ${lib_name} index)
   if(${index} EQUAL -1)
     message(WARNING "${lib_name} is not supported for fetch_repo")
     return()
+  endif()
+
+  if (WIN32)
+    set(PARALLEL_BUILD "")  # No parallel build for Windows
+  else()
+    set(PARALLEL_BUILD "--parallel")  # Enable parallel builds for Unix-like systems
   endif()
 
   # build library
@@ -21,7 +28,7 @@ function(fetch_repo lib_name)
     message(FATAL_ERROR "CMake step for lib${lib_name} failed: ${result}")
   endif()
   execute_process(
-    COMMAND ${CMAKE_COMMAND} --build .
+    COMMAND ${CMAKE_COMMAND} --build . ${PARALLEL_BUILD}
     RESULT_VARIABLE result
     WORKING_DIRECTORY ${DEPENDENCY_DOWNLOAD_PATH}/lib${lib_name})
   if(result)
@@ -34,6 +41,7 @@ function(build_dependency lib_name)
   set(supported_libs
       autoconf
       automake
+      kvspic
       log4cplus)
   list(FIND supported_libs ${lib_name} index)
   if(${index} EQUAL -1)
@@ -73,6 +81,12 @@ function(build_dependency lib_name)
 
   file(REMOVE_RECURSE ${KINESIS_VIDEO_OPEN_SOURCE_SRC}/lib${lib_name})
 
+  if (WIN32)
+    set(PARALLEL_BUILD "")  # No parallel build for Windows
+  else()
+    set(PARALLEL_BUILD "--parallel")  # Enable parallel builds for Unix-like systems
+  endif()
+
   # build library
   configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/CMake/Dependencies/lib${lib_name}-CMakeLists.txt
@@ -87,7 +101,7 @@ function(build_dependency lib_name)
     message(FATAL_ERROR "CMake step for lib${lib_name} failed: ${result}")
   endif()
   execute_process(
-    COMMAND ${CMAKE_COMMAND} --build .
+    COMMAND ${CMAKE_COMMAND} --build . ${PARALLEL_BUILD}
     RESULT_VARIABLE result
     WORKING_DIRECTORY ${KINESIS_VIDEO_OPEN_SOURCE_SRC}/lib${lib_name})
   if(result)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ option(ADD_MUCLIBC "Add -muclibc c flag" OFF)
 option(BUILD_DEPENDENCIES "Whether or not to build depending libraries from source" ON)
 option(BUILD_OPENSSL_PLATFORM "If buildng OpenSSL what is the target platform" OFF)
 option(BUILD_LOG4CPLUS_HOST "Specify host-name for log4cplus for cross-compilation" OFF)
+option(PARALLEL_BUILD "Build dependencies with parallel flag" ON)
 
 # Developer Flags
 option(BUILD_TEST "Build the testing tree" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,14 +203,16 @@ if (NOT BUILD_JNI_ONLY)
       RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 endif()
 
-if(BUILD_JNI OR BUILD_JNI_ONLY)
+if (BUILD_JNI_ONLY)
   set(DEPENDENCY_DOWNLOAD_PATH ${CMAKE_CURRENT_SOURCE_DIR}/dependency)
   set(BUILD_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
   fetch_repo(kvspic ${BUILD_ARGS})
   add_subdirectory("${DEPENDENCY_DOWNLOAD_PATH}/libkvspic/kvspic-src")
   file(GLOB PIC_HEADERS "${pic_project_SOURCE_DIR}/src/*/include")
   include_directories("${PIC_HEADERS}")
+endif()
 
+if(BUILD_JNI OR BUILD_JNI_ONLY)
   find_package(JNI REQUIRED)
   include_directories(${JNI_INCLUDE_DIRS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,12 @@ include(GNUInstallDirs)
 # User Flags
 option(BUILD_GSTREAMER_PLUGIN "Build kvssink GStreamer plugin" OFF)
 option(BUILD_JNI "Build C++ wrapper for JNI to expose the functionality to Java/Android" OFF)
+option(BUILD_JNI_ONLY "Build ONLY the JNI, don't build C++ Producer SDK" OFF)
 option(BUILD_STATIC "Build with static linkage" OFF)
 option(ADD_MUCLIBC "Add -muclibc c flag" OFF)
 option(BUILD_DEPENDENCIES "Whether or not to build depending libraries from source" ON)
 option(BUILD_OPENSSL_PLATFORM "If buildng OpenSSL what is the target platform" OFF)
 option(BUILD_LOG4CPLUS_HOST "Specify host-name for log4cplus for cross-compilation" OFF)
-
 
 # Developer Flags
 option(BUILD_TEST "Build the testing tree" OFF)
@@ -57,80 +57,81 @@ add_definitions(-DKVS_CA_CERT_PATH="${CMAKE_CURRENT_SOURCE_DIR}/certs/cert.pem")
 add_definitions(-DCMAKE_DETECTED_CACERT_PATH)
 
 
-if(BUILD_DEPENDENCIES)
-  if(NOT EXISTS ${KINESIS_VIDEO_OPEN_SOURCE_SRC})
-    file(MAKE_DIRECTORY ${KINESIS_VIDEO_OPEN_SOURCE_SRC}/local)
+if(NOT BUILD_JNI_ONLY)
+  if(BUILD_DEPENDENCIES)
+    if(NOT EXISTS ${KINESIS_VIDEO_OPEN_SOURCE_SRC})
+      file(MAKE_DIRECTORY ${KINESIS_VIDEO_OPEN_SOURCE_SRC}/local)
+    endif()
+
+    if (NOT OPEN_SRC_INSTALL_PREFIX)
+      set(OPEN_SRC_INSTALL_PREFIX ${KINESIS_VIDEO_OPEN_SOURCE_SRC}/local)
+      set(ENV{PKG_CONFIG_PATH}
+            "$ENV{PKG_CONFIG_PATH}:${OPEN_SRC_INSTALL_PREFIX}/lib/pkgconfig")
+      set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${OPEN_SRC_INSTALL_PREFIX})
+      set(ENV{PATH} "$ENV{PATH}:${OPEN_SRC_INSTALL_PREFIX}/bin")
+    endif()
+
+
+    message(STATUS "Begin building dependencies.")
+    if (NOT WIN32)
+      build_dependency(autoconf)
+      build_dependency(automake)
+    endif()
+
+    if(BUILD_LOG4CPLUS_HOST)
+      set(BUILD_ARGS -DBUILD_LOG4CPLUS_HOST=${BUILD_LOG4CPLUS_HOST})
+      build_dependency(log4cplus ${BUILD_ARGS} -DBUILD_STATIC=${BUILD_STATIC})
+    else()
+      build_dependency(log4cplus -DBUILD_STATIC=${BUILD_STATIC})
+    endif()
+
+    message(STATUS "Finished building dependencies.")
   endif()
 
-  if (NOT OPEN_SRC_INSTALL_PREFIX)
-    set(OPEN_SRC_INSTALL_PREFIX ${KINESIS_VIDEO_OPEN_SOURCE_SRC}/local)
-    set(ENV{PKG_CONFIG_PATH}
-          "$ENV{PKG_CONFIG_PATH}:${OPEN_SRC_INSTALL_PREFIX}/lib/pkgconfig")
-    set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${OPEN_SRC_INSTALL_PREFIX})
-    set(ENV{PATH} "$ENV{PATH}:${OPEN_SRC_INSTALL_PREFIX}/bin")
+  set(BUILD_COMMON_LWS
+      FALSE
+      CACHE BOOL "Build ProducerC without LWS Support" FORCE)
+  set(BUILD_COMMON_CURL
+      TRUE
+      CACHE BOOL "Build ProducerC with CURL Support" FORCE)
+  set(DEPENDENCY_DOWNLOAD_PATH ${CMAKE_CURRENT_SOURCE_DIR}/dependency)
+  if(NOT EXISTS ${DEPENDENCY_DOWNLOAD_PATH})
+    file(MAKE_DIRECTORY ${DEPENDENCY_DOWNLOAD_PATH})
   endif()
 
+  fetch_repo(kvscproducer)
+  add_subdirectory(${DEPENDENCY_DOWNLOAD_PATH}/libkvscproducer/kvscproducer-src EXCLUDE_FROM_ALL)
+  ############# find dependent libraries ############
 
-  message(STATUS "Begin building dependencies.")
+  find_package(Threads)
+  find_package(PkgConfig REQUIRED)
 
-  if (NOT WIN32)
-    build_dependency(autoconf)
-    build_dependency(automake)
-  endif()
-  
-  if(BUILD_LOG4CPLUS_HOST)
-    set(BUILD_ARGS -DBUILD_LOG4CPLUS_HOST=${BUILD_LOG4CPLUS_HOST})
-    build_dependency(log4cplus ${BUILD_ARGS} -DBUILD_STATIC=${BUILD_STATIC})
+  if (OPEN_SRC_INSTALL_PREFIX)
+    find_package(CURL REQUIRED PATHS ${OPEN_SRC_INSTALL_PREFIX})
   else()
-    build_dependency(log4cplus -DBUILD_STATIC=${BUILD_STATIC})
+    find_package(CURL REQUIRED)
   endif()
 
-  message(STATUS "Finished building dependencies.")
-endif()
+  set(OPEN_SRC_INCLUDE_DIRS ${OPEN_SRC_INCLUDE_DIRS} ${CURL_INCLUDE_DIRS})
+  link_directories(${CURL_LIBRARY_DIRS})
 
-set(BUILD_COMMON_LWS
-    FALSE
-    CACHE BOOL "Build ProducerC without LWS Support" FORCE)
-set(BUILD_COMMON_CURL
-    TRUE
-    CACHE BOOL "Build ProducerC with CURL Support" FORCE)
-set(DEPENDENCY_DOWNLOAD_PATH ${CMAKE_CURRENT_SOURCE_DIR}/dependency)
-if(NOT EXISTS ${DEPENDENCY_DOWNLOAD_PATH})
-  file(MAKE_DIRECTORY ${DEPENDENCY_DOWNLOAD_PATH})
-endif()
-fetch_repo(kvscproducer)
-add_subdirectory(${DEPENDENCY_DOWNLOAD_PATH}/libkvscproducer/kvscproducer-src EXCLUDE_FROM_ALL)
-
-############# find dependent libraries ############
-
-find_package(Threads)
-find_package(PkgConfig REQUIRED)
-
-if (OPEN_SRC_INSTALL_PREFIX)
-  find_package(CURL REQUIRED PATHS ${OPEN_SRC_INSTALL_PREFIX})
-else()
-  find_package(CURL REQUIRED)
-endif()
-
-set(OPEN_SRC_INCLUDE_DIRS ${OPEN_SRC_INCLUDE_DIRS} ${CURL_INCLUDE_DIRS})
-link_directories(${CURL_LIBRARY_DIRS})
-
-if (WIN32)
-  find_package(Log4cplus
-    NAMES log4cplus REQUIRED
-    PATHS ${OPEN_SRC_INSTALL_PREFIX}/lib)
-  SET(Log4cplus "log4cplus::log4cplus")
-else()
-  find_package(Log4cplus REQUIRED)
-  include_directories(${LOG4CPLUS_INCLUDE_DIR})
-  set(Log4cplus ${LOG4CPLUS_LIBRARIES})
-endif()
-
-if (WIN32)
-  if(EXISTS "C:\\gstreamer\\1.0\\msvc_x86_64\\bin\\pkg-config.exe")
-    set(PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\msvc_x86_64\\bin\\pkg-config.exe")
+  if (WIN32)
+    find_package(Log4cplus
+      NAMES log4cplus REQUIRED
+      PATHS ${OPEN_SRC_INSTALL_PREFIX}/lib)
+    SET(Log4cplus "log4cplus::log4cplus")
   else()
-    set(PKG_CONFIG_EXECUTABLE "D:\\gstreamer\\1.0\\msvc_x86_64\\bin\\pkg-config.exe")
+    find_package(Log4cplus REQUIRED)
+    include_directories(${LOG4CPLUS_INCLUDE_DIR})
+    set(Log4cplus ${LOG4CPLUS_LIBRARIES})
+  endif()
+
+  if (WIN32)
+    if(EXISTS "C:\\gstreamer\\1.0\\msvc_x86_64\\bin\\pkg-config.exe")
+      set(PKG_CONFIG_EXECUTABLE "C:\\gstreamer\\1.0\\msvc_x86_64\\bin\\pkg-config.exe")
+    else()
+      set(PKG_CONFIG_EXECUTABLE "D:\\gstreamer\\1.0\\msvc_x86_64\\bin\\pkg-config.exe")
+    endif()
   endif()
 endif()
 
@@ -182,25 +183,34 @@ include_directories(${KINESIS_VIDEO_PRODUCER_CPP_SRC}/src/credential-providers)
 include_directories(${KINESIS_VIDEO_PRODUCER_CPP_SRC}/src/common)
 include_directories(${KINESIS_VIDEO_PRODUCER_CPP_SRC}/src/JNI/include)
 
-install(
-  DIRECTORY ${KINESIS_VIDEO_PRODUCER_CPP_SRC}/src
-  DESTINATION .)
+if (NOT BUILD_JNI_ONLY)
+  install(
+    DIRECTORY ${KINESIS_VIDEO_PRODUCER_CPP_SRC}/src
+    DESTINATION .)
 
-add_library(KinesisVideoProducer ${LINKAGE} ${PRODUCER_CPP_SOURCE_FILES})
-target_link_libraries(
-  KinesisVideoProducer
-  PUBLIC kvsCommonCurl
-         cproducer
-         ${Log4cplus}
-         ${LIBCURL_LIBRARIES})
+  add_library(KinesisVideoProducer ${LINKAGE} ${PRODUCER_CPP_SOURCE_FILES})
+  target_link_libraries(
+    KinesisVideoProducer
+    PUBLIC kvsCommonCurl
+           cproducer
+           ${Log4cplus}
+           ${LIBCURL_LIBRARIES})
 
-install(
-    TARGETS KinesisVideoProducer
-    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+  install(
+      TARGETS KinesisVideoProducer
+      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+endif()
 
-if(BUILD_JNI)
+if(BUILD_JNI OR BUILD_JNI_ONLY)
+  set(DEPENDENCY_DOWNLOAD_PATH ${CMAKE_CURRENT_SOURCE_DIR}/dependency)
+  set(BUILD_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+  fetch_repo(kvspic ${BUILD_ARGS})
+  add_subdirectory("${DEPENDENCY_DOWNLOAD_PATH}/libkvspic/kvspic-src")
+  file(GLOB PIC_HEADERS "${pic_project_SOURCE_DIR}/src/*/include")
+  include_directories("${PIC_HEADERS}")
+
   find_package(JNI REQUIRED)
   include_directories(${JNI_INCLUDE_DIRS})
 

--- a/README.md
+++ b/README.md
@@ -230,14 +230,15 @@ If playback issues are encountered, pleaser refer to the playback requirements u
 ### Considerations
 - The **`kvssink`** GStreamer plugin and samples, and the **JNI** are _not_ built by default. To build them, use their corresponding cmake command options: `-DBUILD_GSTREAMER_PLUGIN=ON` and `-DBUILD_JNI=ON`.
 - By default, the **dependency libraries** (Curl, OpenSSL, and Log4Cplus) are installed from GitHub and built locally. To instead link to pre-installed libraries on the device, include the following cmake command argument: `cmake .. -DBUILD_DEPENDENCIES=OFF`
- 
+
 ### CMake Arguments
 You can pass the following additional CMake options:
 
-| Option	                     | Default       | Description	|
+| Option	                      | Default       | Description	|
 |:-----------------------------|:-------------:|:-------------|
 | BUILD_GSTREAMER_PLUGIN       | OFF           | Build the `kvssink` GStreamer plugin
 | BUILD_JNI                    | OFF           | Build C++ wrapper for JNI to expose the functionality to Java/Android
+| BUILD_JNI_ONLY               | OFF           | Build only the JNI. C++ Producer will not be built. Requires Java installed.
 | BUILD_DEPENDENCIES           | ON            | Build depending libraries from source
 | BUILD_TEST                   | OFF           | Build unit/integration tests, may be useful to confirm support for your device, to run tests:       `./tst/producerTest`
 | CODE_COVERAGE                | OFF           | Enable coverage reporting

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ You can pass the following additional CMake options:
 | Option	                      | Default       | Description	|
 |:-----------------------------|:-------------:|:-------------|
 | BUILD_GSTREAMER_PLUGIN       | OFF           | Build the `kvssink` GStreamer plugin
+| PARALLEL_BUILD               | ON            | When building dependencies, use multiple CPU cores in parallel (speeds up the build). Not available in Windows.
 | BUILD_JNI                    | OFF           | Build C++ wrapper for JNI to expose the functionality to Java/Android
 | BUILD_JNI_ONLY               | OFF           | Build only the JNI. C++ Producer will not be built. Requires Java installed.
 | BUILD_DEPENDENCIES           | ON            | Build depending libraries from source


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR introduces a new GitHub Actions workflow for building the JNI components of the Kinesis Video Streams Producer SDK across multiple platforms and Java versions. Additionally, it improves dependency management in CMake by optimizing external project downloads and adding support for building the JNI in isolation.

#### GitHub Actions (jni.yml)
Added a new workflow for building JNI with the following configurations:
- macOS (Intel & Apple Silicon)
- Ubuntu 20.04 & 22.04
- Java versions: 11, 17, 21

Total: 4x3 = 12 combinations

#### CMake Improvements
1. Introduced a dedicated CMake flag (`BUILD_JNI_ONLY`) to allow standalone JNI builds without the full Producer SDK.
  - Note: PIC is the only dependency of the JNI. Since Producer-C pulls in PIC, we need to pull PIC ourselves now.
2. Optimized ExternalProject_Add dependencies:
  - Added GIT_SHALLOW and GIT_PROGRESS to reduce clone times (bandwidth and disk space usage) and improve progress visibility.
3. Parallel build support:
  - Use the parallel flag to speed up builds
  - Note: Windows doesn't support parallel builds
4. Dependencies are now conditionally fetched based on whether BUILD_JNI_ONLY is enabled.

*Why was it changed?*
1. CI Coverage: Ensures JNI builds are validated across multiple platforms and Java versions.
2. Performance: Shallow cloning dependencies reduces build times and space used on disk.
3. Modularity: Allowing JNI to be built independently avoids unnecessary dependency resolution when the full SDK and its dependencies are not required.

*Testing*
- Verified JNI builds successfully across all GitHub Actions matrix configurations.
- Confirmed dependency resolution and build correctness with both BUILD_JNI_ONLY=ON and the full Producer SDK build.

JNI build times (cmake + make combined):
- Previously took 7-8 minutes in the CI.
- Are now at most 20s in the CI. Some combinations of runners built it in 8 seconds.
- So, the JNI build was sped up by ((480-20)/480)*100% = 95.8%

Non-JNI (Producer C++ build):
- Previously took about 7:40 to build in the CI
- Now it takes about 6:40 to build in the CI
- 15% faster builds (460/400)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
