### PR TITLE
Add fragment boundary presentation timestamps logs

### DIFF
--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -1270,6 +1270,39 @@ put_frame(std::shared_ptr<KvsSinkCustomData> data, void *frame_data, size_t len,
 
     create_kinesis_video_frame(&frame, pts, dts, flags, frame_data, len, track_id, index);
     put_frame_status = data->kinesis_video_stream->statusPutFrame(frame);
+
+    // Log fragment boundaries: keyframe = new fragment start
+    if (CHECK_FRAME_FLAG_KEY_FRAME(flags)) {
+        if (data->fragment_count > 0) {
+            // Epoch ms timestamps (matching KVS backend's view)
+            uint64_t prev_start_ms = data->fragment_start_pts * DEFAULT_TIME_UNIT_IN_NANOS / 1000000;
+            uint64_t prev_end_ms = data->fragment_max_pts * DEFAULT_TIME_UNIT_IN_NANOS / 1000000;
+            uint64_t curr_start_ms = frame.presentationTs * DEFAULT_TIME_UNIT_IN_NANOS / 1000000;
+            LOG_DEBUG("Fragment #" << data->fragment_count
+                     << " start=" << prev_start_ms
+                     << " end=" << prev_end_ms
+                     << " next_start=" << curr_start_ms
+                     << " gap=" << (int64_t)(curr_start_ms - prev_end_ms) << "ms");
+            // Raw GStreamer PTS (running time ns)
+            uint64_t offset_ns = data->producer_start_time - data->first_pts;
+            LOG_DEBUG("Fragment #" << data->fragment_count
+                     << " gst_start=" << (data->fragment_start_pts_ns - offset_ns)
+                     << " gst_end=" << (data->fragment_max_pts_ns - offset_ns)
+                     << " gst_next_start=" << (static_cast<uint64_t>(pts.count()) - offset_ns) << "ns");
+        }
+        data->fragment_start_pts = frame.presentationTs;
+        data->fragment_max_pts = frame.presentationTs;
+        data->fragment_start_pts_ns = static_cast<uint64_t>(pts.count());
+        data->fragment_max_pts_ns = static_cast<uint64_t>(pts.count());
+        data->fragment_count++;
+    }
+
+    // Track max PTS across all frames in the current fragment
+    if (frame.presentationTs > data->fragment_max_pts) {
+        data->fragment_max_pts = frame.presentationTs;
+        data->fragment_max_pts_ns = static_cast<uint64_t>(pts.count());
+    }
+
     if (data->get_metrics && STATUS_SUCCEEDED(put_frame_status)) {
         if (CHECK_FRAME_FLAG_KEY_FRAME(flags) || data->on_first_frame) {
             KvsSinkMetric *kvs_sink_metric = new KvsSinkMetric();
@@ -1381,6 +1414,8 @@ gst_kvs_sink_handle_buffer (GstCollectPads * pads,
             if (data->producer_start_time == GST_CLOCK_TIME_NONE) {
                 data->producer_start_time = (uint64_t) chrono::duration_cast<nanoseconds>(
                         systemCurrentTime().time_since_epoch()).count();
+                LOG_INFO("kvssink PTS baseline: first_pts=" << data->first_pts
+                         << "ns producer_start_time=" << data->producer_start_time << "ns");
             }
 
             if (!data->use_original_pts) {

--- a/src/gstreamer/gstkvssink.h
+++ b/src/gstreamer/gstkvssink.h
@@ -195,6 +195,14 @@ struct _KvsSinkCustomData {
     guint ack_signal_id = 0;
     guint metric_signal_id = 0;
     uint64_t start_time;  // [nanoSeconds]
+
+    // Fragment boundary tracking (PTS in 100ns units, same as frame.presentationTs)
+    uint64_t fragment_start_pts = 0;
+    uint64_t fragment_max_pts = 0;
+    uint32_t fragment_count = 0;
+    // Raw nanosecond PTS (before division by 100) for accurate gst correlation
+    uint64_t fragment_start_pts_ns = 0;
+    uint64_t fragment_max_pts_ns = 0;
 };
 
 struct _KvsSinkMetric {


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added fragment boundary logging to kvssink. On each keyframe, the previous fragment's start/end timestamps and the gap to the next fragment are logged. Also logs the PTS baseline (first_pts, producer_start_time) once at stream start.

*Why was it changed?*
- To add debugging ability  for possible fragment overlap. Currently there's no visibility into fragment-level timestamps within kvssink. These logs show the exact gap (or negative overlap) between consecutive fragments, making root-cause analysis straightforward.

*How was it changed?*
- Added 5 fields to `_KvsSinkCustomData` in `gstkvssink.h`: `fragment_start_pts`, `fragment_max_pts`, `fragment_count`, `fragment_start_pts_ns`, `fragment_max_pts_ns`.
- In `put_frame()`, after `statusPutFrame`, track fragment boundaries on keyframes. Log the previous fragment's epoch-ms timestamps and the gap to the current keyframe. Also log raw GStreamer running-time PTS for correlation with GStreamer debug output.
- In `gst_kvs_sink_handle_buffer`, log the PTS baseline once when `producer_start_time` is first set.
- All logs are at DEBUG level, emitted only on keyframes (~once per 1.5-10s depending on encoder settings). Zero overhead when log level is above DEBUG.

*What testing was done for the changes?*
- Ran end-to-end with `kvssink_gstreamer_sample` using videotestsrc at 30fps. Verified log output shows expected ~33ms gap between fragments and correct epoch-ms timestamps matching KVS console playback timeline.
- Example output:

```
[INFO ] [16-07-2026 00:30:19:733.117 UTC]  kvssink PTS baseline: first_pts=0ns producer_start_time=1784160945528000000ns
[DEBUG] [16-07-2026 00:30:30:191.785 UTC] Fragment #7 start=1784161828733 end=1784161830199 next_start=1784161830233 gap=34ms
[DEBUG] [16-07-2026 00:30:30:191.804 UTC] Fragment #7 gst_start=9171822417 gst_end=10638489083 gst_next_start=10671822417ns
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.