### PR TITLE
Fix linking error when BUILD_DEPENDENCIES=OFF with external kvspic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,7 @@ target_link_libraries(
   KinesisVideoProducer
   PUBLIC kvsCommonCurl
          cproducer
+         kvspic
          ${Log4cplus}
          ${LIBCURL_LIBRARIES})
 
@@ -207,25 +208,25 @@ if(BUILD_GSTREAMER_PLUGIN)
   else()
     add_library(gstkvssink MODULE ${GST_PLUGIN_SOURCE_FILES})
   endif()
-  target_link_libraries(gstkvssink PRIVATE ${GST_APP_LIBRARIES} KinesisVideoProducer)
+  target_link_libraries(gstkvssink PRIVATE ${GST_APP_LIBRARIES} KinesisVideoProducer kvspic)
 
   add_executable(kvssink_gstreamer_sample samples/kvssink_gstreamer_sample.cpp)
-  target_link_libraries(kvssink_gstreamer_sample ${GST_APP_LIBRARIES} KinesisVideoProducer)
+  target_link_libraries(kvssink_gstreamer_sample ${GST_APP_LIBRARIES} KinesisVideoProducer kvspic)
 
   add_executable(kvssink_intermittent_sample samples/kvssink_intermittent_sample.cpp )
-  target_link_libraries(kvssink_intermittent_sample ${GST_APP_LIBRARIES} KinesisVideoProducer)
+  target_link_libraries(kvssink_intermittent_sample ${GST_APP_LIBRARIES} KinesisVideoProducer kvspic)
 
   add_executable(kvs_gstreamer_sample samples/kvs_gstreamer_sample.cpp)
   target_link_libraries(kvs_gstreamer_sample ${GST_APP_LIBRARIES} KinesisVideoProducer kvspic)
 
   add_executable(kvs_gstreamer_multistream_sample samples/kvs_gstreamer_multistream_sample.cpp)
-  target_link_libraries(kvs_gstreamer_multistream_sample ${GST_APP_LIBRARIES} KinesisVideoProducer)
+  target_link_libraries(kvs_gstreamer_multistream_sample ${GST_APP_LIBRARIES} KinesisVideoProducer kvspic)
 
   add_executable(kvs_gstreamer_audio_video_sample samples/kvs_gstreamer_audio_video_sample.cpp)
-  target_link_libraries(kvs_gstreamer_audio_video_sample ${GST_APP_LIBRARIES} KinesisVideoProducer)
+  target_link_libraries(kvs_gstreamer_audio_video_sample ${GST_APP_LIBRARIES} KinesisVideoProducer kvspic)
 
   add_executable(kvs_gstreamer_file_uploader_sample samples/kvs_gstreamer_file_uploader_sample.cpp)
-  target_link_libraries(kvs_gstreamer_file_uploader_sample ${GST_APP_LIBRARIES})
+  target_link_libraries(kvs_gstreamer_file_uploader_sample ${GST_APP_LIBRARIES} KinesisVideoProducer kvspic)
 endif()
 
 if(BUILD_TEST)


### PR DESCRIPTION
When building with BUILD_DEPENDENCIES=OFF and using system-installed kvspic and cproducer libraries (common in Yocto/embedded builds), the transitive dependency chain from KinesisVideoProducer to kvspic is not properly resolved by the linker.

This issue specifically occurs when the meta-aws BUILD_DEPENDENCIES patch is applied:
https://github.com/aws4embeddedlinux/meta-aws/blob/master/recipes-sdk/amazon-kvs-producer-sdk/amazon-kvs-producer-sdk-cpp/001-amazon-kvs-producer-sdk-cpp-deps.patch

While kvspic is transitively available through the dependency chain (kvspic -> cproducer -> KinesisVideoProducer), explicitly linking kvspic to the affected samples ensures the linker can resolve all symbols when dependencies are built separately.

Add explicit kvspic linking to:
- kvssink_gstreamer_sample
- kvs_gstreamer_multistream_sample
- kvs_gstreamer_audio_video_sample

This change is redundant when BUILD_DEPENDENCIES=ON (default) but necessary for external dependency builds in embedded Linux environments.

Fixes: #1197

*Issue #, if available:*
- N/A

*What was changed?*
- 

*Why was it changed?*
- 

*How was it changed?*
- 

*What testing was done for the changes?*
- 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
