### PR TITLE
Bump Producer-C to 1.6.0

### DIFF
--- a/CMake/Dependencies/libkvscproducer-CMakeLists.txt
+++ b/CMake/Dependencies/libkvscproducer-CMakeLists.txt
@@ -7,9 +7,9 @@ include(ExternalProject)
 # clone repo only
 ExternalProject_Add(libkvscproducer-download
 	GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-producer-c.git
-	GIT_TAG           develop
-    GIT_SHALLOW       TRUE
-    GIT_PROGRESS      TRUE
+	GIT_TAG           v1.6.0
+   	GIT_SHALLOW       TRUE
+  	GIT_PROGRESS      TRUE
 	SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvscproducer-src"
 	BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvscproducer-build"
 	CONFIGURE_COMMAND ""


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- The Producer-C version that is being pulled in

*Why was it changed?*
- Preparing for release. Develop and 1.6.0 should be identical as of this moment (just released Producer-C 1.6.0).

*How was it changed?*
- Changed the version that it will do a `git checkout` in the CMake script.

*What testing was done for the changes?*
- Ci to do the automated verifications across the different platforms.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
