### PR TITLE
Close stale issues

### DIFF
--- a/close-stale-issues.yml
+++ b/close-stale-issues.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Close stale issues
     steps:
-      - uses: aws-actions/stale-issue-cleanup@v3
+      - uses: aws-actions/stale-issue-cleanup@v7
         with:
           ancient-issue-message: This is a very old issue. We encourage you to check if this is still an issue in the latest release and if you find that this is still a problem, please feel free to open a new one.
           stale-issue-message: It looks like this issue has not been active for 10 days. If the issue is not resolved, please add an update to the ticket, else it will be automatically resolved in a few days.

--- a/close-stale-issues.yml
+++ b/close-stale-issues.yml
@@ -1,0 +1,38 @@
+name: Close Stale Issues
+
+# Controls when the action will be run
+# Run every day at 00:00
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  issues: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Close stale issues
+    steps:
+      - uses: aws-actions/stale-issue-cleanup@v3
+        with:
+          ancient-issue-message: This is a very old issue. We encourage you to check if this is still an issue in the latest release and if you find that this is still a problem, please feel free to open a new one.
+          stale-issue-message: It looks like this issue has not been active for 10 days. If the issue is not resolved, please add an update to the ticket, else it will be automatically resolved in a few days.
+
+          # labels to be added
+          stale-issue-label: closing-soon
+          exempt-issue-label: enhancement,pending-research,pending-action,needs-triage
+          response-requested-label: pending-response
+
+          closed-for-staleness-label: closed-for-staleness
+
+          # SLAs
+          days-before-stale: 7
+          days-before-close: 3
+          days-before-ancient: 180
+
+
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          loglevel: DEBUG
+          # Set dry-run to true to not perform label or close actions.
+          dry-run: true


### PR DESCRIPTION
*Issue #, if available:*
N/A

*What was changed?*
Add a github workflow using `aws-actions/stale-issue-cleanup@v7` for this workflow.
The workflow runs on all issues that are tagged with label `pending-response` (waiting on author's response).
- If the issue has seen no activity for 7 days, it will be tagged with label `closing-soon`
- Following that, if the issue still doesn't see any activity for 3 more days it will be closed (reason: staleness)

*Why was it changed?*
- Automate closing of stale issues

*How was it changed?*
- Github actions

*What testing was done for the changes?*
- Dry run enabled. We should verify workflow logs and disable dry run later on.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
