### PR TITLE
Bump Producer-C to 1.6.2

### DIFF
--- a/CMake/Dependencies/libkvscproducer-CMakeLists.txt
+++ b/CMake/Dependencies/libkvscproducer-CMakeLists.txt
@@ -7,7 +7,7 @@ include(ExternalProject)
 # clone repo only
 ExternalProject_Add(libkvscproducer-download
 	GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-producer-c.git
-	GIT_TAG           develop
+	GIT_TAG           v1.6.2
    	GIT_SHALLOW       TRUE
   	GIT_PROGRESS      TRUE
 	SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvscproducer-src"


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Pull in the Producer-C changes which has building libcurl with fPIC flag, which allows for the kvssink build with producer-c and pic statically built inside of it.

*Why was it changed?*
- Using a fixed release version

*How was it changed?*
- Change the git tag it's pulling

*What testing was done for the changes?*
- CI/CD. That develop and v1.6.2 have the same contents

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
