### PR TITLE
Update package names in installation instructions for Mac and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ The following packages are required to build the SDK libraries. Using a package 
 
 _Mac_
 ```bash
-brew install git cmake pkgconf m4
+brew install git cmake pkg-config m4
 ```
 
 _Linux_
 ```bash
 sudo apt update
-sudo apt install git cmake pkgconf m4
+sudo apt install git cmake build-essential pkg-config m4
 ```
 
 _Windows_


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Update package name for `pkg-config`.
- Add `build-essential` for linux.

*Why was it changed?*
- On Linux: No such package `pkgconf`
- On Mac: Cosmetic alias. Both `pkgconf` and `pkg-config` resolve to the same package.
- Add `build-essential` since it also installs `gcc`, `g++` and `make`

*How was it changed?*
- Update the name in the readme

*What testing was done for the changes?*
- Ran the updated installation instructions
- Check with the CI file: https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/blob/master/.github/workflows/kvssink.yml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
