### PR TITLE
Update README to specify CMake 3.x is required, CMake 4.x is not yet supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following instructions describe the SDK and samples setup for Mac, Linux, an
 The following packages are required to build the SDK libraries. Using a package manager such as [_Homebrew_](https://brew.sh/) (Mac), [_APT_](https://en.wikipedia.org/wiki/APT_(software)) (Linux), and [_Chocolatey_](https://chocolatey.org/install) (Windows) is the prefered method of installation.
 * C++ Compiler (GNU or Clang recommended)
 * `git`
-* `CMake`
+* `CMake` (requires 3.x, `CMake` 4.x is not yet supported)
 * `pkg-config` for _Mac_/_Linux_, `pkgconfiglite` for _Windows_
 * `m4`
 * _Windows_ only: `nasm` and `strawberryperl`


### PR DESCRIPTION
*Issue #, if available:*
- Added a clarification to the README to specify version of CMake required.

*What was changed?*
- README

*Why was it changed?*
- To make sure users know to use CMake version 3.x and not 4.x when building.
- #1271  

*How was it changed?*
- Updated README

*What testing was done for the changes?*
- None, only README was changed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
