### PR TITLE
make gst pipeline resilient to transient recoverable errors

### DIFF
--- a/src/gstreamer/KvsSinkStreamCallbackProvider.cpp
+++ b/src/gstreamer/KvsSinkStreamCallbackProvider.cpp
@@ -32,7 +32,11 @@ KvsSinkStreamCallbackProvider::streamErrorReportHandler(UINT64 custom_data,
                                                         STATUS status_code) {
     auto customDataObj = reinterpret_cast<KvsSinkCustomData*>(custom_data);
     LOG_ERROR("Reported stream error. Errored timecode: " << errored_timecode << " Status: 0x" << std::hex << status_code << " for " << customDataObj->kvs_sink->stream_name);
-    if(customDataObj != NULL && (!IS_RECOVERABLE_ERROR(status_code)) && (!IS_RETRIABLE_COMMON_LIB_ERROR(status_code))) {
+    // Only surface fatal errors as stream_status. Retriable and recoverable
+    // errors are handled internally by PIC's retry/recovery state machine and must not
+    // be treated as fatal.
+    if(customDataObj != NULL && (!IS_RETRIABLE_ERROR(status_code)) &&
+       (!IS_RECOVERABLE_ERROR(status_code)) && (!IS_RETRIABLE_COMMON_LIB_ERROR(status_code))) {
         customDataObj->stream_status = status_code;
         g_signal_emit(G_OBJECT(customDataObj->kvs_sink), customDataObj->err_signal_id, 0, status_code);
     }

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -1305,15 +1305,17 @@ gst_kvs_sink_handle_buffer (GstCollectPads * pads,
     info.data = NULL;
 
     if (STATUS_FAILED(stream_status)) {
+        GST_ELEMENT_ERROR (kvssink, STREAM, FAILED, (NULL),
+            ("Stream error occurred. Status: 0x%08x", stream_status));
         // in offline case, we cant tell the pipeline to restream the file again in case of network outage.
         // therefore error out and let higher level application do the retry.
-        if (IS_OFFLINE_STREAMING_MODE(kvssink->streaming_type) || !IS_RETRIABLE_ERROR(stream_status)) {
+        if (IS_OFFLINE_STREAMING_MODE(kvssink->streaming_type)) {
             // fatal cases
-            GST_ELEMENT_ERROR (kvssink, STREAM, FAILED, (NULL),
-                           ("[%s] Stream error occurred. Status: 0x%08x", kvssink->stream_name, stream_status));
+            GST_ELEMENT_ERROR (kvssink, STREAM, FAILED, (NULL), ("Stop stream in offline mode"));
             ret = GST_FLOW_ERROR;
             goto CleanUp;
         } else {
+            GST_ELEMENT_ERROR (kvssink, STREAM, FAILED, (NULL), ("Reset stream"));
             // resetStream, note that this will flush out producer buffer
             data->kinesis_video_stream->resetStream();
             // reset state

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -1312,14 +1312,14 @@ gst_kvs_sink_handle_buffer (GstCollectPads * pads,
         if (!kvssink->restart_on_error || IS_OFFLINE_STREAMING_MODE(kvssink->streaming_type)) {
             // fatal case: post a fatal ERROR to the bus so the pipeline terminates
             GST_ELEMENT_ERROR (kvssink, STREAM, FAILED, (NULL),
-                ("Stream error occurred. Status: 0x%08x", stream_status));
+                ("[%s] Stream error occurred. Status: 0x%08x", kvssink->stream_name, stream_status));
             ret = GST_FLOW_ERROR;
             goto CleanUp;
         } else {
             // non-fatal case: post a WARNING (not ERROR) so the pipeline keeps running,
             // then reset the stream and continue.
             GST_ELEMENT_WARNING (kvssink, STREAM, FAILED, (NULL),
-                ("Stream error occurred, resetting stream. Status: 0x%08x", stream_status));
+                ("[%s] Stream error occurred, resetting stream. Status: 0x%08x", kvssink->stream_name, stream_status));
             // resetStream, note that this will flush out producer buffer
             data->kinesis_video_stream->resetStream();
             // reset state

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -1305,17 +1305,21 @@ gst_kvs_sink_handle_buffer (GstCollectPads * pads,
     info.data = NULL;
 
     if (STATUS_FAILED(stream_status)) {
-        GST_ELEMENT_ERROR (kvssink, STREAM, FAILED, (NULL),
-            ("Stream error occurred. Status: 0x%08x", stream_status));
-        // in offline case, we cant tell the pipeline to restream the file again in case of network outage.
-        // therefore error out and let higher level application do the retry.
-        if (IS_OFFLINE_STREAMING_MODE(kvssink->streaming_type)) {
-            // fatal cases
-            GST_ELEMENT_ERROR (kvssink, STREAM, FAILED, (NULL), ("Stop stream in offline mode"));
+        // A stream error is fatal to the pipeline when:
+        //   - restart-on-error is disabled (user opted out of recovery), OR
+        //   - we are in offline mode: we can't re-stream a file after a network
+        //     outage, so let the higher level application handle the retry.
+        if (!kvssink->restart_on_error || IS_OFFLINE_STREAMING_MODE(kvssink->streaming_type)) {
+            // fatal case: post a fatal ERROR to the bus so the pipeline terminates
+            GST_ELEMENT_ERROR (kvssink, STREAM, FAILED, (NULL),
+                ("Stream error occurred. Status: 0x%08x", stream_status));
             ret = GST_FLOW_ERROR;
             goto CleanUp;
         } else {
-            GST_ELEMENT_ERROR (kvssink, STREAM, FAILED, (NULL), ("Reset stream"));
+            // non-fatal case: post a WARNING (not ERROR) so the pipeline keeps running,
+            // then reset the stream and continue.
+            GST_ELEMENT_WARNING (kvssink, STREAM, FAILED, (NULL),
+                ("Stream error occurred, resetting stream. Status: 0x%08x", stream_status));
             // resetStream, note that this will flush out producer buffer
             data->kinesis_video_stream->resetStream();
             // reset state

--- a/tst/gstreamer/gstkvstest.cpp
+++ b/tst/gstreamer/gstkvstest.cpp
@@ -326,6 +326,72 @@ GST_START_TEST(test_check_credentials)
     }
 GST_END_TEST;
 
+// Test: In realtime mode, a non-retriable stream error should NOT terminate the pipeline.
+// Instead it should reset the stream and continue.
+GST_START_TEST(test_realtime_stream_error_does_not_terminate_pipeline)
+    {
+        GstElement *pElement = setup_kinesisvideoproducersink();
+        GstPad *srcpad;
+
+        srcpad = gst_check_setup_src_pad_by_name(pElement, &srctemplate, "video_0");
+        gst_pad_set_active(srcpad, TRUE);
+
+        // Set to realtime streaming mode (default)
+        g_object_set(G_OBJECT(pElement), "streaming-type", STREAMING_TYPE_REALTIME, NULL);
+
+        fail_unless_equals_int(gst_element_set_state(pElement, GST_STATE_NULL), GST_STATE_CHANGE_SUCCESS);
+        fail_unless_equals_int(gst_element_change_state(pElement, GST_STATE_CHANGE_NULL_TO_READY), GST_STATE_CHANGE_SUCCESS);
+        fail_unless_equals_int(gst_element_change_state(pElement, GST_STATE_CHANGE_READY_TO_PAUSED), GST_STATE_CHANGE_SUCCESS);
+        gst_pad_push_event(srcpad, gst_event_new_caps(gst_caps_from_string("video/x-h264,stream-format=avc,alignment=au,codec_data=abc")));
+        fail_unless_equals_int(gst_element_change_state(pElement, GST_STATE_CHANGE_PAUSED_TO_PLAYING), GST_STATE_CHANGE_SUCCESS);
+
+        // Access internal struct via direct cast (avoids linking gst_kvs_sink_get_type)
+        GstKvsSink *kvssink = (GstKvsSink *) pElement;
+
+        // Verify we're in realtime mode — offline mode would be fatal
+        fail_unless(IS_OFFLINE_STREAMING_MODE(kvssink->streaming_type) == FALSE,
+                    "Should be in realtime mode");
+
+        // Inject a non-retriable stream error
+        kvssink->data->stream_status.store(0x52000067); // STATUS_SERVICE_CALL_UNKNOWN_ERROR
+
+        // In the old code, this non-retriable error in realtime mode would cause
+        // GST_FLOW_ERROR on next buffer (pipeline terminated).
+        // After the fix, realtime mode always takes the resetStream path.
+        // We verify the mode check logic is correct — the error should NOT be fatal.
+        fail_unless(!IS_OFFLINE_STREAMING_MODE(kvssink->streaming_type),
+                    "Realtime mode should not terminate pipeline on stream errors");
+
+        gst_pad_set_active(srcpad, FALSE);
+        cleanup_kinesisvideoproducersink(pElement);
+    }
+GST_END_TEST;
+
+
+// Test: In offline mode, a stream error should still terminate the pipeline (fatal).
+GST_START_TEST(test_offline_stream_error_terminates_pipeline)
+    {
+        GstElement *pElement = setup_kinesisvideoproducersink();
+        GstPad *srcpad;
+
+        srcpad = gst_check_setup_src_pad_by_name(pElement, &srctemplate, "video_0");
+        gst_pad_set_active(srcpad, TRUE);
+
+        // Set to offline streaming mode
+        g_object_set(G_OBJECT(pElement), "streaming-type", STREAMING_TYPE_OFFLINE, NULL);
+
+        // Access internal struct via direct cast (avoids linking gst_kvs_sink_get_type)
+        GstKvsSink *kvssink = (GstKvsSink *) pElement;
+
+        // In offline mode, any stream error should be fatal
+        fail_unless(IS_OFFLINE_STREAMING_MODE(kvssink->streaming_type) == TRUE,
+                    "Should be in offline mode");
+
+        gst_pad_set_active(srcpad, FALSE);
+        cleanup_kinesisvideoproducersink(pElement);
+    }
+GST_END_TEST;
+
 //Verify all State change events and direct state set events.
 
 Suite *gst_kinesisvideoproducer_suite(void) {
@@ -359,6 +425,8 @@ Suite *gst_kinesisvideoproducer_suite(void) {
     tcase_add_test(tc, kvsproducersinkteststop);
     tcase_add_test(tc, check_properties_are_passed_correctly);
     tcase_add_test(tc, check_playing_to_paused_and_back_to_playing);
+    tcase_add_test(tc, test_realtime_stream_error_does_not_terminate_pipeline);
+    tcase_add_test(tc, test_offline_stream_error_terminates_pipeline);
     suite_add_tcase(s, tc);
     return s;
 }

--- a/tst/gstreamer/gstkvstest.cpp
+++ b/tst/gstreamer/gstkvstest.cpp
@@ -326,9 +326,16 @@ GST_START_TEST(test_check_credentials)
     }
 GST_END_TEST;
 
-// Test: In realtime mode, a non-retriable stream error should NOT terminate the pipeline.
+// Test: In realtime mode, any error should not terminate the pipeline.
 // Instead it should reset the stream and continue.
-GST_START_TEST(test_realtime_stream_error_does_not_terminate_pipeline)
+//
+// A stream error is fatal to the pipeline when:
+//   - restart-on-error is disabled (user opted out of recovery), OR
+//   - we are in offline mode (a file cannot be auto-restreamed).
+#define STREAM_ERROR_IS_FATAL(kvssink) \
+    (!(kvssink)->restart_on_error || IS_OFFLINE_STREAMING_MODE((kvssink)->streaming_type))
+
+GST_START_TEST(test_realtime_restart_on_error_is_non_fatal)
     {
         GstElement *pElement = setup_kinesisvideoproducersink();
         GstPad *srcpad;
@@ -336,8 +343,8 @@ GST_START_TEST(test_realtime_stream_error_does_not_terminate_pipeline)
         srcpad = gst_check_setup_src_pad_by_name(pElement, &srctemplate, "video_0");
         gst_pad_set_active(srcpad, TRUE);
 
-        // Set to realtime streaming mode (default)
         g_object_set(G_OBJECT(pElement), "streaming-type", STREAMING_TYPE_REALTIME, NULL);
+        g_object_set(G_OBJECT(pElement), "restart-on-error", TRUE, NULL);
 
         fail_unless_equals_int(gst_element_set_state(pElement, GST_STATE_NULL), GST_STATE_CHANGE_SUCCESS);
         fail_unless_equals_int(gst_element_change_state(pElement, GST_STATE_CHANGE_NULL_TO_READY), GST_STATE_CHANGE_SUCCESS);
@@ -345,31 +352,21 @@ GST_START_TEST(test_realtime_stream_error_does_not_terminate_pipeline)
         gst_pad_push_event(srcpad, gst_event_new_caps(gst_caps_from_string("video/x-h264,stream-format=avc,alignment=au,codec_data=abc")));
         fail_unless_equals_int(gst_element_change_state(pElement, GST_STATE_CHANGE_PAUSED_TO_PLAYING), GST_STATE_CHANGE_SUCCESS);
 
-        // Access internal struct via direct cast (avoids linking gst_kvs_sink_get_type)
         GstKvsSink *kvssink = (GstKvsSink *) pElement;
-
-        // Verify we're in realtime mode — offline mode would be fatal
-        fail_unless(IS_OFFLINE_STREAMING_MODE(kvssink->streaming_type) == FALSE,
-                    "Should be in realtime mode");
 
         // Inject a non-retriable stream error
         kvssink->data->stream_status.store(0x52000067); // STATUS_SERVICE_CALL_UNKNOWN_ERROR
 
-        // In the old code, this non-retriable error in realtime mode would cause
-        // GST_FLOW_ERROR on next buffer (pipeline terminated).
-        // After the fix, realtime mode always takes the resetStream path.
-        // We verify the mode check logic is correct — the error should NOT be fatal.
-        fail_unless(!IS_OFFLINE_STREAMING_MODE(kvssink->streaming_type),
-                    "Realtime mode should not terminate pipeline on stream errors");
+        // realtime + restart-on-error → the error should NOT terminate the pipeline
+        fail_unless(!STREAM_ERROR_IS_FATAL(kvssink),
+                    "realtime + restart-on-error should reset stream, not terminate pipeline");
 
         gst_pad_set_active(srcpad, FALSE);
         cleanup_kinesisvideoproducersink(pElement);
     }
 GST_END_TEST;
 
-
-// Test: In offline mode, a stream error should still terminate the pipeline (fatal).
-GST_START_TEST(test_offline_stream_error_terminates_pipeline)
+GST_START_TEST(test_realtime_no_restart_on_error_is_fatal)
     {
         GstElement *pElement = setup_kinesisvideoproducersink();
         GstPad *srcpad;
@@ -377,15 +374,42 @@ GST_START_TEST(test_offline_stream_error_terminates_pipeline)
         srcpad = gst_check_setup_src_pad_by_name(pElement, &srctemplate, "video_0");
         gst_pad_set_active(srcpad, TRUE);
 
-        // Set to offline streaming mode
-        g_object_set(G_OBJECT(pElement), "streaming-type", STREAMING_TYPE_OFFLINE, NULL);
+        g_object_set(G_OBJECT(pElement), "streaming-type", STREAMING_TYPE_REALTIME, NULL);
+        g_object_set(G_OBJECT(pElement), "restart-on-error", FALSE, NULL);
 
-        // Access internal struct via direct cast (avoids linking gst_kvs_sink_get_type)
         GstKvsSink *kvssink = (GstKvsSink *) pElement;
 
-        // In offline mode, any stream error should be fatal
-        fail_unless(IS_OFFLINE_STREAMING_MODE(kvssink->streaming_type) == TRUE,
-                    "Should be in offline mode");
+        // With restart-on-error disabled, even realtime errors are fatal
+        fail_unless(STREAM_ERROR_IS_FATAL(kvssink),
+                    "restart-on-error=false should make stream errors fatal");
+
+        gst_pad_set_active(srcpad, FALSE);
+        cleanup_kinesisvideoproducersink(pElement);
+    }
+GST_END_TEST;
+
+// Test: offline mode → FATAL regardless of restart-on-error.
+GST_START_TEST(test_offline_stream_error_is_fatal)
+    {
+        GstElement *pElement = setup_kinesisvideoproducersink();
+        GstPad *srcpad;
+
+        srcpad = gst_check_setup_src_pad_by_name(pElement, &srctemplate, "video_0");
+        gst_pad_set_active(srcpad, TRUE);
+
+        g_object_set(G_OBJECT(pElement), "streaming-type", STREAMING_TYPE_OFFLINE, NULL);
+
+        GstKvsSink *kvssink = (GstKvsSink *) pElement;
+
+        // Offline mode is fatal even when restart-on-error is enabled
+        g_object_set(G_OBJECT(pElement), "restart-on-error", TRUE, NULL);
+        fail_unless(STREAM_ERROR_IS_FATAL(kvssink),
+                    "offline mode should be fatal even with restart-on-error=true");
+
+        // Also fatal when restart-on-error is disabled
+        g_object_set(G_OBJECT(pElement), "restart-on-error", FALSE, NULL);
+        fail_unless(STREAM_ERROR_IS_FATAL(kvssink),
+                    "offline mode should be fatal with restart-on-error=false");
 
         gst_pad_set_active(srcpad, FALSE);
         cleanup_kinesisvideoproducersink(pElement);
@@ -425,8 +449,9 @@ Suite *gst_kinesisvideoproducer_suite(void) {
     tcase_add_test(tc, kvsproducersinkteststop);
     tcase_add_test(tc, check_properties_are_passed_correctly);
     tcase_add_test(tc, check_playing_to_paused_and_back_to_playing);
-    tcase_add_test(tc, test_realtime_stream_error_does_not_terminate_pipeline);
-    tcase_add_test(tc, test_offline_stream_error_terminates_pipeline);
+    tcase_add_test(tc, test_realtime_restart_on_error_is_non_fatal);
+    tcase_add_test(tc, test_realtime_no_restart_on_error_is_fatal);
+    tcase_add_test(tc, test_offline_stream_error_is_fatal);
     suite_add_tcase(s, tc);
     return s;
 }

--- a/tst/gstreamer/gstkvstest.cpp
+++ b/tst/gstreamer/gstkvstest.cpp
@@ -326,96 +326,6 @@ GST_START_TEST(test_check_credentials)
     }
 GST_END_TEST;
 
-// Test: In realtime mode, any error should not terminate the pipeline.
-// Instead it should reset the stream and continue.
-//
-// A stream error is fatal to the pipeline when:
-//   - restart-on-error is disabled (user opted out of recovery), OR
-//   - we are in offline mode (a file cannot be auto-restreamed).
-#define STREAM_ERROR_IS_FATAL(kvssink) \
-    (!(kvssink)->restart_on_error || IS_OFFLINE_STREAMING_MODE((kvssink)->streaming_type))
-
-GST_START_TEST(test_realtime_restart_on_error_is_non_fatal)
-    {
-        GstElement *pElement = setup_kinesisvideoproducersink();
-        GstPad *srcpad;
-
-        srcpad = gst_check_setup_src_pad_by_name(pElement, &srctemplate, "video_0");
-        gst_pad_set_active(srcpad, TRUE);
-
-        g_object_set(G_OBJECT(pElement), "streaming-type", STREAMING_TYPE_REALTIME, NULL);
-        g_object_set(G_OBJECT(pElement), "restart-on-error", TRUE, NULL);
-
-        fail_unless_equals_int(gst_element_set_state(pElement, GST_STATE_NULL), GST_STATE_CHANGE_SUCCESS);
-        fail_unless_equals_int(gst_element_change_state(pElement, GST_STATE_CHANGE_NULL_TO_READY), GST_STATE_CHANGE_SUCCESS);
-        fail_unless_equals_int(gst_element_change_state(pElement, GST_STATE_CHANGE_READY_TO_PAUSED), GST_STATE_CHANGE_SUCCESS);
-        gst_pad_push_event(srcpad, gst_event_new_caps(gst_caps_from_string("video/x-h264,stream-format=avc,alignment=au,codec_data=abc")));
-        fail_unless_equals_int(gst_element_change_state(pElement, GST_STATE_CHANGE_PAUSED_TO_PLAYING), GST_STATE_CHANGE_SUCCESS);
-
-        GstKvsSink *kvssink = (GstKvsSink *) pElement;
-
-        // Inject a non-retriable stream error
-        kvssink->data->stream_status.store(0x52000067); // STATUS_SERVICE_CALL_UNKNOWN_ERROR
-
-        // realtime + restart-on-error → the error should NOT terminate the pipeline
-        fail_unless(!STREAM_ERROR_IS_FATAL(kvssink),
-                    "realtime + restart-on-error should reset stream, not terminate pipeline");
-
-        gst_pad_set_active(srcpad, FALSE);
-        cleanup_kinesisvideoproducersink(pElement);
-    }
-GST_END_TEST;
-
-GST_START_TEST(test_realtime_no_restart_on_error_is_fatal)
-    {
-        GstElement *pElement = setup_kinesisvideoproducersink();
-        GstPad *srcpad;
-
-        srcpad = gst_check_setup_src_pad_by_name(pElement, &srctemplate, "video_0");
-        gst_pad_set_active(srcpad, TRUE);
-
-        g_object_set(G_OBJECT(pElement), "streaming-type", STREAMING_TYPE_REALTIME, NULL);
-        g_object_set(G_OBJECT(pElement), "restart-on-error", FALSE, NULL);
-
-        GstKvsSink *kvssink = (GstKvsSink *) pElement;
-
-        // With restart-on-error disabled, even realtime errors are fatal
-        fail_unless(STREAM_ERROR_IS_FATAL(kvssink),
-                    "restart-on-error=false should make stream errors fatal");
-
-        gst_pad_set_active(srcpad, FALSE);
-        cleanup_kinesisvideoproducersink(pElement);
-    }
-GST_END_TEST;
-
-// Test: offline mode → FATAL regardless of restart-on-error.
-GST_START_TEST(test_offline_stream_error_is_fatal)
-    {
-        GstElement *pElement = setup_kinesisvideoproducersink();
-        GstPad *srcpad;
-
-        srcpad = gst_check_setup_src_pad_by_name(pElement, &srctemplate, "video_0");
-        gst_pad_set_active(srcpad, TRUE);
-
-        g_object_set(G_OBJECT(pElement), "streaming-type", STREAMING_TYPE_OFFLINE, NULL);
-
-        GstKvsSink *kvssink = (GstKvsSink *) pElement;
-
-        // Offline mode is fatal even when restart-on-error is enabled
-        g_object_set(G_OBJECT(pElement), "restart-on-error", TRUE, NULL);
-        fail_unless(STREAM_ERROR_IS_FATAL(kvssink),
-                    "offline mode should be fatal even with restart-on-error=true");
-
-        // Also fatal when restart-on-error is disabled
-        g_object_set(G_OBJECT(pElement), "restart-on-error", FALSE, NULL);
-        fail_unless(STREAM_ERROR_IS_FATAL(kvssink),
-                    "offline mode should be fatal with restart-on-error=false");
-
-        gst_pad_set_active(srcpad, FALSE);
-        cleanup_kinesisvideoproducersink(pElement);
-    }
-GST_END_TEST;
-
 //Verify all State change events and direct state set events.
 
 Suite *gst_kinesisvideoproducer_suite(void) {
@@ -449,9 +359,6 @@ Suite *gst_kinesisvideoproducer_suite(void) {
     tcase_add_test(tc, kvsproducersinkteststop);
     tcase_add_test(tc, check_properties_are_passed_correctly);
     tcase_add_test(tc, check_playing_to_paused_and_back_to_playing);
-    tcase_add_test(tc, test_realtime_restart_on_error_is_non_fatal);
-    tcase_add_test(tc, test_realtime_no_restart_on_error_is_fatal);
-    tcase_add_test(tc, test_offline_stream_error_is_fatal);
     suite_add_tcase(s, tc);
     return s;
 }


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- In `gst_kvs_sink_handle_buffer`, stream error handling no longer unconditionally terminates the GStreamer pipeline. A stream error is now fatal only when `restart-on-error` is disabled OR when running in offline mode. In realtime mode with `restart-on-error` enabled (the default), the stream is reset and the pipeline continues running.
- In `KvsSinkStreamCallbackProvider::streamErrorReportHandler`, added `!IS_RETRIABLE_ERROR(status_code)` to the filter that latches `stream_status` and emits the `stream-error` signal, so retriable control-plane errors are no longer treated as fatal.

*Why was it changed?*
- Previously, the error check `IS_OFFLINE_STREAMING_MODE(...) || !IS_RETRIABLE_ERROR(stream_status)` would kill the entire pipeline for any error outside the narrow `IS_RETRIABLE_ERROR` set. Data-plane errors received via ACKs during streaming would terminate a long-running realtime pipeline unnecessarily. For a 24/7 camera, a single transient backend error should not tear down the whole GStreamer pipeline.
- Additionally, the recovery path was calling `GST_ELEMENT_ERROR`, which posts a fatal `GST_MESSAGE_ERROR` to the pipeline bus. Even though the C code continued (reset stream, reset status), the bus message caused the application/`gst-launch` to shut the pipeline down, which defeats the entire purpose.
- The error-report handler filtered `!IS_RECOVERABLE_ERROR && !IS_RETRIABLE_COMMON_LIB_ERROR` but was missing `!IS_RETRIABLE_ERROR`, making it inconsistent with the KVS GStreamer samples (`kvs_gstreamer_sample.cpp`, `kvs_gstreamer_audio_video_sample.cpp`) and the continuous-retry callback, both of which treat `IS_RETRIABLE_ERROR` as non-fatal. Retriable control-plane errors (describe/create/putStream/getToken/getEndpoint) are already retried by PIC's state machine and the continuous-retry `resetStream`, so latching them as fatal `stream_status` caused multiple redundant resets or unwanted pipeline termination.

*How was it changed?*
- Replaced the fatal-condition check with `!kvssink->restart_on_error || IS_OFFLINE_STREAMING_MODE(kvssink->streaming_type)`. This reuses the existing `restart-on-error` property (default TRUE) so users have explicit control over recovery behavior.
- Fatal path (offline, or `restart-on-error=false`): posts `GST_ELEMENT_ERROR` and returns `GST_FLOW_ERROR` to terminate the pipeline.
- Recovery path (realtime + `restart-on-error=true`): posts `GST_ELEMENT_WARNING` (non-fatal, logged and surfaced to the app but does not stop the pipeline), calls `resetStream()` to flush the producer buffer and re-establish the connection, then resets `stream_status` and continues.
- Added `!IS_RETRIABLE_ERROR(status_code)` to `streamErrorReportHandler` so only genuinely fatal errors (neither retriable, recoverable, nor common-lib-retriable) latch `stream_status` and raise the `stream-error` signal, aligning kvssink with the sample handlers and preventing double-handling of errors the lower layers already recover from.

*What testing was done for the changes?*
- Built successfully on macOS (clang) and Ubuntu 22.04 (gcc) with `-DBUILD_GSTREAMER_PLUGIN=ON -DBUILD_TEST=ON`.
- Existing tests pass
- Simulated 403 and saw that PIC/Producer layer retries, kvssink logs error but doesn't terminate the pipeline. With `restart-on-error` enabled, kvssink terminates the pipeline cleanly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.