### PR TITLE
Add LOCAL_KVSC_PATH and LOCAL_KVSPIC_PATH Cmake var to use local dependency repos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,13 +95,33 @@ set(BUILD_COMMON_LWS
 set(BUILD_COMMON_CURL
     TRUE
     CACHE BOOL "Build ProducerC with CURL Support" FORCE)
-set(DEPENDENCY_DOWNLOAD_PATH ${CMAKE_CURRENT_SOURCE_DIR}/dependency)
-if(NOT EXISTS ${DEPENDENCY_DOWNLOAD_PATH})
-  file(MAKE_DIRECTORY ${DEPENDENCY_DOWNLOAD_PATH})
-endif()
 
-fetch_repo(kvscproducer)
-add_subdirectory(${DEPENDENCY_DOWNLOAD_PATH}/libkvscproducer/kvscproducer-src EXCLUDE_FROM_ALL)
+# Local development override: point to your local producer-C checkout
+set(LOCAL_KVSC_PATH "" CACHE PATH "Path to local KVS Producer C SDK (skips git fetch when set)")
+set(LOCAL_KVSPIC_PATH "" CACHE PATH "Path to local KVS PIC SDK (passed to Producer C, skips git fetch when set)")
+
+if(LOCAL_KVSC_PATH)
+  message(STATUS "Using LOCAL KVS Producer C SDK at: ${LOCAL_KVSC_PATH}")
+  if(NOT EXISTS ${LOCAL_KVSC_PATH}/CMakeLists.txt)
+    message(FATAL_ERROR "LOCAL_KVSC_PATH does not contain a CMakeLists.txt: ${LOCAL_KVSC_PATH}")
+  endif()
+  # Forward LOCAL_KVSPIC_PATH to Producer C so it uses local PIC too
+  if(LOCAL_KVSPIC_PATH)
+    set(LOCAL_KVSPIC_PATH ${LOCAL_KVSPIC_PATH} CACHE PATH "" FORCE)
+  endif()
+  add_subdirectory(${LOCAL_KVSC_PATH} ${CMAKE_CURRENT_BINARY_DIR}/kvscproducer-build EXCLUDE_FROM_ALL)
+else()
+  set(DEPENDENCY_DOWNLOAD_PATH ${CMAKE_CURRENT_SOURCE_DIR}/dependency)
+  if(NOT EXISTS ${DEPENDENCY_DOWNLOAD_PATH})
+    file(MAKE_DIRECTORY ${DEPENDENCY_DOWNLOAD_PATH})
+  endif()
+  fetch_repo(kvscproducer)
+  # Forward LOCAL_KVSPIC_PATH even when using fetched Producer C
+  if(LOCAL_KVSPIC_PATH)
+    set(LOCAL_KVSPIC_PATH ${LOCAL_KVSPIC_PATH} CACHE PATH "" FORCE)
+  endif()
+  add_subdirectory(${DEPENDENCY_DOWNLOAD_PATH}/libkvscproducer/kvscproducer-src EXCLUDE_FROM_ALL)
+endif()
 ############# find dependent libraries ############
 
 find_package(Threads)

--- a/README.md
+++ b/README.md
@@ -399,6 +399,43 @@ Afterwards, go to your repository settings and add the following repository secr
 * Key: `AWS_REGION` -- Region to use (e.g. `us-west-2`)
 * Key: `AWS_ROLE_SESSION_NAME` -- Optional. This name appears in AWS CloudTrail logs for entries associated with this session.
 
+## Local Development with Dependency Overrides
+
+When developing changes across the SDK stack (C++ SDK → C Producer → PIC), you can point the build to local checkouts instead of fetching from GitHub. This avoids the git-fetch cycle and lets you test changes across repos immediately.
+
+### CMake Variables
+
+| Variable | Used By | Description |
+|----------|---------|-------------|
+| `LOCAL_KVSC_PATH` | C++ SDK | Path to a local [KVS Producer C SDK](https://github.com/awslabs/amazon-kinesis-video-streams-producer-c) checkout |
+| `LOCAL_KVSPIC_PATH` | C++ SDK, C Producer | Path to a local [KVS PIC](https://github.com/awslabs/amazon-kinesis-video-streams-pic) checkout |
+
+### Usage
+
+```bash
+# Build C++ SDK using local C Producer and local PIC
+mkdir -p build && cd build
+cmake .. \
+  -DBUILD_GSTREAMER_PLUGIN=ON \
+  -DLOCAL_KVSC_PATH=/path/to/amazon-kinesis-video-streams-producer-c \
+  -DLOCAL_KVSPIC_PATH=/path/to/amazon-kinesis-video-streams-pic
+make
+```
+
+You can use either variable independently:
+
+```bash
+# Only override PIC (C Producer is still fetched from GitHub)
+cmake .. -DLOCAL_KVSPIC_PATH=/path/to/amazon-kinesis-video-streams-pic
+
+# Only override C Producer (PIC is fetched by C Producer from GitHub)
+cmake .. -DLOCAL_KVSC_PATH=/path/to/amazon-kinesis-video-streams-producer-c
+```
+
+When `LOCAL_KVSC_PATH` is set, the C++ SDK uses `add_subdirectory` to include the local C Producer directly. When `LOCAL_KVSPIC_PATH` is set, it is forwarded to the C Producer build so PIC is also resolved locally. This means a single `cmake` + `make` builds all three layers from your working copies. Changes in PIC or C Producer source files are picked up on the next `make` without re-running `cmake`.
+
+<br>
+
 ## Development
 
 The repository is using develop branch as the aggregation and all of the feature development is done in appropriate feature branches. The PRs (Pull Requests) are cut on a feature branch and once approved with all the checks passed, they can be merged by a click of a button on the PR tool. The master branch should always be build-able and all the tests should be passing. We are welcoming any contribution to the code base. The master branch contains our most recent release cycle from develop.


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added `LOCAL_KVSC_PATH` and `LOCAL_KVSPIC_PATH` CMake cache variables for local dependency override
- Added "Local Development with Dependency Overrides" section to README.md documenting usage

*Why was it changed?*
- Developers working across the SDK stack (C++ SDK → C Producer → PIC) had to commit and push changes to dependency repos before they could be picked up by the downstream build, or make changes in dependency folder which can be lost during a rebuild. This slowed iteration significantly during cross-repo development (e.g., debugging the PIC state machine while testing from the C++ SDK).
- The `LOCAL_KVSC_PATH` / `LOCAL_KVSPIC_PATH` flags let you point cmake at local checkouts, skipping the git fetch and building all three layers from working copies in a single `make`.

*How was it changed?*
- `CMakeLists.txt`: Added two `CACHE PATH` variables. When `LOCAL_KVSC_PATH` is set, `add_subdirectory` is used instead of `fetch_repo(kvscproducer)`. `LOCAL_KVSPIC_PATH` is forwarded to the C Producer build in both paths (local and fetched).
- `README.md`: Added a new section before "Development" documenting the variables, usage examples, and a typical multi-repo workflow.

*What testing was done for the changes?*
- Built with both variables set to local checkouts and verified that the full stack compiles and links correctly
- Built with only `LOCAL_KVSPIC_PATH` set and verified that the C Producer is fetched but uses local PIC
- Built with neither variable set and verified default git-fetch behavior is unchanged
- Ran GStreamer sample (`kvssink_gstreamer_sample`) end-to-end after building with local overrides

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.