### PR TITLE
Don't require kvssink build to build samples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
-          sh -c 'cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE;cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DCMAKE_INSTALL_PREFIX=.'
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_SAMPLES=FALSE -DCOMPILER_WARNINGS=TRUE -DCMAKE_INSTALL_PREFIX=.
           make
           make install
       - name: Configure AWS Credentials
@@ -70,7 +70,7 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DCMAKE_INSTALL_PREFIX=. -DPARALLEL_BUILD=${{ matrix.parallel-build }}
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_SAMPLES=FALSE -DCMAKE_INSTALL_PREFIX=. -DPARALLEL_BUILD=${{ matrix.parallel-build }}
 
           if [[ "${{ matrix.parallel-build }}" == 'ON' ]]; then
             make
@@ -225,7 +225,7 @@ jobs:
   #     - name: Build repository
   #       run: |
   #         mkdir build && cd build
-  #         cmake .. -DBUILD_TEST=TRUE -DMEMORY_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
+  #         cmake .. -DBUILD_TEST=TRUE -DBUILD_SAMPLES=FALSE -DMEMORY_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
   #         make
   #         ulimit -c unlimited -S
   #         timeout --signal=SIGABRT 150m ./tst/producerTest --gtest_break_on_failure
@@ -364,7 +364,7 @@ jobs:
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic64 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_SAMPLES=FALSE -DBUILD_OPENSSL_PLATFORM=linux-generic64 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
           make
           make install
           file libKinesisVideoProducer.so
@@ -387,7 +387,7 @@ jobs:
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-aarch64 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_SAMPLES=FALSE -DBUILD_OPENSSL_PLATFORM=linux-aarch64 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
           make
           make install
           file libKinesisVideoProducer.so
@@ -410,7 +410,7 @@ jobs:
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic32 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_SAMPLES=FALSE -DBUILD_OPENSSL_PLATFORM=linux-generic32 -DBUILD_LOG4CPLUS_HOST=arm-linux -DCMAKE_INSTALL_PREFIX=.
           make
           make install
           file libKinesisVideoProducer.so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ include(GNUInstallDirs)
 
 # User Flags
 option(BUILD_GSTREAMER_PLUGIN "Build kvssink GStreamer plugin" OFF)
+option(BUILD_SAMPLES "Whether to build the sample applications." ON)
 option(BUILD_JNI "Build C++ wrapper for JNI to expose the functionality to Java/Android" OFF)
 option(BUILD_JNI_ONLY "Build ONLY the JNI, don't build C++ Producer SDK" OFF)
 option(BUILD_STATIC "Build with static linkage" OFF)
@@ -221,12 +222,15 @@ if(BUILD_JNI OR BUILD_JNI_ONLY)
   target_link_libraries(KinesisVideoProducerJNI kvspic)
 endif()
 
-
-if(BUILD_GSTREAMER_PLUGIN)
+if(BUILD_GSTREAMER_PLUGIN OR BUILD_SAMPLES)
+  # Find GStreamer.
   pkg_check_modules(GST_APP REQUIRED gstreamer-app-1.0)
   include_directories(${GST_APP_INCLUDE_DIRS})
   link_directories(${GST_APP_LIBRARY_DIRS})
+endif()
 
+if(BUILD_GSTREAMER_PLUGIN)
+  # Build kvssink.
   if(BUILD_STATIC)
     add_library(gstkvssink STATIC ${GST_PLUGIN_SOURCE_FILES})
   else()
@@ -234,8 +238,18 @@ if(BUILD_GSTREAMER_PLUGIN)
   endif()
   target_link_libraries(gstkvssink PRIVATE ${GST_APP_LIBRARIES} KinesisVideoProducer)
 
-  add_executable(kvssink_gstreamer_sample samples/kvssink_gstreamer_sample.cpp)
-  target_link_libraries(kvssink_gstreamer_sample ${GST_APP_LIBRARIES} KinesisVideoProducer)
+  install(
+    TARGETS gstkvssink
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+endif()
+
+if(BUILD_SAMPLES)
+  if(BUILD_GSTREAMER_PLUGIN)
+    add_executable(kvssink_gstreamer_sample samples/kvssink_gstreamer_sample.cpp)
+    target_link_libraries(kvssink_gstreamer_sample ${GST_APP_LIBRARIES} KinesisVideoProducer)
+    endif()
 
   add_executable(kvs_gstreamer_sample samples/kvs_gstreamer_sample.cpp)
   target_link_libraries(kvs_gstreamer_sample ${GST_APP_LIBRARIES} KinesisVideoProducer kvspic)


### PR DESCRIPTION
*Issue #, if available:*
Merging in https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/pull/1159

*Description of changes:*
Don't require kvssink build to build samples, don't require samples build to build kvssink.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
