### PR TITLE
Add retries for rpi build

### DIFF
--- a/.github/workflows/raspberry-pi.yaml
+++ b/.github/workflows/raspberry-pi.yaml
@@ -69,6 +69,13 @@ jobs:
               cd build
 
               cmake .. -DBUILD_GSTREAMER_PLUGIN=ON -DBUILD_DEPENDENCIES=OFF -DALIGNED_MEMORY_MODEL=ON
+              if [ $? -ne 0 ]; then
+                echo "CMake configuration failed!"
+                exit 1
+              fi
+
+              echo "Listing contents of build directory:"
+              ls -l
           
               # Running 'make' under QEMU inside GitHub Actions has shown instability,
               # with random segmentation faults occurring sporadically. This could be 

--- a/.github/workflows/raspberry-pi.yaml
+++ b/.github/workflows/raspberry-pi.yaml
@@ -69,7 +69,36 @@ jobs:
               cd build
 
               cmake .. -DBUILD_GSTREAMER_PLUGIN=ON -DBUILD_DEPENDENCIES=OFF -DALIGNED_MEMORY_MODEL=ON
-              make
+          
+              # Running 'make' under QEMU inside GitHub Actions has shown instability,
+              # with random segmentation faults occurring sporadically. This could be 
+              # due to QEMU's emulation overhead, memory constraints, or transient 
+              # issues in the GitHub-hosted environment. To mitigate these failures, 
+              # we retry the build up to 5 times before considering it a hard failure.
+
+              max_retries=5
+              attempt=0
+              while [ $attempt -lt $max_retries ]; do
+                attempt=$((attempt + 1))
+                echo "Attempt $attempt of $max_retries..."
+
+                set +e  # Temporarily disable exit on error
+                make -j
+                exit_code=$?
+                set -e  # Re-enable exit on error
+              
+                if [ $exit_code -eq 0 ]; then
+                  break
+                fi
+              
+                echo "Build failed with exit code $exit_code - retrying..."
+                sleep 5
+              done
+              
+              if [ $exit_code -ne 0 ]; then
+                echo "Build failed after $max_retries attempts."
+                exit 1
+              fi
 
               export GST_PLUGIN_PATH=$(pwd)
 

--- a/.github/workflows/raspberry-pi.yaml
+++ b/.github/workflows/raspberry-pi.yaml
@@ -77,9 +77,9 @@ jobs:
               echo "Listing contents of build directory:"
               ls -l
           
-              # Running 'make' under QEMU inside GitHub Actions has shown instability,
+              # Running -make- under QEMU inside GitHub Actions has shown instability,
               # with random segmentation faults occurring sporadically. This could be 
-              # due to QEMU's emulation overhead, memory constraints, or transient 
+              # due to QEMU-s emulation overhead, memory constraints, or transient 
               # issues in the GitHub-hosted environment. To mitigate these failures, 
               # we retry the build up to 5 times before considering it a hard failure.
 
@@ -90,7 +90,7 @@ jobs:
                 echo "Attempt $attempt of $max_retries..."
 
                 set +e  # Temporarily disable exit on error
-                make
+                make -j
                 exit_code=$?
                 set -e  # Re-enable exit on error
               

--- a/.github/workflows/raspberry-pi.yaml
+++ b/.github/workflows/raspberry-pi.yaml
@@ -90,7 +90,7 @@ jobs:
                 echo "Attempt $attempt of $max_retries..."
 
                 set +e  # Temporarily disable exit on error
-                make -j
+                make
                 exit_code=$?
                 set -e  # Re-enable exit on error
               


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add retries for the raspberry pi builds.

*Why was it changed*
- Running 'make' under QEMU inside GitHub Actions has shown instability, with random segmentation faults occurring sporadically. This could be  due to QEMU's emulation overhead, memory constraints, transient issues in the GitHub-hosted environment, or a compiler/linker bug (gcc-10). To mitigate these failures, we retry the build up to 5 times before considering it a hard failure.

<img width="1117" alt="image" src="https://github.com/user-attachments/assets/418a0a89-2465-4d88-8529-7d4bd82d386a" />

<img width="1116" alt="image" src="https://github.com/user-attachments/assets/d572ef7c-ab1f-429c-be6e-41325ba295cf" />

- Added the `-j` (parallel) flag for significantly faster builds. In the CI, the build times (including retries) for the qemu-emulated raspberry pi went from about 7:50 minutes down to about 4:30, over 40% faster. Note that this may increase the instability, although I have set the retry count to 5 to compensate the potential for additional instability.

Data:

| Configuration | Time Start | Time Stop | Elapsed (mm:ss) |
|----------------|-------------|------------|---------|
| [No parallel](https://productionresultssa16.blob.core.windows.net/actions-results/ab908e3b-df87-4716-a146-21847c147c23/workflow-job-run-eb30739b-39d8-53a1-923d-770eda2dff60/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-03-14T22%3A27%3A09Z&sig=a7WyXHnLO2kLaP3BixdFKPv4AvBuAKLXzfREG%2BoEWYE%3D&ske=2025-03-15T09%3A11%3A33Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-03-14T21%3A11%3A33Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-01-05&sp=r&spr=https&sr=b&st=2025-03-14T22%3A17%3A04Z&sv=2025-01-05) | 2025-03-14T05:01:27.4533082Z | 2025-03-14T05:09:10.1439082Z | 7:50
| [Parallel](https://productionresultssa7.blob.core.windows.net/actions-results/340df3d5-f042-4aa3-8c3e-d3ab8e0d5516/workflow-job-run-eb30739b-39d8-53a1-923d-770eda2dff60/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-03-14T22%3A24%3A24Z&sig=pfiuSY67DYdavt%2FuByGfOW7EbXqHsN4dekapyT%2FijYM%3D&ske=2025-03-15T09%3A11%3A31Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-03-14T21%3A11%3A31Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-01-05&sp=r&spr=https&sr=b&st=2025-03-14T22%3A14%3A19Z&sv=2025-01-05) | 2025-03-14T08:07:58.1106956Z | 2025-03-14T08:12:20.9572709Z | 4:22 |

*Testing*

Verified the retry behavior works. Observe the following debug logs, which show the retries getting invoked:

```
...
[ 66%] Building C object dependency/libkvscproducer/kvscproducer-src/CMakeFiles/kvsCommonCurl.dir/src/source/Common/SslInit.c.o
[ 66%] Building C object dependency/libkvscproducer/kvscproducer-src/CMakeFiles/kvsCommonCurl.dir/src/source/Common/Curl/CurlIotCredentialProvider.c.o
[ 67%] Linking CXX executable kvs_gstreamer_file_uploader_sample
Error running link command: Segmentation fault
make[2]: *** [CMakeFiles/kvs_gstreamer_file_uploader_sample.dir/build.make:103: kvs_gstreamer_file_uploader_sample] Error 1
make[1]: *** [CMakeFiles/Makefile2:162: CMakeFiles/kvs_gstreamer_file_uploader_sample.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 67%] Linking C static library libkvspic.a
[ 68%] Linking C shared library libkvsCommonCurl.so
[ 68%] Built target kvspic
[ 68%] Built target kvsCommonCurl
make: *** [Makefile:149: all] Error 2
+ exit_code=2
+ set -e
+ '[' 2 -eq 0 ']'
+ echo 'Build failed with exit code 2 - retrying...'
Build failed with exit code 2 - retrying...
+ sleep 5
+ '[' 1 -lt 5 ']'
+ attempt=2
+ echo 'Attempt 2 of 5...'
+ set +e
+ make -j
Attempt 2 of 5...
[ 20%] Built target kvspicUtils
[ 21%] Linking CXX executable kvs_gstreamer_file_uploader_sample
[ 59%] Built target kvspic
[ 68%] Built target kvsCommonCurl
[ 68%] Built target kvs_gstreamer_file_uploader_sample
Scanning dependencies of target cproducer
[ 70%] Building C object dependency/libkvscproducer/kvscproducer-src/CMakeFiles/cproducer.dir/src/source/FileAuthCallbacks.c.o
...
[ 77%] Building C object dependency/libkvscproducer/kvscproducer-src/CMakeFiles/cproducer.dir/src/source/CredentialProviderAuthCallbacks.c.o
[ 79%] Building C object dependency/libkvscproducer/kvscproducer-src/CMakeFiles/cproducer.dir/src/source/StreamCallbacksProvider.c.o
[ 79%] Building C object dependency/libkvscproducer/kvscproducer-src/CMakeFiles/cproducer.dir/src/source/StreamInfoProvider.c.o
cc: internal compiler error: Segmentation fault signal terminated program cc1
Please submit a full bug report,
with preprocessed source if appropriate.
See <file:///usr/share/doc/gcc-10/README.Bugs> for instructions.
make[2]: *** [dependency/libkvscproducer/kvscproducer-src/CMakeFiles/cproducer.dir/build.make:199: dependency/libkvscproducer/kvscproducer-src/CMakeFiles/cproducer.dir/src/source/Producer.c.o] Error 4
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:496: dependency/libkvscproducer/kvscproducer-src/CMakeFiles/cproducer.dir/all] Error 2
make: *** [Makefile:149: all] Error 2
+ exit_code=2
+ set -e
+ '[' 2 -eq 0 ']'
Build failed with exit code 2 - retrying...
+ echo 'Build failed with exit code 2 - retrying...'
+ sleep 5
+ '[' 2 -lt 5 ']'
+ attempt=3
+ echo 'Attempt 3 of 5...'
Attempt 3 of 5...
+ set +e
+ make -j
[  1%] Built target kvs_gstreamer_file_uploader_sample
[ 39%] Built target kvspic
[ 59%] Built target kvspicUtils
[ 68%] Built target kvsCommonCurl
[ 70%] Building C object dependency/libkvscproducer/kvscproducer-src/CMakeFiles/cproducer.dir/src/source/Producer.c.o
[ 71%] Linking C shared library libcproducer.so
[ 80%] Built target cproducer
Scanning dependencies of target KinesisVideoProducer
[ 80%] Building CXX object CMakeFiles/KinesisVideoProducer.dir/src/CallbackProvider.cpp.o
[ 80%] Building CXX object CMakeFiles/KinesisVideoProducer.dir/src/Auth.cpp.o
[ 81%] Building CXX object CMakeFiles/KinesisVideoProducer.dir/src/CachingEndpointOnlyCallbackProvider.cpp.o
[ 82%] Building CXX object CMakeFiles/KinesisVideoProducer.dir/src/DefaultCallbackProvider.cpp.o
[ 85%] Building CXX object CMakeFiles/KinesisVideoProducer.dir/src/KinesisVideoProducer.cpp.o
...
```

> [!NOTE]
> From my manual testing, I have not observed these segfaults on real Rpi hardware, only in this emulated environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
