### PR TITLE
Pin cmake to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,14 @@ jobs:
       contents: read
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          brew install pkg-config openssl cmake gstreamer log4cplus
-          brew unlink openssl
+          brew install cmake gstreamer log4cplus
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Build repository
         run: |
           mkdir build && cd build
@@ -62,11 +65,14 @@ jobs:
       AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          brew install pkg-config openssl cmake gstreamer log4cplus
-          brew unlink openssl
+          brew install cmake gstreamer log4cplus
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Build repository
         run: |
           mkdir build && cd build
@@ -317,7 +323,11 @@ jobs:
       contents: read
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Move repository
         run: |
           mkdir C:\producer


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/awslabs/amazon-kinesis-video-streams-producer-c/pull/479

*What was changed?*
- CMake version used in the CI

*Why was it changed?*
- GitHub actions upgraded it to v4, which Curl does not work with.

*How was it changed?*
- Use a setup cmake action to pin the CMake version to v3 (currently v3.31.0).

*What testing was done for the changes?*
- CI passed for Producer-C PR

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.