### PR TITLE
Kvssink leak fix and ci

### DIFF
--- a/.github/configs/no_logs_configuration
+++ b/.github/configs/no_logs_configuration
@@ -1,0 +1,1 @@
+log4cplus.rootLogger=OFF

--- a/.github/valgrind/glib.supp
+++ b/.github/valgrind/glib.supp
@@ -1,0 +1,37 @@
+{
+   glib-dl-memory-leak-ubuntu-22.04
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:g_malloc
+   obj:/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.7200.4
+   obj:/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.7200.4
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   obj:/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+}
+
+{
+   glib-dl-memory-leak-ubuntu-20.04
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:g_malloc
+   obj:/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.6400.6
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   obj:/usr/lib/x86_64-linux-gnu/ld-2.31.so
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,12 @@ jobs:
           make
           make install
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
+          role-duration-seconds: 3600
       - name: Run tests
         run: |
           cd build
@@ -87,12 +87,12 @@ jobs:
           fi
       - name: Configure AWS Credentials
         if: ${{ matrix.parallel-build == 'ON' }} # Only need to run the tests once
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
+          role-duration-seconds: 3600
       - name: Run tests
         if: ${{ matrix.parallel-build == 'ON' }}
         run: |
@@ -100,7 +100,7 @@ jobs:
           ./tst/producerTest
 
   linux-gcc-code-coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       AWS_KVS_LOG_LEVEL: 2
     permissions:
@@ -121,12 +121,12 @@ jobs:
           make
           make install
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
+          role-duration-seconds: 3600
       - name: Run tests
         run: |
           cd build
@@ -139,7 +139,7 @@ jobs:
           bash <(curl -s https://codecov.io/bash)
 
   address-sanitizer:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read
@@ -162,12 +162,12 @@ jobs:
           make
           make install
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
+          role-duration-seconds: 3600
       - name: Run tests
         run: |
           cd build
@@ -175,7 +175,7 @@ jobs:
           timeout --signal=SIGABRT 60m ./tst/producerTest
 
   undefined-behavior-sanitizer:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read
@@ -198,12 +198,12 @@ jobs:
           make
           make install
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
+          role-duration-seconds: 3600
       - name: Run tests
         run: |
           cd build
@@ -263,7 +263,7 @@ jobs:
   #         timeout --signal=SIGABRT 20m ./tst/producerTest
 
   ubuntu-gcc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -301,12 +301,12 @@ jobs:
 
       - name: Configure AWS Credentials
         if: ${{ matrix.parallel-build == 'ON' }} # Only need to run the tests once
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
+          role-duration-seconds: 3600
       - name: Run tests
         if: ${{ matrix.parallel-build == 'ON' }}
         run: |
@@ -345,19 +345,19 @@ jobs:
           dir
           .\build_windows.bat
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
+          role-duration-seconds: 3600
       - name: Run tests
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\producer\open-source\local\lib;D:\producer\open-source\local\bin'
           & "D:\producer\build\tst\producerTest.exe"
 
   arm64-cross-compilation:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CC: aarch64-linux-gnu-gcc
       CXX: aarch64-linux-gnu-g++
@@ -380,7 +380,7 @@ jobs:
           file libKinesisVideoProducer.so
 
   linux-aarch64-cross-compilation:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CC: aarch64-linux-gnu-gcc
       CXX: aarch64-linux-gnu-g++
@@ -403,7 +403,7 @@ jobs:
           file libKinesisVideoProducer.so
 
   arm32-cross-compilation:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CC: arm-linux-gnueabi-gcc
       CXX: arm-linux-gnueabi-g++
@@ -426,7 +426,7 @@ jobs:
           file libKinesisVideoProducer.so
 
   linux-build-gcc-static:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -442,7 +442,7 @@ jobs:
           make
 
   linux-build-gcc-shared:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v3

--- a/.github/workflows/kvssink.yml
+++ b/.github/workflows/kvssink.yml
@@ -19,22 +19,23 @@ jobs:
       contents: read
     strategy:
       matrix:
-        include:
+        run-config:
           - os: Ubuntu 22.04
             image: public.ecr.aws/ubuntu/ubuntu:22.04_stable
           - os: Ubuntu 20.04
             image: public.ecr.aws/ubuntu/ubuntu:20.04_stable
       fail-fast: false
 
-    name: kvssink unit tests on ${{ matrix.os }}
+    name: kvssink unit tests on ${{ matrix.run-config.os }}
+    container: ${{ matrix.run-config.image }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y automake build-essential cmake git \
+          apt-get update
+          apt-get install -y automake m4 build-essential cmake git \
             gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad \
             gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly \
             gstreamer1.0-tools \
@@ -59,7 +60,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
+          role-duration-seconds: 900
 
       - name: Run the unit tests
         working-directory: ./build
@@ -84,11 +85,16 @@ jobs:
 
   mac-debug-dump-dir:
     runs-on: macos-latest
-    env:
-      AWS_KVS_LOG_LEVEL: 1
     permissions:
       id-token: write
       contents: read
+
+    env:
+      AWS_KVS_LOG_LEVEL: 1
+      STREAM_NAME: cpp-kvssink-debug-dump-dir-macos-latest
+      GST_PLUGIN_PATH: ${{ github.workspace }}/build
+      KVS_DEBUG_DUMP_DATA_FILE_DIR: ${{ github.workspace }}/build/debug_output
+
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
@@ -108,12 +114,9 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
+          role-duration-seconds: 900
 
       - name: Run kvssink with dump dir
-        env:
-          GST_PLUGIN_PATH: ${{ github.workspace }}/build
-          KVS_DEBUG_DUMP_DATA_FILE_DIR: ${{ github.workspace }}/build/debug_output
         working-directory: ./build
         run: |
           mkdir -p debug_output
@@ -121,7 +124,7 @@ jobs:
             ! video/x-raw,framerate=30/1,width=640,height=480 \
             ! videoconvert ! x264enc tune=zerolatency key-int-max=45 \
             ! h264parse \
-            ! kvssink stream-name="demo-stream"
+            ! kvssink stream-name="$STREAM_NAME"
 
       - name: Verify MKV dump
         working-directory: ./build/debug_output
@@ -138,31 +141,37 @@ jobs:
           done
 
   linux-debug-dump-dir:
-    runs-on: ubuntu-latest
-    env:
-      AWS_KVS_LOG_LEVEL: 1
     permissions:
       id-token: write
       contents: read
     strategy:
       matrix:
-        include:
-          - os: Ubuntu 22.04
+        run-config:
+          - os: Ubuntu-22.04
             image: public.ecr.aws/ubuntu/ubuntu:22.04_stable
-          - os: Ubuntu 20.04
+          - os: Ubuntu-20.04
             image: public.ecr.aws/ubuntu/ubuntu:20.04_stable
       fail-fast: false
+
+    runs-on: ubuntu-latest
+    container: ${{ matrix.run-config.image }}
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      STREAM_NAME: cpp-kvssink-debug-dump-dir-${{ matrix.run-config.os }}
+      GST_PLUGIN_PATH: ${{ github.workspace }}/build
+      KVS_DEBUG_DUMP_DATA_FILE_DIR: ${{ github.workspace }}/build/debug_output
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y automake build-essential cmake git \
-            gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad \
-            gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly \
-            gstreamer1.0-tools \
+          apt-get update
+          apt-get install -y automake build-essential cmake git \
+            gstreamer1.0-plugins-base gstreamer1.0-plugins-base-apps \
+            gstreamer1.0-plugins-bad gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-ugly gstreamer1.0-tools \
             libcurl4-openssl-dev libgstreamer1.0-dev \
             libgstreamer-plugins-base1.0-dev liblog4cplus-dev \
             libssl-dev pkg-config mkvtoolnix
@@ -184,12 +193,9 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
+          role-duration-seconds: 900
 
       - name: Run kvssink with dump dir
-        env:
-          GST_PLUGIN_PATH: ${{ github.workspace }}/build
-          KVS_DEBUG_DUMP_DATA_FILE_DIR: ${{ github.workspace }}/build/debug_output
         working-directory: ./build
         run: |
           mkdir -p debug_output
@@ -197,7 +203,7 @@ jobs:
             ! video/x-raw,framerate=30/1,width=640,height=480 \
             ! videoconvert ! x264enc tune=zerolatency key-int-max=45 \
             ! h264parse \
-            ! kvssink stream-name="demo-stream"
+            ! kvssink stream-name="$STREAM_NAME"
 
       - name: Verify MKV dump
         working-directory: ./build/debug_output
@@ -212,11 +218,13 @@ jobs:
             echo "Verifying $file with mkvinfo (verbose and hexdump):"
             mkvinfo -v -X "$file"
           done
+        shell: bash
 
   windows-debug-dump-dir:
     runs-on: windows-2022
     env:
       AWS_KVS_LOG_LEVEL: 1
+      STREAM_NAME: cpp-kvssink-debug-dump-dir-windows-2022
     permissions:
       id-token: write
       contents: read
@@ -245,7 +253,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
+          role-duration-seconds: 900
       - name: Run kvssink with dump dir
         env:
           GST_PLUGIN_PATH: D:\producer\build\
@@ -258,7 +266,7 @@ jobs:
           New-Item -ItemType Directory -Path "D:\producer\build\debug_output" -Force
 
           # Stream for 15 seconds (450 frames @ 30 fps)
-          gst-launch-1.0.exe videotestsrc is-live=true num-buffers=450 ! video/x-raw,framerate=30/1,width=640,height=480 ! videoconvert ! x264enc tune=zerolatency key-int-max=45 ! h264parse ! kvssink stream-name="demo-stream"
+          gst-launch-1.0.exe videotestsrc is-live=true num-buffers=450 ! video/x-raw,framerate=30/1,width=640,height=480 ! videoconvert ! x264enc tune=zerolatency key-int-max=45 ! h264parse ! kvssink stream-name="$STREAM_NAME"
       - name: Verify MKV dump
         working-directory: D:\producer\build
         run: |
@@ -301,6 +309,7 @@ jobs:
             build-essential
             cmake
             git
+            gstreamer1.0-plugins-base
             gstreamer1.0-plugins-base-apps
             gstreamer1.0-plugins-bad
             gstreamer1.0-plugins-good
@@ -355,7 +364,7 @@ jobs:
               ! video/x-raw,framerate=30/1,width=640,height=480 \
               ! videoconvert ! x264enc tune=zerolatency key-int-max=45 \
               ! h264parse \
-              ! kvssink stream-name='demo-stream-cpp-kvssink-ci-wsl-videotestsrc-${{ matrix.image }}' \
+              ! kvssink stream-name='cpp-kvssink-ci-wsl-videotestsrc-${{ matrix.image }}' \
                   aws-region=${{ env.AWS_DEFAULT_REGION }} \
                   access-key=${{ env.AWS_ACCESS_KEY_ID }} \
                   secret-key=${{ env.AWS_SECRET_ACCESS_KEY }} \
@@ -380,3 +389,112 @@ jobs:
             echo "Verifying $file with mkvinfo:"
             mkvinfo -v -X "$file"
           done
+
+  valgrind-check:
+    strategy:
+      matrix:
+        run-config:
+          - os: Ubuntu-22.04
+            image: public.ecr.aws/ubuntu/ubuntu:22.04_stable
+          - os: Ubuntu-20.04
+            image: public.ecr.aws/ubuntu/ubuntu:20.04_stable
+
+        deps:
+          - name: Deps-ON
+            cmake_flags: -DBUILD_DEPENDENCIES=ON
+          - name: Deps-OFF
+            cmake_flags: -DBUILD_DEPENDENCIES=OFF
+
+      fail-fast: false
+
+    runs-on: ubuntu-latest
+    container: ${{ matrix.run-config.image }}
+
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      STREAM_NAME: valgrind-test-stream-cpp-kvssink-${{ matrix.run-config.os }}-${{ matrix.deps.name }}
+      GST_PLUGIN_PATH: ${{ github.workspace }}/build
+
+    name: Valgrind ${{ matrix.run-config.os }} (${{ matrix.deps.name }})
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y build-essential cmake pkg-config git \
+            gstreamer1.0-plugins-base gstreamer1.0-plugins-base-apps \
+            gstreamer1.0-plugins-bad gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-ugly gstreamer1.0-tools \
+            libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+            valgrind
+
+      - name: Install additional build dependencies
+        if: ${{ matrix.deps.name == 'Deps-ON' }}
+        run: |
+          apt-get install -y m4
+
+      - name: Install prebuilt-dependencies
+        if: ${{ matrix.deps.name == 'Deps-OFF' }}
+        run: |
+          apt-get install -y libcurl4-openssl-dev liblog4cplus-dev libssl-dev
+
+      - name: Setup build directory
+        run: |
+          mkdir -p build
+          cd build
+
+      - name: Build kvssink
+        working-directory: ./build
+        run: |
+          cmake .. -DBUILD_GSTREAMER_PLUGIN=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DALIGNED_MEMORY_MODEL=ON ${{ matrix.deps.cmake_flags }}
+          make -j$(nproc)
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 900
+
+      - name: Verify kvssink works
+        working-directory: ./build
+        run: |
+          # Run it once just to confirm          
+          gst-launch-1.0 videotestsrc num-buffers=1 ! x264enc ! h264parse ! kvssink stream-name="$STREAM_NAME"
+
+      - name: Run kvssink with valgrind
+        working-directory: ./build
+        run: |          
+          mkdir -p valgrind_logs
+          LOG_FILE="valgrind_logs/${{ matrix.sample-executable.name }}.log"
+
+          echo "::group::Application logs for kvssink"
+          valgrind --leak-check=full \
+            --show-leak-kinds=definite \
+            --track-origins=yes \
+            --log-file="$LOG_FILE" \
+            --suppressions="../.github/valgrind/glib.supp" \
+            gst-launch-1.0 videotestsrc num-buffers=1 \
+              ! x264enc \
+              ! h264parse \
+              ! kvssink stream-name="$STREAM_NAME" log-config="../.github/configs/no_logs_configuration"
+          echo "::endgroup::"
+
+          echo "========== Valgrind Output =========="
+          cat "$LOG_FILE"
+          echo "====================================="
+
+          if grep -qE "definitely lost: [^0]" "$LOG_FILE" || grep -qE "indirectly lost: [^0]" "$LOG_FILE"; then
+            echo "❌ Valgrind found something definitely or indirectly lost"
+            exit 1
+          fi
+
+        shell: bash

--- a/.github/workflows/kvssink.yml
+++ b/.github/workflows/kvssink.yml
@@ -22,9 +22,12 @@ jobs:
         run-config:
           - os: Ubuntu 22.04
             image: public.ecr.aws/ubuntu/ubuntu:22.04_stable
-          - os: Ubuntu 20.04
-            image: public.ecr.aws/ubuntu/ubuntu:20.04_stable
+#          - os: Ubuntu 20.04
+#            image: public.ecr.aws/ubuntu/ubuntu:20.04_stable
       fail-fast: false
+
+    env:
+      DEBIAN_FRONTEND: noninteractive
 
     name: kvssink unit tests on ${{ matrix.run-config.os }}
     container: ${{ matrix.run-config.image }}
@@ -225,6 +228,8 @@ jobs:
     env:
       AWS_KVS_LOG_LEVEL: 1
       STREAM_NAME: cpp-kvssink-debug-dump-dir-windows-2022
+      GST_PLUGIN_PATH: D:\producer\build\
+      KVS_DEBUG_DUMP_DATA_FILE_DIR: D:\producer\build\debug_output
     permissions:
       id-token: write
       contents: read
@@ -255,9 +260,6 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           role-duration-seconds: 900
       - name: Run kvssink with dump dir
-        env:
-          GST_PLUGIN_PATH: D:\producer\build\
-          KVS_DEBUG_DUMP_DATA_FILE_DIR: D:\producer\build\debug_output
         working-directory: D:\producer\build\
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\producer\open-source\local\lib;D:\producer\open-source\local\bin;D:\gstreamer\1.0\msvc_x86_64\bin'
@@ -266,7 +268,7 @@ jobs:
           New-Item -ItemType Directory -Path "D:\producer\build\debug_output" -Force
 
           # Stream for 15 seconds (450 frames @ 30 fps)
-          gst-launch-1.0.exe videotestsrc is-live=true num-buffers=450 ! video/x-raw,framerate=30/1,width=640,height=480 ! videoconvert ! x264enc tune=zerolatency key-int-max=45 ! h264parse ! kvssink stream-name="$STREAM_NAME"
+          gst-launch-1.0.exe videotestsrc is-live=true num-buffers=450 ! video/x-raw,framerate=30/1,width=640,height=480 ! videoconvert ! x264enc tune=zerolatency key-int-max=45 ! h264parse ! kvssink stream-name="$env:STREAM_NAME"
       - name: Verify MKV dump
         working-directory: D:\producer\build
         run: |
@@ -402,8 +404,8 @@ jobs:
         deps:
           - name: Deps-ON
             cmake_flags: -DBUILD_DEPENDENCIES=ON
-          - name: Deps-OFF
-            cmake_flags: -DBUILD_DEPENDENCIES=OFF
+#          - name: Deps-OFF
+#            cmake_flags: -DBUILD_DEPENDENCIES=OFF
 
       fail-fast: false
 

--- a/.github/workflows/raspberry-pi.yaml
+++ b/.github/workflows/raspberry-pi.yaml
@@ -43,7 +43,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
+          role-duration-seconds: 3600
 
       - name: Build and Test
         env:

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -10,9 +10,41 @@ on:
       - develop
       - master
 
+env:
+  SAMPLE_MP4_LOCATION: https://raw.githubusercontent.com/aws-samples/amazon-kinesis-video-streams-demos/refs/heads/master/sample-video/sample.mp4
+
 jobs:
+  prep-assets:
+    runs-on: ubuntu-latest
+    outputs:
+      sample-artifact-name: ${{ steps.set-output.outputs.artifact-name }}
+    steps:
+    - name: Restore cached sample.mp4
+      uses: actions/cache@v4
+      with:
+        path: sample.mp4
+        key: sample-mp4-v1
+
+    - name: Download sample.mp4 if not cached
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: curl -fsSL -o sample.mp4 "$SAMPLE_MP4_LOCATION"
+
+    - name: Save to cache
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache@v4
+      with:
+        path: sample.mp4
+        key: sample-mp4-v1
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: sample-mp4
+        path: sample.mp4
+
   sample-checks:
     name: ${{ matrix.runner.id }} - ${{ matrix.sample.name }}
+    needs: prep-assets
 
     strategy:
       matrix:
@@ -106,13 +138,19 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
+          role-duration-seconds: 900
+
+      - name: Download sample.mp4 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sample-mp4
+          path: ./assets
 
       - name: Run ${{ matrix.sample.name }} (Linux & Mac)
         if: runner.os == 'Linux' || runner.os == 'macOS'
         working-directory: ./build
         run: |
-          curl -fsSL -o sample.mp4 https://awsj-iot-handson.s3-ap-northeast-1.amazonaws.com/kvs-workshop/sample.mp4
+          mv ../assets/*.mp4 .
           ./${{ matrix.sample.name }} demo-stream-producer-cpp-${{ matrix.runner.id }}-ci-${{ matrix.sample.name }} ${{ matrix.sample.args }}
 
       - name: Run ${{ matrix.sample.name }} (Windows)
@@ -129,7 +167,7 @@ jobs:
 
           mkdir D:\producer\debug_output
 
-          Invoke-WebRequest -Uri https://awsj-iot-handson.s3-ap-northeast-1.amazonaws.com/kvs-workshop/sample.mp4 -OutFile sample.mp4
+          cp -r D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\assets\*.mp4 .
           dir
           $exePath = Join-Path $PWD ${{ matrix.sample.name }}.exe
           & $exePath demo-stream-producer-cpp-${{ matrix.runner.id }}-ci-${{ matrix.sample.name }} ${{ matrix.sample.args }}
@@ -225,7 +263,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
+          role-duration-seconds: 900
 
       - name: Run multistream sample
         working-directory: ./build
@@ -310,6 +348,7 @@ jobs:
 
   wsl-sample-checks:
     name: WSL ${{ matrix.image }} - ${{ matrix.sample.name }}
+    needs: prep-assets
 
     strategy:
       matrix:
@@ -365,16 +404,23 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
 
+      - name: Download sample.mp4 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sample-mp4
+          path: ./assets
+
       - name: Move repository in WSL
         run: |
           # Copy to ~/kvs-cpp-repo for simplicity
           # Note: Can't move due to no permissions
           REPO_NAME=$(basename ${{ github.repository }})
           cp -r /mnt/d/a/$REPO_NAME/$REPO_NAME ~/kvs-cpp-repo
+          mkdir -p ~/kvs-cpp-repo/build
+          cp -r /mnt/d/a/$REPO_NAME/$REPO_NAME/assets/*.mp4 ~/kvs-cpp-repo/build
 
       - name: Build samples in WSL
         run: |
-          mkdir -p ~/kvs-cpp-repo/build
           cd ~/kvs-cpp-repo/build
           cmake .. -DBUILD_GSTREAMER_PLUGIN=ON -DALIGNED_MEMORY_MODEL=ON -DBUILD_DEPENDENCIES=OFF
           make -j$(nproc)
@@ -394,8 +440,6 @@ jobs:
           mkdir "$KVS_DEBUG_DUMP_DATA_FILE_DIR"
           export GST_PLUGIN_PATH=~/kvs-cpp-repo/build
           export AWS_KVS_LOG_LEVEL=2
-
-          curl -fsSL -o sample.mp4 https://awsj-iot-handson.s3-ap-northeast-1.amazonaws.com/kvs-workshop/sample.mp4
 
           # Note: `env.` syntax to reference credentials to have GitHub Actions inject
           # the secret values into these environment variables before the command runs,

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -815,6 +815,10 @@ gst_kvs_sink_finalize(GObject *object) {
     kvssink->credentials_.reset();
     kvssink->data.reset();
 
+    if (kvssink->data.use_count() > 0) {
+        LOG_ERROR("KvsSinkCustomData is not properly cleaned up. The ref count is: " << kvssink->data.use_count());
+    }
+
     // Eventually calls g_free(kvssink), smart pointers need to be cleaned up before
     G_OBJECT_CLASS (parent_class)->finalize(object);
 }

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -814,6 +814,10 @@ gst_kvs_sink_finalize(GObject *object) {
     if (data->kinesis_video_producer) {
         data->kinesis_video_producer.reset();
     }
+    
+    // Reset the shared pointer to properly release the KvsSinkCustomData
+    kvssink->data.reset();
+ 
     G_OBJECT_CLASS (parent_class)->finalize(object);
 }
 

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -788,7 +788,6 @@ gst_kvs_sink_init(GstKvsSink *kvssink) {
 static void
 gst_kvs_sink_finalize(GObject *object) {
     GstKvsSink *kvssink = GST_KVS_SINK (object);
-    auto data = kvssink->data;
 
     gst_object_unref(kvssink->collect);
     g_free(kvssink->stream_name);
@@ -806,18 +805,17 @@ gst_kvs_sink_finalize(GObject *object) {
     g_free(kvssink->credential_file_path);
 
     if (kvssink->iot_certificate) {
-        gst_structure_free (kvssink->iot_certificate);
+        gst_structure_free(kvssink->iot_certificate);
     }
     if (kvssink->stream_tags) {
-        gst_structure_free (kvssink->stream_tags);
+        gst_structure_free(kvssink->stream_tags);
     }
-    if (data->kinesis_video_producer) {
-        data->kinesis_video_producer.reset();
-    }
-    
-    // Reset the shared pointer to properly release the KvsSinkCustomData
+
+    // Reset the smart pointers to properly release the data
+    kvssink->credentials_.reset();
     kvssink->data.reset();
- 
+
+    // Eventually calls g_free(kvssink), smart pointers need to be cleaned up before
     G_OBJECT_CLASS (parent_class)->finalize(object);
 }
 

--- a/src/gstreamer/gstkvssink.h
+++ b/src/gstreamer/gstkvssink.h
@@ -141,6 +141,8 @@ struct _GstKvsSink {
     guint                       num_video_streams;
 
 
+    // Since this struct is freed (not deleted), these pointers must be
+    // manually cleaned up before freeing (finalize method)
     std::unique_ptr<Credentials> credentials_;
     std::shared_ptr<KvsSinkCustomData> data;
 };


### PR DESCRIPTION
*Issue #, if available:*
- #682, #1244

*What was changed?*
- Adjust the cleanup logic in `gst_kvs_sink_finalize` to address a memory leak related to the use of smart pointers and free().

*Why was it changed?*
- A memory leak occurred because of the improper combination of `free()` and smart pointers. In C++, `free()` does not invoke destructors (specifically, decrease the reference count of smart pointers). Prior to calling `free()`, the smart pointers (`credentials_` and `data`) still had active reference counts, leading to the resources not being released before the memory was freed.
  - The `std::unordered_set<uint64_t> track_cpd_received` (part of _KvsSinkCustomData which was also marked in the leak), will get cleaned up when `KvsSinkCustomData` destructor is called, after the reference count reaches 0.
- You can find the leaks tool output below:

<details><summary>Leaks</summary>

```
STACK OF 1 INSTANCE OF 'ROOT CYCLE: <std::__shared_ptr_emplace<_KvsSinkCustomData>>':
17  libsystem_pthread.dylib               0x19a4d30fc thread_start + 8
16  libsystem_pthread.dylib               0x19a4d82e4 _pthread_start + 136
15  libglib-2.0.0.dylib                   0x1028a895c g_thread_proxy + 68
14  libgstreamer-1.0.0.dylib              0x10271f068 gst_thread_func + 112
13  gst-launch-1.0                        0x1024fcc84 real_main + 952
12  libgstreamer-1.0.0.dylib              0x10271edf4 gst_parse_launchv_full + 728
11  libgstreamer-1.0.0.dylib              0x10271eec8 gst_parse_launch_full + 132
10  libgstreamer-1.0.0.dylib              0x102680e6c priv_gst_parse_launch + 160
9   libgstreamer-1.0.0.dylib              0x10267e334 priv_gst_parse_yyparse + 1804
8   libgstreamer-1.0.0.dylib              0x10268027c gst_parse_element_make + 612
7   libgstreamer-1.0.0.dylib              0x1026b1d14 gst_element_factory_create_with_properties + 100
6   libgobject-2.0.0.dylib                0x1025f61e0 g_object_new_with_properties + 408
5   libgobject-2.0.0.dylib                0x1025f6964 g_object_new_internal + 68
4   libgobject-2.0.0.dylib                0x10260ad38 g_type_create_instance + 404
3   libgstkvssink.so                      0x102b430bc gst_kvs_sink_init(_GstKvsSink*) + 444
2   libc++abi.dylib                       0x19a49236c operator new(unsigned long) + 52
1   libsystem_malloc.dylib                0x19a2fc39c _malloc + 88
0   libsystem_malloc.dylib                0x19a30f76c _malloc_zone_malloc_instrumented_or_legacy + 148 
====
    5 (608 bytes) ROOT CYCLE: <std::__shared_ptr_emplace<_KvsSinkCustomData> 0x1403f6ff0> [192]
       1 (32 bytes) ROOT CYCLE: <malloc in gst_kvs_sink_handle_sink_event(_GstCollectPads*, _GstCollectData*, _GstEvent*, void*) 0x1403d9e00> [32]
          CYCLE BACK TO <std::__shared_ptr_emplace<_KvsSinkCustomData> 0x1403f6ff0> [192]
       1 (304 bytes) <com::amazonaws::kinesis::video::KinesisVideoStream 0x1403f7dd0> [304]
       1 (48 bytes) <std::__shared_ptr_pointer<com::amazonaws::kinesis::video::KinesisVideoStream*, void (*)(com::amazonaws::kinesis::video::KinesisVideoStream*)> 0x1403f67b0> [48]
       1 (32 bytes) <malloc in gst_kvs_sink_handle_sink_event(_GstCollectPads*, _GstCollectData*, _GstEvent*, void*) 0x140343410> [32]

STACK OF 1 INSTANCE OF 'ROOT LEAK: <com::amazonaws::kinesis::video::Credentials>':
15  libsystem_pthread.dylib               0x19a4d30fc thread_start + 8
14  libsystem_pthread.dylib               0x19a4d82e4 _pthread_start + 136
13  libglib-2.0.0.dylib                   0x1028a895c g_thread_proxy + 68
12  libgstreamer-1.0.0.dylib              0x10271f068 gst_thread_func + 112
11  gst-launch-1.0                        0x1024fcdf8 real_main + 1324
10  libgstreamer-1.0.0.dylib              0x1026b0038 gst_element_set_state_func + 360
9   libgstreamer-1.0.0.dylib              0x1026ae8e4 gst_element_change_state + 220
8   libgstreamer-1.0.0.dylib              0x1026d8b10 gst_pipeline_change_state + 380
7   libgstreamer-1.0.0.dylib              0x102689bd0 gst_bin_change_state_func + 1036
6   libgstreamer-1.0.0.dylib              0x1026b0038 gst_element_set_state_func + 360
5   libgstreamer-1.0.0.dylib              0x1026ae8e4 gst_element_change_state + 220
4   libgstkvssink.so                      0x102b4466c gst_kvs_sink_change_state(_GstElement*, GstStateChange) + 1360
3   libgstkvssink.so                      0x102b401a0 kinesis_video_producer_init(_GstKvsSink*) + 3752
2   libc++abi.dylib                       0x19a49236c operator new(unsigned long) + 52
1   libsystem_malloc.dylib                0x19a2fc39c _malloc + 88
0   libsystem_malloc.dylib                0x19a30f76c _malloc_zone_malloc_instrumented_or_legacy + 148 
====
    2 (160 bytes) ROOT LEAK: <com::amazonaws::kinesis::video::Credentials 0x1400d3d00> [96]
       1 (64 bytes) <malloc in std::basic_string<char>::__init_copy_ctor_external(char const*, unsigned long) 0x1400d3d60> [64]
```

</details>

*How is it different from the PR #1244 ?*
- An auto data copy constructor increased the reference count of `kvssink->data` by 1. However, the struct (KvsSinkCustomData) containing the smart pointer was freed before the method ends (while the reference count was still 1).
- This PR addresses this issue by removing the unnecessary copy constructor and ensuring the smart pointer is properly reset before freeing memory.
- Below is a visualization of the issue:

<details><summary>Visualization</summary>
 
```
static void
gst_kvs_sink_finalize(GObject *object) {
    // Ref count = 1 
    GstKvsSink *kvssink = GST_KVS_SINK (object);
    auto data = kvssink->data;
    // Ref count = 2
    gst_object_unref(kvssink->collect);
    g_free(kvssink->stream_name);
    ...

    if (data->kinesis_video_producer) {
        data->kinesis_video_producer.reset();
    }

    // Ref count = 2
    // Reset the shared pointer to properly release the KvsSinkCustomData
    kvssink->data.reset();
    // Ref count = 1

    G_OBJECT_CLASS (parent_class)->finalize(object);
}
// Afterwards once `data` goes out of scope, ref count = 0. Undefined behavior since it was already freed in the `finalize`.
```

- Also, this PR addresses the leak in the Credentials object as well.

</details>

*How was it changed?*
1. Removed `auto data` copy constructor (unnecessary).
2. Removed `data->kinesis_video_producer.reset();` since it will have gotten cleaned up through `kvssink->data.reset()`.
3. Reset the `credentials_` smart pointer as well before to ensure proper cleanup of the associated resources.
4. Added comments to clarify the need for manual cleanup of smart pointers before calling `free()`.

*What testing was done for the changes?*
- Performed manual testing using `valgrind` to ensure that no memory leaks occurred during the finalization of GstKvsSink objects.
- Verified that all resources were correctly released, including the `credentials_` and `data` pointers.
- Added valgrind kvssink check to the CI to ensure memory leaks don't get created in the future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
