### PR TITLE
Adjust windows CI PATH, update chocolatey gstreamer version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,12 +331,12 @@ jobs:
       - name: Move repository
         run: |
           mkdir C:\producer
-          Move-Item -Path "D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\*" -Destination "D:\producer"
+          Move-Item -Path "$env:GITHUB_WORKSPACE\*" -Destination "D:\producer"
       - name: Install dependencies
         run: |
           choco install nasm strawberryperl
-          choco install gstreamer --version=1.22.8
-          choco install gstreamer-devel --version=1.22.8
+          choco install gstreamer --version=1.22.12
+          choco install gstreamer-devel --version=1.22.12
       - name: Build repository
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\producer\open-source\local\lib;D:\producer\open-source\local\bin'

--- a/.github/workflows/kvssink.yml
+++ b/.github/workflows/kvssink.yml
@@ -226,12 +226,12 @@ jobs:
       - name: Move repository
         run: |
           mkdir D:\producer
-          Move-Item -Path "D:\a\amazon-kinesis-video-streams-producer-sdk-cpp\amazon-kinesis-video-streams-producer-sdk-cpp\*" -Destination "D:\producer"
+          Move-Item -Path "$env:GITHUB_WORKSPACE\*" -Destination "D:\producer"
       - name: Install dependencies
         run: |
           choco install nasm strawberryperl mkvtoolnix
-          choco install gstreamer --version=1.22.8
-          choco install gstreamer-devel --version=1.22.8
+          choco install gstreamer --version=1.22.12
+          choco install gstreamer-devel --version=1.22.12
       - name: Build repository
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\producer\open-source\local\lib;D:\producer\open-source\local\bin'
@@ -323,7 +323,8 @@ jobs:
           # Copy to ~/kvs-cpp-repo for simplicity
           # Note: Can't move due to no permissions
           REPO_NAME=$(basename ${{ github.repository }})
-          cp -r /mnt/d/a/$REPO_NAME/$REPO_NAME ~/kvs-cpp-repo
+          DRIVE_LETTER=$(echo "${{ github.workspace }}" | sed -r 's/^([A-Za-z]):.*/\1/' | tr '[:upper:]' '[:lower:]')
+          cp -r /mnt/$DRIVE_LETTER/a/$REPO_NAME/$REPO_NAME ~/kvs-cpp-repo
 
       - name: Build kvssink in WSL
         run: |

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -78,8 +78,8 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           choco install nasm strawberryperl pkgconfiglite mkvtoolnix
-          choco install gstreamer --version=1.22.8
-          choco install gstreamer-devel --version=1.22.8
+          choco install gstreamer --version=1.22.12
+          choco install gstreamer-devel --version=1.22.12
 
       - name: Build samples (Linux & Mac)
         if: runner.os == 'Linux' || runner.os == 'macOS'
@@ -370,7 +370,8 @@ jobs:
           # Copy to ~/kvs-cpp-repo for simplicity
           # Note: Can't move due to no permissions
           REPO_NAME=$(basename ${{ github.repository }})
-          cp -r /mnt/d/a/$REPO_NAME/$REPO_NAME ~/kvs-cpp-repo
+          DRIVE_LETTER=$(echo "${{ github.workspace }}" | sed -r 's/^([A-Za-z]):.*/\1/' | tr '[:upper:]' '[:lower:]')
+          cp -r /mnt/$DRIVE_LETTER/a/$REPO_NAME/$REPO_NAME ~/kvs-cpp-repo
 
       - name: Build samples in WSL
         run: |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ sudo apt install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1
 ```
 _Windows_
 ```bat
-choco install gstreamer --version=1.22.8 gstreamer-devel --version=1.22.8
+choco install gstreamer --version=1.22.12 gstreamer-devel --version=1.22.12
 ```
 #### Verify GStreamer Installation
 Run the following command to display the GStreamer version to confirm the installation was successful:


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- CI configuration for windows jobs, README

*Why was it changed?*
- 1.22.8 is no longer hosted on Chocolatey. The only version from 1.22.x set is 1.22.12.
- GitHub actions randomly changed the drive from `D:\` drive to `C:\` drive. Adjust the paths like in https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/pull/2148.

https://gstreamer.freedesktop.org/data/pkg/windows/
<img width="309" alt="image" src="https://github.com/user-attachments/assets/1136ceaf-ffbd-499d-9e10-6d126393e2f3" />

*How was it changed?*
- Bumped the CI configuration

*What testing was done for the changes?*
- Checked the CI in a fork

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
