### PR TITLE
ci: scoped down github action permission to the minimum required permission

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,9 @@ on:
   schedule:
     - cron: '41 13 * * 2'
 
+permissions:
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze
@@ -41,6 +44,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
+        aws-region: us-west-2
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Use min. permissions required by result publish action.

*Why was it changed?*
- security reason

*How was it changed?*
- added lines to yml files

*What testing was done for the changes?*
- tested through CI/CD

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
