### PR TITLE
Fix samples to work with rpi camera and update documentation

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -21,7 +21,7 @@ jobs:
 
           # labels to be added
           stale-issue-label: closing-soon
-          exempt-issue-label: enhancement,pending-research,pending-action,needs-triage
+          exempt-issue-labels: enhancement,pending-research,pending-action,needs-triage
           response-requested-label: pending-response
 
           closed-for-staleness-label: closed-for-staleness

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For more info on KVS please see [AWS KVS Documentation](https://docs.aws.amazon.
 <br>
 
 ## Quick Start
-The following instructions describe the SDK and samples setup for Mac, Linux, and Windows platforms. For dedicated Raspberry Pi instructions, see [Use the C++ producer SDK on Raspberry Pi](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/producersdk-cpp-rpi.html)
+The following instructions describe the SDK and samples setup for Mac, Linux, and Windows platforms. For dedicated Raspberry Pi instructions, see [Use the C++ producer SDK on Raspberry Pi](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/producersdk-cpp-rpi.html) and [Raspberry Pi setup guide](docs/raspberry-pi.md).
 
 ### Required Tools
 The following packages are required to build the SDK libraries. Using a package manager such as [_Homebrew_](https://brew.sh/) (Mac), [_APT_](https://en.wikipedia.org/wiki/APT_(software)) (Linux), and [_Chocolatey_](https://chocolatey.org/install) (Windows) is the prefered method of installation.

--- a/docs/raspberry-pi.md
+++ b/docs/raspberry-pi.md
@@ -94,7 +94,7 @@ $ gst-launch-1.0 -v v4l2src device=/dev/video0 ! h264parse ! video/x-h264,stream
 ###### Running the `gst-launch-1.0` command to start streaming from camera source:
 
 ```
-$ gst-launch-1.0 -v v4l2src do-timestamp=TRUE device=/dev/video0 ! videoconvert ! video/x-raw,format=I420,width=640,height=480,framerate=30/1 ! omxh264enc periodicty-idr=45 inline-header=FALSE ! h264parse ! video/x-h264,stream-format=avc,alignment=au ! kvssink stream-name=YourStreamName access-key="YourAccessKey" secret-key="YourSecretKey"
+$ gst-launch-1.0 -v v4l2src do-timestamp=TRUE device=/dev/video0 ! videoconvert ! video/x-raw,format=I420,width=640,height=480,framerate=30/1 ! omxh264enc periodicity-idr=45 inline-header=FALSE ! h264parse ! video/x-h264,stream-format=avc,alignment=au ! kvssink stream-name=YourStreamName access-key="YourAccessKey" secret-key="YourSecretKey"
 ```
 or use a different encoder
 ```
@@ -139,7 +139,7 @@ card 3: Camera [H264 USB Camera], device 0: USB Audio [USB Audio]
 The audio recording device is represented by `hw:card_number,device_numer`. So to use the second device in the example, use `hw:3,0` as the device in `gst-launch-1.0` command.
 
 ```
-gst-launch-1.0 -v v4l2src device=/dev/video0 ! videoconvert ! video/x-raw,width=640,height=480,framerate=30/1,format=I420 ! omxh264enc periodicty-idr=45 inline-header=FALSE ! h264parse ! video/x-h264,stream-format=avc,alignment=au,profile=baseline ! kvssink name=sink stream-name="my-stream-name" access-key="YourAccessKey" secret-key="YourSecretKey" alsasrc device=hw:1,0 ! audioconvert ! avenc_aac ! queue ! sink.
+gst-launch-1.0 -v v4l2src device=/dev/video0 ! videoconvert ! video/x-raw,width=640,height=480,framerate=30/1,format=I420 ! omxh264enc periodicity-idr=45 inline-header=FALSE ! h264parse ! video/x-h264,stream-format=avc,alignment=au,profile=baseline ! kvssink name=sink stream-name="my-stream-name" access-key="YourAccessKey" secret-key="YourSecretKey" alsasrc device=hw:1,0 ! audioconvert ! avenc_aac ! queue ! sink.
 ```
 
 if your camera supports outputting h264 encoded stream directly, then you can use this command:

--- a/docs/raspberry-pi.md
+++ b/docs/raspberry-pi.md
@@ -5,15 +5,26 @@ The following steps were tested on a Debian buster platform
 
 Run the following commands to install the prerequisite libraries to get started:
 
-`sudo apt-get install cmake m4 git build-essential`
+```
+sudo apt-get install cmake m4 git build-essential
 
-`sudo apt-get install gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-tools gstreamer1.0-omx-rpi
-gstreamer1.0-plugins-base-apps`
+sudo apt-get install gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-tools gstreamer1.0-omx-rpi
+gstreamer1.0-plugins-base-apps
+```
 
 Also, install the gstreamer1.0-omx package to get the omxh264enc hardware encoder:
 
-`sudo apt-get install gstreamer1.0-omx`
+```
+sudo apt-get install gstreamer1.0-omx
+```
 
+On **Raspberry Pi OS Bookworm and later**, `gstreamer1.0-omx` is no longer available. These versions will have the `v4l2h264enc` hardware encoder
+
+**Note:** For Pi camera modules, install `gstreamer1.0-libcamera` to enable `libcamerasrc` support, the programmatic samples provided will fall back to `v4l2src` for USB cameras if it is not available.
+
+```
+sudo apt-get install gstreamer1.0-libcamera
+```
 
 ### How to run sample applications for sending media to KVS using [GStreamer](https://gstreamer.freedesktop.org/):
 
@@ -90,10 +101,16 @@ or use a different encoder
 $ gst-launch-1.0 -v v4l2src device=/dev/video0 ! videoconvert ! video/x-raw,format=I420,width=640,height=480,framerate=30/1 ! x264enc  bframes=0 key-int-max=45 bitrate=500 tune=zerolatency ! video/x-h264,stream-format=avc,alignment=au ! kvssink stream-name=YourStreamName storage-size=128 access-key="YourAccessKey" secret-key="YourSecretKey"
 ```
 
-**Note:** If you are using **Raspberry PI with Bullseye** you have to use another encoder as well as `libcamerasrc` instead of `v4l2src device=/dev/video0`
+**Note:** If you are using **Raspberry Pi with Bullseye or later** (Bookworm, Trixie), use `libcamerasrc` instead of `v4l2src` for Pi camera modules. On Bookworm and later, `omxh264enc` is no longer available, use `v4l2h264enc` or `x264enc` instead.
 
+Using `v4l2h264enc` (hardware encoder, may not work on all kernel versions):
 ```
 $ gst-launch-1.0 libcamerasrc ! video/x-raw,width=640,height=480,framerate=30/1,format=I420 ! videoconvert ! v4l2h264enc extra-controls="controls,repeat_sequence_header=1" ! video/x-h264,level='(string)4' ! h264parse ! video/x-h264,stream-format=avc, alignment=au,width=640,height=480,framerate=30/1 ! kvssink stream-name="test-stream" access-key="YourAccessKey" secret-key="YourSecretKey" aws-region="YourRegion"
+```
+
+Using `x264enc` (software encoder):
+```
+$ gst-launch-1.0 libcamerasrc ! video/x-raw,width=640,height=480,framerate=30/1,format=I420 ! videoconvert ! x264enc bframes=0 key-int-max=45 bitrate=512 speed-preset=veryfast tune=zerolatency ! video/x-h264,stream-format=avc,alignment=au ! h264parse ! kvssink stream-name="test-stream" access-key="YourAccessKey" secret-key="YourSecretKey" aws-region="YourRegion"
 ```
 
 
@@ -258,7 +275,7 @@ To send log information to a file (named kvsProducerLog.index), you need to use 
 
 The addFileLoggerPlatformCallbacksProvider API takes five parameters.
 
-* First parameter is the PClientCallbacks that is created during the createCallback provider API (e.g.createDefaultCallbacksProviderWithAuthCallbacks.
+* First parameter is the PClientCallbacks that is created during the createCallback provider API (e.g.createDefaultCallbacksProviderWithAuthCallbacks).
 * Second parameter is the size of string buffer that file logger will use. Logs are buffered in the string buffer and flushed into files when the buffer is full.
 * Third parameter is the maximum number of files that file logger will generate. When the limit is reached, oldest log file will be deleted before creating the new one.
 * Fourth parameter is the absolute directory path to store the log file.

--- a/docs/raspberry-pi.md
+++ b/docs/raspberry-pi.md
@@ -24,7 +24,14 @@ On **Raspberry Pi OS Bookworm and later**, `gstreamer1.0-omx` is no longer avail
 
 ```
 sudo apt-get install gstreamer1.0-libcamera
+
+// use gst-inspect to verify installation of the plugin
+gst-inspect-1.0 libcamerasrc
+
+// try using libcamerasrc in basic pipeline to verify camera is detected
+gst-launch-1.0 -v v4l2src ! videoconvert ! autovideosink
 ```
+For additional info, pleae refer the [Use the C++ producer SDK on Raspberry Pi](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/producersdk-cpp-rpi.html)
 
 ### How to run sample applications for sending media to KVS using [GStreamer](https://gstreamer.freedesktop.org/):
 

--- a/samples/kvs_gstreamer_audio_video_sample.cpp
+++ b/samples/kvs_gstreamer_audio_video_sample.cpp
@@ -906,28 +906,83 @@ int gstreamer_init(int argc, char *argv[], CustomData &data) {
         video_caps_string += ", width=(int) 1280, height=(int) 720";
 
 #elif defined __linux__
-        videosrc = gst_element_factory_make("v4l2src", "videosrc");
-        if (!video_device.empty()) {
-            LOG_INFO("Using video device " << video_device);
-            // find your video device by running path/to/sdk/kinesis-video-native-build/downloads/local/bin/gst-device-monitor-1.0
-            g_object_set(G_OBJECT (videosrc), "device", video_device.c_str(), NULL);
-        } else {
-            LOG_INFO("Using default video device");
+        // Video source: libcamerasrc (Pi camera modules) -> v4l2src (USB/legacy cameras)
+        videosrc = gst_element_factory_make("libcamerasrc", "videosrc");
+        if (videosrc) {
+            if (gst_element_set_state(videosrc, GST_STATE_READY) == GST_STATE_CHANGE_SUCCESS) {
+                gst_element_set_state(videosrc, GST_STATE_NULL);
+                LOG_INFO("Using libcamerasrc");
+            } else {
+                LOG_INFO("libcamerasrc found but no compatible camera detected, falling back");
+                gst_object_unref(videosrc);
+                videosrc = NULL;
+            }
+        }
+        if (!videosrc) {
+            videosrc = gst_element_factory_make("v4l2src", "videosrc");
+            if (videosrc) {
+                LOG_INFO("Using v4l2src");
+                if (!video_device.empty()) {
+                    LOG_INFO("Using video device " << video_device);
+                    g_object_set(G_OBJECT (videosrc), "device", video_device.c_str(), NULL);
+                } else {
+                    LOG_INFO("Using default video device");
+                }
+            } else {
+                LOG_ERROR("Failed to create any video source");
+                return 1;
+            }
         }
 
-        if (nullptr != (h264enc = gst_element_factory_make("omxh264enc", "h264enc"))) {
-            // setting target bitrate in omx is currently broken: https://gitlab.freedesktop.org/gstreamer/gst-omx/issues/21
-            g_object_set(G_OBJECT (h264enc), "periodicty-idr", 45, "inline-header", FALSE, NULL);
-        } else {
+        // Encoder: omxh264enc (legacy Pi) -> v4l2h264enc (Bookworm and later) -> x264enc (software)
+        h264enc = gst_element_factory_make("omxh264enc", "h264enc");
+        if (h264enc) {
+            if (gst_element_set_state(h264enc, GST_STATE_READY) == GST_STATE_CHANGE_SUCCESS) {
+                gst_element_set_state(h264enc, GST_STATE_NULL);
+                LOG_INFO("Using omxh264enc");
+                g_object_set(G_OBJECT (h264enc), "periodicty-idr", 45, "inline-header", FALSE, NULL);
+            } else {
+                LOG_INFO("omxh264enc found but not usable, falling back");
+                gst_object_unref(h264enc);
+                h264enc = NULL;
+            }
+        }
+
+        if (!h264enc) {
+            h264enc = gst_element_factory_make("v4l2h264enc", "h264enc");
+            if (h264enc) {
+                if (gst_element_set_state(h264enc, GST_STATE_READY) == GST_STATE_CHANGE_SUCCESS) {
+                    gst_element_set_state(h264enc, GST_STATE_NULL);
+                    LOG_INFO("Using v4l2h264enc");
+                    GstStructure *extra_controls = gst_structure_new("controls",
+                        "repeat_sequence_header", G_TYPE_INT, 1,
+                        NULL);
+                    g_object_set(G_OBJECT (h264enc), "extra-controls", extra_controls, NULL);
+                    gst_structure_free(extra_controls);
+                } else {
+                    LOG_INFO("v4l2h264enc found but not usable, falling back");
+                    gst_object_unref(h264enc);
+                    h264enc = NULL;
+                }
+            }
+        }
+
+        if (!h264enc) {
             h264enc = gst_element_factory_make("x264enc", "h264enc");
-            g_object_set(G_OBJECT (h264enc), "bframes", 0, "key-int-max", 45, "bitrate", 512, NULL);
-            gst_util_set_object_arg(G_OBJECT (h264enc), "tune", "zerolatency");
+            if (h264enc) {
+                LOG_INFO("Using x264enc");
+                g_object_set(G_OBJECT (h264enc), "bframes", 0, "key-int-max", 45, "bitrate", 512, NULL);
+                gst_util_set_object_arg(G_OBJECT (h264enc), "speed-preset", "veryfast");
+                gst_util_set_object_arg(G_OBJECT (h264enc), "tune", "zerolatency");
+            } else {
+                LOG_ERROR("Failed to create any H.264 encoder");
+                return 1;
+            }
         }
 
         audiosrc = gst_element_factory_make("alsasrc", "audiosrc");
         if (!audio_device.empty()) {
             LOG_INFO("Using audio device " << audio_device);
-            // find your audio recording device by running "arecord -l"
             g_object_set(G_OBJECT (audiosrc), "device", audio_device.c_str(), NULL);
         } else {
             LOG_ERROR("No audio device found. Please do export " << AUDIO_DEVICE_ENV_VAR << "=audio_device to config audio device (e.g. export AWS_KVS_AUDIO_DEVICE=hw:1,0)");

--- a/samples/kvs_gstreamer_audio_video_sample.cpp
+++ b/samples/kvs_gstreamer_audio_video_sample.cpp
@@ -1076,8 +1076,10 @@ int main(int argc, char *argv[]) {
 
     if (argc < 2) {
         LOG_ERROR(
-                "Usage: AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kinesis_video_gstreamer_audio_video_sample_app my-stream-name -f /path/to/file"
-                        "AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kinesis_video_gstreamer_audio_video_sample_app my-stream-name");
+                "Usage: AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET "
+                << argv[0] << " my-stream-name -f /path/to/file\n"
+                "   or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET "
+                << argv[0] << " my-stream-name");
         return 1;
     }
 

--- a/samples/kvs_gstreamer_audio_video_sample.cpp
+++ b/samples/kvs_gstreamer_audio_video_sample.cpp
@@ -940,7 +940,7 @@ int gstreamer_init(int argc, char *argv[], CustomData &data) {
             if (gst_element_set_state(h264enc, GST_STATE_READY) == GST_STATE_CHANGE_SUCCESS) {
                 gst_element_set_state(h264enc, GST_STATE_NULL);
                 LOG_INFO("Using omxh264enc");
-                g_object_set(G_OBJECT (h264enc), "periodicty-idr", 45, "inline-header", FALSE, NULL);
+                g_object_set(G_OBJECT (h264enc), "periodicity-idr", 45, "inline-header", FALSE, NULL);
             } else {
                 LOG_INFO("omxh264enc found but not usable, falling back");
                 gst_object_unref(h264enc);

--- a/samples/kvs_gstreamer_sample.cpp
+++ b/samples/kvs_gstreamer_sample.cpp
@@ -1144,10 +1144,14 @@ int main(int argc, char* argv[]) {
 
     if (argc < 2) {
         LOG_ERROR(
-                "Usage: AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kvs_gstreamer_sample my-stream-name -w width -h height -f framerate -b bitrateInKBPS\n \
-           or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kvs_gstreamer_sample my-stream-name\n \
-           or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kvs_gstreamer_sample my-stream-name rtsp-url\n \
-           or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kvs_gstreamer_sample my-stream-name path/to/file1 path/to/file2 ...\n");
+                "Usage: AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET "
+                << argv[0] << " my-stream-name -w width -h height -f framerate -b bitrateInKBPS\n"
+                "   or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET "
+                << argv[0] << " my-stream-name\n"
+                "   or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET "
+                << argv[0] << " my-stream-name rtsp-url\n"
+                "   or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET "
+                << argv[0] << " my-stream-name path/to/file1 path/to/file2 ...");
         return 1;
     }
 

--- a/samples/kvs_gstreamer_sample.cpp
+++ b/samples/kvs_gstreamer_sample.cpp
@@ -903,7 +903,7 @@ int gstreamer_live_source_init(int argc, char* argv[], CustomData *data, GstElem
             gst_structure_free(extra_controls);
         } else if (isOmxEnc) {
             g_object_set(G_OBJECT(encoder), "control-rate", 2, "target-bitrate", bitrateInKBPS * 1000,
-                         "periodicty-idr", 45, "inline-header", FALSE, NULL);
+                         "periodicity-idr", 45, "inline-header", FALSE, NULL);
         } else {
             g_object_set(G_OBJECT(encoder), "bframes", 0, "key-int-max", 45, "bitrate", bitrateInKBPS, NULL);
             gst_util_set_object_arg(G_OBJECT(encoder), "speed-preset", "veryfast");

--- a/samples/kvs_gstreamer_sample.cpp
+++ b/samples/kvs_gstreamer_sample.cpp
@@ -623,7 +623,7 @@ static void pad_added_cb(GstElement *element, GstPad *pad, GstElement *target) {
 
 int gstreamer_live_source_init(int argc, char* argv[], CustomData *data, GstElement *pipeline) {
 
-    bool vtenc = false, isOnRpi = false;
+    bool vtenc = false, isOmxEnc = false, isV4l2Enc = false;
 
     /* init stream format */
     int width = 0, height = 0, framerate = 25, bitrateInKBPS = 512;
@@ -725,14 +725,39 @@ int gstreamer_live_source_init(int argc, char* argv[], CustomData *data, GstElem
             return 1;
         }
     } else {
-        // Failed creating vtenc - check pi hardware encoder
+        // Try hardware encoders with readiness check, then software fallback
+        // 1. omxh264enc (legacy Pi OS)
         encoder = gst_element_factory_make("omxh264enc", "encoder");
         if (encoder) {
-            LOG_DEBUG("Using omxh264enc");
-            isOnRpi = true;
-        } else {
-            // - attempt x264enc
-            isOnRpi = false;
+            if (gst_element_set_state(encoder, GST_STATE_READY) == GST_STATE_CHANGE_SUCCESS) {
+                gst_element_set_state(encoder, GST_STATE_NULL);
+                LOG_DEBUG("Using omxh264enc");
+                isOmxEnc = true;
+            } else {
+                LOG_DEBUG("omxh264enc found but not usable, falling back");
+                gst_object_unref(encoder);
+                encoder = NULL;
+            }
+        }
+
+        // 2. v4l2h264enc (Bookworm and later)
+        if (!encoder) {
+            encoder = gst_element_factory_make("v4l2h264enc", "encoder");
+            if (encoder) {
+                if (gst_element_set_state(encoder, GST_STATE_READY) == GST_STATE_CHANGE_SUCCESS) {
+                    gst_element_set_state(encoder, GST_STATE_NULL);
+                    LOG_DEBUG("Using v4l2h264enc");
+                    isV4l2Enc = true;
+                } else {
+                    LOG_DEBUG("v4l2h264enc found but not usable, falling back");
+                    gst_object_unref(encoder);
+                    encoder = NULL;
+                }
+            }
+        }
+
+        // 3. x264enc software fallback
+        if (!encoder) {
             encoder = gst_element_factory_make("x264enc", "encoder");
             if (encoder) {
                 LOG_DEBUG("Using x264enc");
@@ -741,20 +766,35 @@ int gstreamer_live_source_init(int argc, char* argv[], CustomData *data, GstElem
                 return 1;
             }
         }
-        source = gst_element_factory_make("v4l2src", "source");
+
+        source = gst_element_factory_make("libcamerasrc", "source");
         if (source) {
-            LOG_DEBUG("Using v4l2src");
-        } else {
-            LOG_DEBUG("Failed to create v4l2src, trying ksvideosrc")
-            source = gst_element_factory_make("ksvideosrc", "source");
-            if (source) {
-                LOG_DEBUG("Using ksvideosrc");
+            if (gst_element_set_state(source, GST_STATE_READY) == GST_STATE_CHANGE_SUCCESS) {
+                gst_element_set_state(source, GST_STATE_NULL);
+                LOG_DEBUG("Using libcamerasrc");
             } else {
-                LOG_ERROR("Failed to create ksvideosrc");
-                return 1;
+                LOG_DEBUG("libcamerasrc found but no compatible camera detected, falling back");
+                gst_object_unref(source);
+                source = NULL;
             }
         }
-        vtenc = false;
+        if (!source) {
+            LOG_WARN("GStreamer libcamera plugin not installed or no compatible camera detected.");
+            LOG_WARN("Install gstreamer1.0-libcamera to use camera modules compatible with the libcamera.");
+            source = gst_element_factory_make("v4l2src", "source");
+            if (source) {
+                LOG_DEBUG("Using v4l2src");
+            } else {
+                LOG_DEBUG("Failed to create v4l2src, trying ksvideosrc")
+                source = gst_element_factory_make("ksvideosrc", "source");
+                if (source) {
+                    LOG_DEBUG("Using ksvideosrc");
+                } else {
+                    LOG_ERROR("Failed to create ksvideosrc");
+                    return 1;
+                }
+            }
+        }
     }
 
     if (!pipeline || !source || !source_filter || !encoder || !filter || !appsink || !h264parse) {
@@ -764,10 +804,13 @@ int gstreamer_live_source_init(int argc, char* argv[], CustomData *data, GstElem
 
     /* configure source */
     if (vtenc) {
-        g_object_set(G_OBJECT (source), "is-live", TRUE, NULL);
-    } else {
-        g_object_set(G_OBJECT (source), "do-timestamp", TRUE, "device", "/dev/video0", NULL);
+        g_object_set(G_OBJECT(source), "is-live", TRUE, NULL);
+    } else if (g_strcmp0(gst_element_get_name(gst_element_get_factory(source)), "v4l2src") == 0) {
+        g_object_set(G_OBJECT(source), "do-timestamp", TRUE, "device", "/dev/video0", NULL);
+    } else if (g_strcmp0(gst_element_get_name(gst_element_get_factory(source)), "ksvideosrc") == 0) {
+        g_object_set(G_OBJECT(source), "do-timestamp", TRUE, NULL);
     }
+    /* libcamerasrc handles timestamps and device selection internally */
 
     /* Determine whether device supports h264 encoding and select a streaming resolution supported by the device*/
     if (GST_STATE_CHANGE_FAILURE == gst_element_set_state(source, GST_STATE_READY)) {
@@ -850,13 +893,21 @@ int gstreamer_live_source_init(int argc, char* argv[], CustomData *data, GstElem
     /* configure encoder */
     if (!data->h264_stream_supported){
         if (vtenc) {
-            g_object_set(G_OBJECT (encoder), "allow-frame-reordering", FALSE, "realtime", TRUE, "max-keyframe-interval",
+            g_object_set(G_OBJECT(encoder), "allow-frame-reordering", FALSE, "realtime", TRUE, "max-keyframe-interval",
                          45, "bitrate", bitrateInKBPS, NULL);
-        } else if (isOnRpi) {
-            g_object_set(G_OBJECT (encoder), "control-rate", 2, "target-bitrate", bitrateInKBPS*1000,
+        } else if (isV4l2Enc) {
+            GstStructure *extra_controls = gst_structure_new("controls",
+                "repeat_sequence_header", G_TYPE_INT, 1,
+                NULL);
+            g_object_set(G_OBJECT(encoder), "extra-controls", extra_controls, NULL);
+            gst_structure_free(extra_controls);
+        } else if (isOmxEnc) {
+            g_object_set(G_OBJECT(encoder), "control-rate", 2, "target-bitrate", bitrateInKBPS * 1000,
                          "periodicty-idr", 45, "inline-header", FALSE, NULL);
         } else {
-            g_object_set(G_OBJECT (encoder), "bframes", 0, "key-int-max", 45, "bitrate", bitrateInKBPS, NULL);
+            g_object_set(G_OBJECT(encoder), "bframes", 0, "key-int-max", 45, "bitrate", bitrateInKBPS, NULL);
+            gst_util_set_object_arg(G_OBJECT(encoder), "speed-preset", "veryfast");
+            gst_util_set_object_arg(G_OBJECT(encoder), "tune", "zerolatency");
         }
     }
 
@@ -866,6 +917,9 @@ int gstreamer_live_source_init(int argc, char* argv[], CustomData *data, GstElem
                                              "stream-format", G_TYPE_STRING, "avc",
                                              "alignment", G_TYPE_STRING, "au",
                                              NULL);
+    if (isV4l2Enc) {
+        gst_caps_set_simple(h264_caps, "level", G_TYPE_STRING, "4", NULL);
+    }
     if (!data->h264_stream_supported) {
         gst_caps_set_simple(h264_caps, "profile", G_TYPE_STRING, "baseline",
                             NULL);
@@ -1090,10 +1144,10 @@ int main(int argc, char* argv[]) {
 
     if (argc < 2) {
         LOG_ERROR(
-                "Usage: AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kinesis_video_gstreamer_sample_app my-stream-name -w width -h height -f framerate -b bitrateInKBPS\n \
-           or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kinesis_video_gstreamer_sample_app my-stream-name\n \
-           or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kinesis_video_gstreamer_sample_app my-stream-name rtsp-url\n \
-           or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kinesis_video_gstreamer_sample_app my-stream-name path/to/file1 path/to/file2 ...\n");
+                "Usage: AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kvs_gstreamer_sample my-stream-name -w width -h height -f framerate -b bitrateInKBPS\n \
+           or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kvs_gstreamer_sample my-stream-name\n \
+           or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kvs_gstreamer_sample my-stream-name rtsp-url\n \
+           or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kvs_gstreamer_sample my-stream-name path/to/file1 path/to/file2 ...\n");
         return 1;
     }
 

--- a/samples/kvssink_gstreamer_sample.cpp
+++ b/samples/kvssink_gstreamer_sample.cpp
@@ -545,7 +545,7 @@ int gstreamer_live_source_init(int argc, char *argv[], CustomData *data, GstElem
             gst_structure_free(extra_controls);
         } else if (isOmxEnc) {
             g_object_set(G_OBJECT(encoder), "control-rate", 2, "target-bitrate", bitrateInKBPS * 1000,
-                         "periodicty-idr", 45, "inline-header", FALSE, NULL);
+                         "periodicity-idr", 45, "inline-header", FALSE, NULL);
         } else {
             g_object_set(G_OBJECT(encoder), "bframes", 0, "key-int-max", 45, "bitrate", bitrateInKBPS, NULL);
             gst_util_set_object_arg(G_OBJECT(encoder), "speed-preset", "veryfast");

--- a/samples/kvssink_gstreamer_sample.cpp
+++ b/samples/kvssink_gstreamer_sample.cpp
@@ -807,10 +807,14 @@ int main(int argc, char *argv[]) {
 
     if (argc < 2) {
         LOG_ERROR(
-                "Usage: AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kvssink_gstreamer_sample my-stream-name -w width -h height -f framerate -b bitrateInKBPS -runtime runtimeInSeconds\n \
-           or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kvssink_gstreamer_sample my-stream-name\n \
-           or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kvssink_gstreamer_sample my-stream-name rtsp-url -runtime runtimeInSeconds\n \
-           or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kvssink_gstreamer_sample my-stream-name path/to/file1 path/to/file2 ...\n");
+                "Usage: AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET " 
+                << argv[0] << " my-stream-name -w width -h height -f framerate -b bitrateInKBPS -runtime runtimeInSeconds\n"
+                "   or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET " 
+                << argv[0] << "my-stream-name\n"
+                "   or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET "
+                << argv[0] << "my-stream-name rtsp-url -runtime runtimeInSeconds\n"
+                "   or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET "
+                << argv[0] << "my-stream-name path/to/file1 path/to/file2 ...");
         return 1;
     }
 

--- a/samples/kvssink_gstreamer_sample.cpp
+++ b/samples/kvssink_gstreamer_sample.cpp
@@ -260,7 +260,7 @@ void determine_credentials(GstElement *kvssink, CustomData *data) {
 
 int gstreamer_live_source_init(int argc, char *argv[], CustomData *data, GstElement *pipeline) {
 
-    bool vtenc = false, isOnRpi = false;
+    bool vtenc = false, isOmxEnc = false, isV4l2Enc = false;
 
     /* init stream format */
     int width = 0, height = 0, framerate = 25, bitrateInKBPS = 512;
@@ -367,14 +367,39 @@ int gstreamer_live_source_init(int argc, char *argv[], CustomData *data, GstElem
             return 1;
         }
     } else {
-        // Failed creating vtenc - check pi hardware encoder
+        // Try hardware encoders with readiness check, then software fallback
+        // 1. omxh264enc (legacy Pi OS)
         encoder = gst_element_factory_make("omxh264enc", "encoder");
         if (encoder) {
-            LOG_DEBUG("Using omxh264enc")
-            isOnRpi = true;
-        } else {
-            // - attempt x264enc
-            isOnRpi = false;
+            if (gst_element_set_state(encoder, GST_STATE_READY) == GST_STATE_CHANGE_SUCCESS) {
+                gst_element_set_state(encoder, GST_STATE_NULL);
+                LOG_DEBUG("Using omxh264enc")
+                isOmxEnc = true;
+            } else {
+                LOG_DEBUG("omxh264enc found but not usable, falling back")
+                gst_object_unref(encoder);
+                encoder = NULL;
+            }
+        }
+
+        // 2. v4l2h264enc (Bookworm Pi)
+        if (!encoder) {
+            encoder = gst_element_factory_make("v4l2h264enc", "encoder");
+            if (encoder) {
+                if (gst_element_set_state(encoder, GST_STATE_READY) == GST_STATE_CHANGE_SUCCESS) {
+                    gst_element_set_state(encoder, GST_STATE_NULL);
+                    LOG_DEBUG("Using v4l2h264enc")
+                    isV4l2Enc = true;
+                } else {
+                    LOG_DEBUG("v4l2h264enc found but not usable, falling back")
+                    gst_object_unref(encoder);
+                    encoder = NULL;
+                }
+            }
+        }
+
+        // 3. x264enc software fallback
+        if (!encoder) {
             encoder = gst_element_factory_make("x264enc", "encoder");
             if (encoder) {
                 LOG_DEBUG("Using x264enc");
@@ -383,20 +408,34 @@ int gstreamer_live_source_init(int argc, char *argv[], CustomData *data, GstElem
                 return 1;
             }
         }
-        source = gst_element_factory_make("v4l2src", "source");
+        source = gst_element_factory_make("libcamerasrc", "source");
         if (source) {
-            LOG_DEBUG("Using v4l2src");
-        } else {
-            LOG_DEBUG("Failed to create v4l2src, trying ksvideosrc")
-            source = gst_element_factory_make("ksvideosrc", "source");
-            if (source) {
-                LOG_DEBUG("Using ksvideosrc");
+            if (gst_element_set_state(source, GST_STATE_READY) == GST_STATE_CHANGE_SUCCESS) {
+                gst_element_set_state(source, GST_STATE_NULL);
+                LOG_DEBUG("Using libcamerasrc");
             } else {
-                LOG_ERROR("Failed to create ksvideosrc");
-                return 1;
+                LOG_DEBUG("libcamerasrc found but no compatible camera detected, falling back");
+                gst_object_unref(source);
+                source = NULL;
             }
         }
-        vtenc = false;
+        if (!source) {
+            LOG_WARN("GStreamer libcamera plugin not installed or no compatible camera detected.");
+            LOG_WARN("Install gstreamer1.0-libcamera to use camera modules compatible with the libcamera stack.");
+            source = gst_element_factory_make("v4l2src", "source");
+            if (source) {
+                LOG_DEBUG("Using v4l2src");
+            } else {
+                LOG_DEBUG("Failed to create v4l2src, trying ksvideosrc")
+                source = gst_element_factory_make("ksvideosrc", "source");
+                if (source) {
+                    LOG_DEBUG("Using ksvideosrc");
+                } else {
+                    LOG_ERROR("Failed to create any video source");
+                    return 1;
+                }
+            }
+        }
     }
 
     if (!pipeline || !source || !source_filter || !encoder || !filter || !kvssink || !h264parse) {
@@ -407,9 +446,12 @@ int gstreamer_live_source_init(int argc, char *argv[], CustomData *data, GstElem
     /* configure source */
     if (vtenc) {
         g_object_set(G_OBJECT(source), "is-live", TRUE, NULL);
-    } else {
+    } else if (g_strcmp0(gst_element_get_name(gst_element_get_factory(source)), "v4l2src") == 0) {
         g_object_set(G_OBJECT(source), "do-timestamp", TRUE, "device", "/dev/video0", NULL);
+    } else if (g_strcmp0(gst_element_get_name(gst_element_get_factory(source)), "ksvideosrc") == 0) {
+        g_object_set(G_OBJECT(source), "do-timestamp", TRUE, NULL);
     }
+    /* libcamerasrc handles timestamps and device selection internally */
 
     /* Determine whether device supports h264 encoding and select a streaming resolution supported by the device*/
     if (GST_STATE_CHANGE_FAILURE == gst_element_set_state(source, GST_STATE_READY)) {
@@ -495,11 +537,19 @@ int gstreamer_live_source_init(int argc, char *argv[], CustomData *data, GstElem
         if (vtenc) {
             g_object_set(G_OBJECT(encoder), "allow-frame-reordering", FALSE, "realtime", TRUE, "max-keyframe-interval",
                          45, "bitrate", bitrateInKBPS, NULL);
-        } else if (isOnRpi) {
+        } else if (isV4l2Enc) {
+            GstStructure *extra_controls = gst_structure_new("controls",
+                "repeat_sequence_header", G_TYPE_INT, 1,
+                NULL);
+            g_object_set(G_OBJECT(encoder), "extra-controls", extra_controls, NULL);
+            gst_structure_free(extra_controls);
+        } else if (isOmxEnc) {
             g_object_set(G_OBJECT(encoder), "control-rate", 2, "target-bitrate", bitrateInKBPS * 1000,
                          "periodicty-idr", 45, "inline-header", FALSE, NULL);
         } else {
             g_object_set(G_OBJECT(encoder), "bframes", 0, "key-int-max", 45, "bitrate", bitrateInKBPS, NULL);
+            gst_util_set_object_arg(G_OBJECT(encoder), "speed-preset", "veryfast");
+            gst_util_set_object_arg(G_OBJECT(encoder), "tune", "zerolatency");
         }
     }
 
@@ -509,6 +559,9 @@ int gstreamer_live_source_init(int argc, char *argv[], CustomData *data, GstElem
                                              "stream-format", G_TYPE_STRING, "avc",
                                              "alignment", G_TYPE_STRING, "au",
                                              NULL);
+    if (isV4l2Enc) {
+        gst_caps_set_simple(h264_caps, "level", G_TYPE_STRING, "4", NULL);
+    }
     if (!data->h264_stream_supported) {
         gst_caps_set_simple(h264_caps, "profile", G_TYPE_STRING, "baseline",
                             NULL);
@@ -754,10 +807,10 @@ int main(int argc, char *argv[]) {
 
     if (argc < 2) {
         LOG_ERROR(
-                "Usage: AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kvssink_gstreamer_sample_app my-stream-name -w width -h height -f framerate -b bitrateInKBPS -runtime runtimeInSeconds\n \
-           or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kvssink_gstreamer_sample_app my-stream-name\n \
-           or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kvssink_gstreamer_sample_app my-stream-name rtsp-url -runtime runtimeInSeconds\n \
-           or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kvssink_gstreamer_sample_app my-stream-name path/to/file1 path/to/file2 ...\n");
+                "Usage: AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kvssink_gstreamer_sample my-stream-name -w width -h height -f framerate -b bitrateInKBPS -runtime runtimeInSeconds\n \
+           or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kvssink_gstreamer_sample my-stream-name\n \
+           or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kvssink_gstreamer_sample my-stream-name rtsp-url -runtime runtimeInSeconds\n \
+           or AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET ./kvssink_gstreamer_sample my-stream-name path/to/file1 path/to/file2 ...\n");
         return 1;
     }
 


### PR DESCRIPTION
*Issue #, if available:*
- Programmatic samples do not work on Raspberry Pi with camera module.

*What was changed?*
- Modified `kvs_gstreamer_sample` , `kvs_gstreamer_audio_video_sample` and `kvssink_gstreamer_sample` to follow a lookup chain for video source (`libcamerasrc [new added] --> v4l2src [existing]-->ksvideosrc [existing]`). Pi Camera modules use `libcamera` stack and must be accessed using `libcamerasrc`. USB cameras will still use `v4l2src`
- Modified h264 hardware encoder selection to add `v4l2h264enc` in the chain : `omxh264enc [existing] -> v4l2h264enc [new] -> x264enc [existing]`. omxh264enc is not available for RPi OS bookworm and later and `v4l2h264enc` must be used for these versions.
- Modify encoder configuration properties based on selected encoder.
- Update README and raspberry-pi.md with notes about using libcamerasrc and v4l2h264enc.
 
*Why was it changed?*
- Programmatic samples provided in the SDK do not work with Rpi camera modules out of the box. 

*How was it changed?*
- Modified gstreamer pipeline creation in samples

*What testing was done for the changes?*
- **TODO** before merging PR 
  - Test with USB Camera
  - Test on windows
- Manual testing with Rpi and camera module.
- Tested sample apps in MacOS and RPi

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
