### PR TITLE
JNI: Fix logging cleanup issue

### DIFF
--- a/src/JNI/com/amazonaws/kinesis/video/producer/jni/NativeProducerInterface.cpp
+++ b/src/JNI/com/amazonaws/kinesis/video/producer/jni/NativeProducerInterface.cpp
@@ -48,20 +48,14 @@ extern "C" {
         CHECK(env != NULL && thiz != NULL);
 
         KinesisVideoClientWrapper* pWrapper = FROM_WRAPPER_HANDLE(handle);
-        if (pWrapper != NULL) {
-            // Cache the globalRef for later deletion
-            jobject globalRef = pWrapper->getGlobalRef();
 
-            // Free the existing engine
-            delete pWrapper;
-
-            // Free the global reference
-            if (globalRef != NULL) {
-                env->DeleteGlobalRef(globalRef);
-            }
-        }
-
+        // Calling leave early since the logger is part of pWrapper.
+        // Avoiding errors by logging after free
         LEAVE();
+
+        if (pWrapper != NULL) {
+            delete pWrapper;
+        }
     }
 
     /**

--- a/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/JNICommon.h
+++ b/src/JNI/include/com/amazonaws/kinesis/video/producer/jni/JNICommon.h
@@ -7,6 +7,7 @@
 
 #include <jni.h>                  // Basic native API
 #include <string.h>
+#include <iostream>
 
 #define EXCEPTION_NAME "com/amazonaws/kinesisvideo/producer/ProducerException"
 


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*
This PR addresses two separate undefined behavior issues in `KinesisVideoClientWrapper`:  

1. **Dereferencing `pWrapper` After Free**  
   - The previous implementation logs via `LEAVE();` after calling `delete pWrapper;`. Since `LEAVE()` relies on `pWrapper`'s internal state (which was already freed), this resulted in undefined behavior. From my testing, this caused either:  
     - An infinite loop of `NullPointerException` errors, since `CHECK` inside of the logging function also prints logs.
     - A segmentation fault (`SIGSEGV`).  


<details>
<summary>Logs (NullPointerException)</summary>

```
2025-03-16 08:56:22,015 [main] INFO  c.a.k.j.c.KinesisVideoJavaClientFactory - [PIC] KinesisVideoProducerJNI - Java_com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni_freeKinesisVideoClient(): Freeing Kinesis Video client.
2025-03-16 08:56:22,015 [main] INFO  c.a.k.j.c.KinesisVideoJavaClientFactory - [PIC] KinesisVideoClient - freeKinesisVideoClient(): Freeing Kinesis Video Client
2025-03-16 08:56:22,015 [main] DEBUG c.a.k.j.c.KinesisVideoJavaClientFactory - [PIC] KinesisVideoClient - freeKinesisVideoClientInternal(): Total allocated memory 0
	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.free(NativeKinesisVideoProducerJni.java:302)
	at com.amazonaws.kinesisvideo.internal.client.NativeKinesisVideoClient.free(NativeKinesisVideoClient.java:222)
	at com.amazonaws.kinesisvideo.demoapp.DemoAppMain.main(DemoAppMain.java:71)
Exception in thread "main" java.lang.NullPointerException
	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.freeKinesisVideoClient(Native Method)
	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.free(NativeKinesisVideoProducerJni.java:302)
	at com.amazonaws.kinesisvideo.internal.client.NativeKinesisVideoClient.free(NativeKinesisVideoClient.java:222)
	at com.amazonaws.kinesisvideo.demoapp.DemoAppMain.main(DemoAppMain.java:71)
Exception in thread "main" java.lang.NullPointerException
	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.freeKinesisVideoClient(Native Method)
	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.free(NativeKinesisVideoProducerJni.java:302)
	at com.amazonaws.kinesisvideo.internal.client.NativeKinesisVideoClient.free(NativeKinesisVideoClient.java:222)
	at com.amazonaws.kinesisvideo.demoapp.DemoAppMain.main(DemoAppMain.java:71)
Exception in thread "main" java.lang.NullPointerException
	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.freeKinesisVideoClient(Native Method)
	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.free(NativeKinesisVideoProducerJni.java:302)
	at com.amazonaws.kinesisvideo.internal.client.NativeKinesisVideoClient.free(NativeKinesisVideoClient.java:222)
	at com.amazonaws.kinesisvideo.demoapp.DemoAppMain.main(DemoAppMain.java:71)
Exception in thread "main" java.lang.NullPointerException
	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.freeKinesisVideoClient(Native Method)
	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.free(NativeKinesisVideoProducerJni.java:302)
	at com.amazonaws.kinesisvideo.internal.client.NativeKinesisVideoClient.free(NativeKinesisVideoClient.java:222)
	at com.amazonaws.kinesisvideo.demoapp.DemoAppMain.main(DemoAppMain.java:71)
Exception in thread "main" java.lang.NullPointerException
	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.freeKinesisVideoClient(Native Method)
	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.free(NativeKinesisVideoProducerJni.java:302)
	at com.amazonaws.kinesisvideo.internal.client.NativeKinesisVideoClient.free(NativeKinesisVideoClient.java:222)
	at com.amazonaws.kinesisvideo.demoapp.DemoAppMain.main(DemoAppMain.java:71)
Exception in thread "main" java.lang.NullPointerException
	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.freeKinesisVideoClient(Native Method)
	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.free(NativeKinesisVideoProducerJni.java:302)
	at com.amazonaws.kinesisvideo.internal.client.NativeKinesisVideoClient.free(NativeKinesisVideoClient.java:222)
	at com.amazonaws.kinesisvideo.demoapp.DemoAppMain.main(DemoAppMain.java:71)
```

</details>

<details>
<summary>Logs (segfault)</summary>

```
2025-03-16 08:56:35,592 [main] INFO  c.a.k.j.c.KinesisVideoJavaClientFactory - [PIC] KinesisVideoProducerJNI - Java_com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni_freeKinesisVideoClient(): Freeing Kinesis Video client.
2025-03-16 08:56:35,592 [main] INFO  c.a.k.j.c.KinesisVideoJavaClientFactory - [PIC] KinesisVideoClient - freeKinesisVideoClient(): Freeing Kinesis Video Client
2025-03-16 08:56:35,592 [main] DEBUG c.a.k.j.c.KinesisVideoJavaClientFactory - [PIC] KinesisVideoClient - freeKinesisVideoClientInternal(): Total allocated memory 0
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x000000010acb278a, pid=6277, tid=8707
#
# JRE version: OpenJDK Runtime Environment Temurin-11.0.26+4 (11.0.26+4) (build 11.0.26+4)
# Java VM: OpenJDK 64-Bit Server VM Temurin-11.0.26+4 (11.0.26+4, mixed mode, tiered, compressed oops, g1 gc, bsd-amd64)
# Problematic frame:
# V  [libjvm.dylib+0x1e478a]  AccessInternal::PostRuntimeDispatch<G1BarrierSet::AccessBarrier<1196148ull, G1BarrierSet>, (AccessInternal::BarrierType)2, 1196148ull>::oop_access_barrier(void*)+0x6
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# An error report file with more information is saved as:
# /Users/runner/work/amazon-kinesis-video-streams-producer-sdk-java/amazon-kinesis-video-streams-producer-sdk-java/hs_err_pid6277.log
#
# If you would like to submit a bug report, please visit:
#   https://github.com/adoptium/adoptium-support/issues
#
```

</details>


2. **Using `mGlobalJniObjRef` After Free**  
   - The `mGlobalJniObjRef` reference was accessed after being freed, leading to crashes when attempting JNI calls. It was freed but the pointer itself wasn't cleared, so checks for `mGlobalJniObjRef == NULL` did not actually early return as intended.
   - If the global JNI object reference was already released, subsequent attempts to log using it caused segmentation faults or invalid JNI state errors (mentioned above).

Therefore,

  - Moved `LEAVE();` before `delete pWrapper;` to ensure logging happens while `pWrapper` is still valid.  
  - Eliminated redundant calls to `getGlobalRef()`, ensuring proper reference cleanup using RAII.
  - Prevented logging through JVM if `mGlobalJniObjRef` is already NULL, instead it will print to `cout` instad. 
  - Set `mGlobalJniObjRef` to NULL after freeing it.
  - Added explicit `NULL` checks before dereferencing JNI environment pointers.

<details>
<summary>Cout backup logging logs</summary>

```
2025-03-16 00:37:03,879 [main] INFO  c.a.k.j.c.KinesisVideoJavaClientFactory - [PIC] KinesisVideoProducerJNI - Java_com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni_freeKinesisVideoClient(): Freeing Kinesis Video client.
...
logPrintFunc called after free! Level: 1, Tag: KinesisVideoProducerJNI, Message: Java_com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni_freeKinesisVideoClient(): Leave
```

</details>

Minor adjustment:
  - Renamed `detached` to `attached` to better reflect the actual thread attachment state.

*Testing*
- Verified correct behavior in scenarios that previously caused segmentation faults both manually and in the CI.
- Ensured that logging through JVM not occur after resource deallocation and the `cout` backup is used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
