### PR TITLE
Add option to link to PIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ option(BUILD_DEPENDENCIES "Whether or not to build depending libraries from sour
 option(BUILD_OPENSSL_PLATFORM "If buildng OpenSSL what is the target platform" OFF)
 option(BUILD_LOG4CPLUS_HOST "Specify host-name for log4cplus for cross-compilation" OFF)
 option(PARALLEL_BUILD "Build dependencies with parallel flag" ON)
+option(KVS_LINK_PIC_ALSO "Explicitly link kvspic to targets (needed for some external dependency builds)" OFF)
 
 # Developer Flags
 option(BUILD_TEST "Build the testing tree" OFF)
@@ -187,9 +188,12 @@ target_link_libraries(
   KinesisVideoProducer
   PUBLIC kvsCommonCurl
          cproducer
-         kvspic
          ${Log4cplus}
          ${LIBCURL_LIBRARIES})
+
+if(KVS_LINK_PIC_ALSO)
+  target_link_libraries(KinesisVideoProducer PUBLIC kvspic)
+endif()
 
 install(
     TARGETS KinesisVideoProducer
@@ -208,25 +212,35 @@ if(BUILD_GSTREAMER_PLUGIN)
   else()
     add_library(gstkvssink MODULE ${GST_PLUGIN_SOURCE_FILES})
   endif()
-  target_link_libraries(gstkvssink PRIVATE ${GST_APP_LIBRARIES} KinesisVideoProducer kvspic)
+  target_link_libraries(gstkvssink PRIVATE ${GST_APP_LIBRARIES} KinesisVideoProducer)
 
   add_executable(kvssink_gstreamer_sample samples/kvssink_gstreamer_sample.cpp)
-  target_link_libraries(kvssink_gstreamer_sample ${GST_APP_LIBRARIES} KinesisVideoProducer kvspic)
+  target_link_libraries(kvssink_gstreamer_sample ${GST_APP_LIBRARIES} KinesisVideoProducer)
 
   add_executable(kvssink_intermittent_sample samples/kvssink_intermittent_sample.cpp )
-  target_link_libraries(kvssink_intermittent_sample ${GST_APP_LIBRARIES} KinesisVideoProducer kvspic)
+  target_link_libraries(kvssink_intermittent_sample ${GST_APP_LIBRARIES} KinesisVideoProducer)
 
   add_executable(kvs_gstreamer_sample samples/kvs_gstreamer_sample.cpp)
-  target_link_libraries(kvs_gstreamer_sample ${GST_APP_LIBRARIES} KinesisVideoProducer kvspic)
+  target_link_libraries(kvs_gstreamer_sample ${GST_APP_LIBRARIES} KinesisVideoProducer)
 
   add_executable(kvs_gstreamer_multistream_sample samples/kvs_gstreamer_multistream_sample.cpp)
-  target_link_libraries(kvs_gstreamer_multistream_sample ${GST_APP_LIBRARIES} KinesisVideoProducer kvspic)
+  target_link_libraries(kvs_gstreamer_multistream_sample ${GST_APP_LIBRARIES} KinesisVideoProducer)
 
   add_executable(kvs_gstreamer_audio_video_sample samples/kvs_gstreamer_audio_video_sample.cpp)
-  target_link_libraries(kvs_gstreamer_audio_video_sample ${GST_APP_LIBRARIES} KinesisVideoProducer kvspic)
+  target_link_libraries(kvs_gstreamer_audio_video_sample ${GST_APP_LIBRARIES} KinesisVideoProducer)
 
   add_executable(kvs_gstreamer_file_uploader_sample samples/kvs_gstreamer_file_uploader_sample.cpp)
-  target_link_libraries(kvs_gstreamer_file_uploader_sample ${GST_APP_LIBRARIES} KinesisVideoProducer kvspic)
+  target_link_libraries(kvs_gstreamer_file_uploader_sample ${GST_APP_LIBRARIES} KinesisVideoProducer)
+
+  if(KVS_LINK_PIC_ALSO)
+    target_link_libraries(gstkvssink PRIVATE kvspic)
+    target_link_libraries(kvssink_gstreamer_sample kvspic)
+    target_link_libraries(kvssink_intermittent_sample kvspic)
+    target_link_libraries(kvs_gstreamer_sample kvspic)
+    target_link_libraries(kvs_gstreamer_multistream_sample kvspic)
+    target_link_libraries(kvs_gstreamer_audio_video_sample kvspic)
+    target_link_libraries(kvs_gstreamer_file_uploader_sample kvspic)
+  endif()
 endif()
 
 if(BUILD_TEST)

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ You can pass the following additional CMake options:
 | ALIGNED_MEMORY_MODEL         | OFF           | Build for aligned memory model only devices
 | BUILD_LOG4CPLUS_HOST         | OFF           | Specify host-name for log4cplus for cross-compilation
 | CONSTRAINED_DEVICE           | OFF           | Set the thread stack size to 0.5MB, needed for Alpine builds
+| KVS_LINK_PIC_ALSO            | OFF           | Explicitly link kvspic to targets, needed for some external dependency builds
 
 These options can be set as arguments to the `cmake` command, for example:
 ```


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/pull/1277

*What was changed?*
- Made the changes from 1277 opt-in

*Why was it changed?*
- AddressSanitizer CI job is failing after chose changes:
```
=================================================================
==33041==ERROR: AddressSanitizer: odr-violation (0x7f2ca89ed880):
  [1] size=8 'globalMemAlloc' /home/runner/work/amazon-kinesis-video-streams-producer-sdk-cpp/amazon-kinesis-video-streams-producer-sdk-cpp/dependency/libkvscproducer/kvscproducer-src/dependency/libkvspic/kvspic-src/src/utils/src/Allocators.c:39:10
  [2] size=8 'globalMemAlloc' /home/runner/work/amazon-kinesis-video-streams-producer-sdk-cpp/amazon-kinesis-video-streams-producer-sdk-cpp/dependency/libkvscproducer/kvscproducer-src/dependency/libkvspic/kvspic-src/src/utils/src/Allocators.c:39:10
These globals were registered at these points:
  [1]:
    #0 0x5558d481023a in __asan_register_globals (/home/runner/work/amazon-kinesis-video-streams-producer-sdk-cpp/amazon-kinesis-video-streams-producer-sdk-cpp/build/tst/producerTest+0x5123a) (BuildId: 10931c6b20f2992701442c149ef4a7b8037a91c3)
    #1 0x7f2ca89d0f3e in asan.module_ctor Allocators.c
    #2 0x7f2ca89f747d  (/lib64/ld-linux-x86-64.so.2+0x647d) (BuildId: 359db9ab2fbd854c2e97c40be710987ad40c8c92)

  [2]:
    #0 0x5558d481023a in __asan_register_globals (/home/runner/work/amazon-kinesis-video-streams-producer-sdk-cpp/amazon-kinesis-video-streams-producer-sdk-cpp/build/tst/producerTest+0x5123a) (BuildId: 10931c6b20f2992701442c149ef4a7b8037a91c3)
    #1 0x7f2ca888eeee in asan.module_ctor Allocators.c
    #2 0x7f2ca89f747d  (/lib64/ld-linux-x86-64.so.2+0x647d) (BuildId: 359db9ab2fbd854c2e97c40be710987ad40c8c92)

==33041==HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_odr_violation=0
SUMMARY: AddressSanitizer: odr-violation: global 'globalMemAlloc' at /home/runner/work/amazon-kinesis-video-streams-producer-sdk-cpp/amazon-kinesis-video-streams-producer-sdk-cpp/dependency/libkvscproducer/kvscproducer-src/dependency/libkvspic/kvspic-src/src/utils/src/Allocators.c:39:10
==33041==ABORTING
```

- The mentioned PR added explicit kvspic linking to KinesisVideoProducer and all GStreamer samples. Since cproducer already links kvspic as a PUBLIC dependency, this created duplicate linkage paths causing `globalMemAlloc` and other globals in [`Allocators.c`](https://github.com/awslabs/amazon-kinesis-video-streams-pic/blob/release-1.3.1/src/utils/src/Allocators.c) to be defined twice in the same binary.

*How was it changed?*
- Added a CMake option `KVS_LINK_PIC_ALSO` (default OFF) that allows opt-in explicit linking when needed for BUILD_DEPENDENCIES=OFF scenarios. This approach preserves the fix for both the Yocto/embedded builds and existing builds.

*What testing was done for the changes?*
- CI/CD, the AddressSanitizer job which was failing previously should now pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
