### PR TITLE
Treat transient retriable common lib error as non-fatal

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     name: Close stale issues
     steps:
-      - uses: aws-actions/stale-issue-cleanup@v7
+      - uses: aws-actions/stale-issue-cleanup@v7.1.1
         with:
           ancient-issue-message: This is a very old issue. We encourage you to check if this is still an issue in the latest release and if you find that this is still a problem, please feel free to open a new one.
           stale-issue-message: It looks like this issue has not been active for 10 days. If the issue is not resolved, please add an update to the ticket, else it will be automatically resolved in a few days.
 
           # labels to be added
           stale-issue-label: closing-soon
-          exempt-issue-labels: enhancement,pending-research,pending-action,needs-triage
+          exempt-issue-labels: enhancement,pending-research,pending-action,needs-triage,bug
           response-requested-label: pending-response
 
           closed-for-staleness-label: closed-for-staleness

--- a/src/gstreamer/KvsSinkStreamCallbackProvider.cpp
+++ b/src/gstreamer/KvsSinkStreamCallbackProvider.cpp
@@ -32,7 +32,7 @@ KvsSinkStreamCallbackProvider::streamErrorReportHandler(UINT64 custom_data,
                                                         STATUS status_code) {
     auto customDataObj = reinterpret_cast<KvsSinkCustomData*>(custom_data);
     LOG_ERROR("Reported stream error. Errored timecode: " << errored_timecode << " Status: 0x" << std::hex << status_code << " for " << customDataObj->kvs_sink->stream_name);
-    if(customDataObj != NULL && (!IS_RECOVERABLE_ERROR(status_code))) {
+    if(customDataObj != NULL && (!IS_RECOVERABLE_ERROR(status_code)) && (!IS_RETRIABLE_COMMON_LIB_ERROR(status_code))) {
         customDataObj->stream_status = status_code;
         g_signal_emit(G_OBJECT(customDataObj->kvs_sink), customDataObj->err_signal_id, 0, status_code);
     }


### PR DESCRIPTION
*Issue #, if available:*
- #1294

*What was changed?*
- Added `IS_RETRIABLE_COMMON_LIB_ERROR` check to `KvsSinkStreamCallbackProvider::streamErrorReportHandler` (The StreamErrorReportHandler provided for kvssink).

*Why was it changed?*
- When the IoT credentials endpoint experiences a transient network timeout during credential rotation, `blockingCurlCall` returns `STATUS_CURL_PERFORM_FAILED` (0x16000001). This error propagates through `notifyCallResult` to the kvssink stream error handler, which was treating it as fatal,  setting stream_status and emitting the GStreamer error signal. This caused the pipeline to terminate (`gst_kvs_sink_handle_buffer` [checks for `stream_status`](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/blob/master/src/gstreamer/gstkvssink.cpp#L1307)) even though the C Producer's `continuousRetryStreamErrorReportHandler` was already handling recovery by resetting the stream. The mismatch between the two handlers meant kvssink killed the pipeline before the retry/recovery mechanism could complete.

*How was it changed?*
- The condition in `streamErrorReportHandler` was changed to also check for `IS_RETRIABLE_COMMON_LIB_ERROR` which includes `STATUS_CURL_PERFORM_FAILED` (0x16000001):
  ```cpp
  if(customDataObj != NULL && (!IS_RECOVERABLE_ERROR(status_code)) && (!IS_RETRIABLE_COMMON_LIB_ERROR(status_code)))
  ```
  This prevents transient common library errors (curl timeouts, IoT response failures, etc.) from setting `stream_status` or emitting the GStreamer error signal, allowing the continuous retry handler to recover the stream gracefully.

*How this changes kvssink behavior?*
- kvssink will not treat curl timeout as fatal and rely on PIC state machine retries (max count: 5) before emitting the Gstreamer error signal and closing the stream.
- This will allow kvssink to handle transient curl errors - the curl API call will be retried 5 times before sending a non-retriable stream status.

*What testing was done for the changes?*
- Reproduced the issue using IoT certificate authentication with a forced 60-second credential expiration to trigger frequent rotation. Blocked the IoT credentials endpoint using macOS pf firewall (`pfctl`) during active streaming to simulate the curl timeout failure at the time of credential rotation. Verified that without the fix, the pipeline terminates with `GST_ELEMENT_ERROR` even when credentials endpoint was unblocked and curl API call succeeded in the second retry. With the fix applied, in the same scenario as before, the pipeline survives the outageand continues streaming after the endpoint becomes reachable and credentials are successfully refreshed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
