### PR TITLE
Upgrade from mac 13 to mac 15 due to deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   mac-os-build-clang:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       AWS_KVS_LOG_LEVEL: 2
     permissions:
@@ -47,7 +47,7 @@ jobs:
           ./tst/producerTest
 
   mac-os-build-gcc:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     strategy:
       matrix:
         parallel-build:

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -65,8 +65,8 @@ jobs:
           - name: kvssink_intermittent_sample # There is no file source option for this sample (will use gst videotestsrc).
             args: testsrc 120 # <gst-videotestsrc> <sample_duration_seconds>
         runner:
-          - id: macos-13
-            image: macos-13
+          - id: macos-15-intel
+            image: macos-15-intel
 
           - id: ubuntu-22.04
             image: ubuntu-latest


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- CI: Runner type used

*Why was it changed?*
- MacOS 13 (x86_64) is being deprecated and being replaced with `macos-15-intel`
- https://github.com/actions/runner-images/issues/13045

*How was it changed?*
- Updated the runner type in the ci configuration file

*What testing was done for the changes?*
- If the CI passes, the migration completed successfully

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
