### PR TITLE
Fix CMake command formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ cmake -DBUILD_GSTREAMER_PLUGIN=ON ..
 ```
 _Windows_ (may need to run twice)
 ```bat
-cmake -G "NMake Makefiles -DBUILD_GSTREAMER_PLUGIN=ON" ..
+cmake -G "NMake Makefiles" -DBUILD_GSTREAMER_PLUGIN=ON ..
 ```
 
 


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
Change in the README File for the CMake command

*Why was it changed?*
The old command had the quotes at wrong place.

*How was it changed?*
Just changed the position of the quote.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
