### PR TITLE
Fix event metadata in av sample

### DIFF
--- a/samples/kvs_gstreamer_audio_video_sample.cpp
+++ b/samples/kvs_gstreamer_audio_video_sample.cpp
@@ -506,7 +506,7 @@ static GstFlowReturn on_new_sample(GstElement *sink, CustomData *data) {
     // Sample to demonstrate how event metadata tags can be generated for fragment(s)
     // Ref: https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/notifications.html
     //      https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/images.html
-    if (CHECK_FRAME_FLAG_KEY_FRAME(kinesis_video_flags)) {
+    if (CHECK_FRAME_FLAG_KEY_FRAME(frame.flags)) {
     // Add event metadata after key frame
          switch(gEvents) {
             case 1:

--- a/samples/kvs_gstreamer_audio_video_sample.cpp
+++ b/samples/kvs_gstreamer_audio_video_sample.cpp
@@ -470,19 +470,6 @@ static GstFlowReturn on_new_sample(GstElement *sink, CustomData *data) {
         } else {
             if (key_frame_count % KEYFRAME_EVENT_INTERVAL == 0) {
                 key_frame_count = 0;
-                switch(gEvents) {
-                    case 1:
-                        data->kinesis_video_stream->putEventMetadata(STREAM_EVENT_TYPE_NOTIFICATION, NULL);
-                        break;
-                    case 2:
-                        data->kinesis_video_stream->putEventMetadata(STREAM_EVENT_TYPE_IMAGE_GENERATION, NULL);
-                        break;
-                    case 3:
-                        data->kinesis_video_stream->putEventMetadata(STREAM_EVENT_TYPE_NOTIFICATION | STREAM_EVENT_TYPE_IMAGE_GENERATION, NULL);
-                        break;
-                    default:
-                        break;
-                }
             }
             kinesis_video_flags = FRAME_FLAG_KEY_FRAME;
             key_frame_count++;
@@ -515,6 +502,29 @@ static GstFlowReturn on_new_sample(GstElement *sink, CustomData *data) {
                                kinesis_video_flags, info.data, info.size, track_id);
 
     data->kinesis_video_stream->putFrame(frame);
+
+    // Sample to demonstrate how event metadata tags can be generated for fragment(s)
+    // Ref: https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/notifications.html
+    //      https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/images.html
+    if (CHECK_FRAME_FLAG_KEY_FRAME(kinesis_video_flags)) {
+    // Add event metadata after key frame
+         switch(gEvents) {
+            case 1:
+                DLOGI("Adding metadata for notification");
+                data->kinesis_video_stream->putEventMetadata(STREAM_EVENT_TYPE_NOTIFICATION, NULL);
+                break;
+            case 2:
+                DLOGI("Adding the metadata for image generation");
+                data->kinesis_video_stream->putEventMetadata(STREAM_EVENT_TYPE_IMAGE_GENERATION, NULL);
+                break;
+            case 3:
+                DLOGI("Adding the metadata for both notification and image generaion");
+                data->kinesis_video_stream->putEventMetadata(STREAM_EVENT_TYPE_NOTIFICATION | STREAM_EVENT_TYPE_IMAGE_GENERATION, NULL);
+                break;
+            default:
+                break;
+        }
+    }
 
 CleanUp:
 
@@ -1011,7 +1021,7 @@ int main(int argc, char *argv[]) {
 
     if (argc < 2) {
         LOG_ERROR(
-                "Usage: AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kinesis_video_gstreamer_audio_video_sample_app my-stream-name /path/to/file"
+                "Usage: AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kinesis_video_gstreamer_audio_video_sample_app my-stream-name -f /path/to/file"
                         "AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kinesis_video_gstreamer_audio_video_sample_app my-stream-name");
         return 1;
     }


### PR DESCRIPTION
*Issue #, if available:*

The `kvs_gstreamer_audio_video_sample.cpp` file does not generate images in S3, even after enabling the stream configuration according to the AWS documentation [UpdateImageGenerationConfiguration](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/images.html#UpdateImageGenerationConfiguration).
The `kvs_gstreamer_sample.cpp` works.

*Description of changes:*

Fixed the sample `putEventMetaData` to be consistent with the `kvs_gstreamer_sample.cpp`

```
[INFO ] [18-06-2025 20:59:15:507.962 UTC] on_new_sample(): Adding the metadata for both notification and image generation
```

MKV info shows that the tags are added when using the command-line parameter  `-e both ` :

```

|  + Frame with size 1252
| + Simple block: track number 2, 1 frame(s), timestamp 486187:34:13.907000000
|  + Frame with size 187
| + Simple block: track number 2, 1 frame(s), timestamp 486187:34:13.928000000
|  + Frame with size 178
|+ Tags
| + Tag
|  + Simple
|   + Name: AWS_KINESISVIDEO_NOTIFICATION
|   + String
|+ Tags
| + Tag
|  + Simple
|   + Name: AWS_KINESISVIDEO_IMAGE_GENERATION
|   + String
|+ Cluster
| + Cluster timestamp: 486187:34:13.932000000
| + Cluster position: 0
```



Note: The README steps will be updated separately.