### PR TITLE
kvssink: Add a new property that allows ignoring envs for region

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,16 @@ The `kvssink` GStreamer element includes the following parameters:
 | access&#x2011;key      | N/A               | The AWS access key that is used to access Kinesis Video Streams. You must provide either this parameter or credential-path, or set the AWS_ACCESS_KEY_ID environment variable.
 | secret&#x2011;key      | N/A               | The AWS secret key that is used to access Kinesis Video Streams. You must provide either this parameter or credential-path, or set the AWS_SECRET_ACCESS_KEY environment variable.
 | credential&#x2011;path | '.kvs/credential' | A path to a file containing your credentials for accessing Kinesis Video Streams. For example credential files and more information, see [Provide credentials to kvssink](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/examples-gstreamer-plugin-parameters.html#credentials-to-kvssink). You must provide either this parameter or access-key and secret-key, or set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.
+| ignore&#x2011;region&#x2011;env | false | When true, the AWS_DEFAULT_REGION environment variable is ignored and the `aws-region` parameter is always used. See the precedence note below.
+| ignore&#x2011;credentials&#x2011;env | false | When true, the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_SESSION_TOKEN environment variables are ignored and the `access-key`, `secret-key`, and `session-token` parameters are always used. See the precedence note below.
+
+**Environment variable precedence.** By default, when both an environment variable and its corresponding `kvssink` parameter are set, the environment variable takes precedence. The region lookup order is:
+
+1. `AWS_DEFAULT_REGION` environment variable is reviewed first. If it is set, that region is used to configure the client.
+2. `aws-region` parameter is reviewed next. If it is set, that region is used to configure the client.
+3. If neither of the previous methods were used, `kvssink` defaults to `us-west-2`.
+
+Set kvssink's `ignore-region-env=true` property to skip step 1 so the `aws-region` parameter is always used. Credentials follow the same env-first precedence; set `ignore-credentials-env=true` to skip the `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` environment variables so the `access-key` / `secret-key` / `session-token` parameters are always used. Both ignore environment properties default to `false`.
 
 To see all `kvssink` parameters, see [AWS Docs - kvssink Paramters](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/examples-gstreamer-plugin-parameters.html).
 

--- a/src/gstreamer/Util/KvsSinkResolution.cpp
+++ b/src/gstreamer/Util/KvsSinkResolution.cpp
@@ -2,18 +2,18 @@
 
 namespace kvs_sink_util {
 
+bool shouldUseEnvVar(bool ignore_env, const char *env_value) {
+    return !ignore_env && nullptr != env_value;
+}
+
 std::string resolveRegion(const std::string &property_region, const char *env_region, bool ignore_env) {
     // By default, the AWS_DEFAULT_REGION env var overrides the aws-region property. When ignore_env is
     // set, the env var is ignored and the aws-region property is always used.
     // The aws-region property has a default value of DEFAULT_REGION.
-    if (!ignore_env && nullptr != env_region) {
+    if (shouldUseEnvVar(ignore_env, env_region)) {
         return std::string(env_region);
     }
     return property_region;
-}
-
-bool shouldUseCredentialsEnv(bool ignore_env, const char *env_value) {
-    return !ignore_env && nullptr != env_value;
 }
 
 }

--- a/src/gstreamer/Util/KvsSinkResolution.cpp
+++ b/src/gstreamer/Util/KvsSinkResolution.cpp
@@ -1,0 +1,19 @@
+#include "KvsSinkResolution.h"
+
+namespace kvs_sink_util {
+
+std::string resolveRegion(const std::string &property_region, const char *env_region, bool ignore_env) {
+    // By default, the AWS_DEFAULT_REGION env var overrides the aws-region property. When ignore_env is
+    // set, the env var is ignored and the aws-region property is always used.
+    // The aws-region property has a default value of DEFAULT_REGION.
+    if (!ignore_env && nullptr != env_region) {
+        return std::string(env_region);
+    }
+    return property_region;
+}
+
+bool shouldUseCredentialsEnv(bool ignore_env, const char *env_value) {
+    return !ignore_env && nullptr != env_value;
+}
+
+}

--- a/src/gstreamer/Util/KvsSinkResolution.h
+++ b/src/gstreamer/Util/KvsSinkResolution.h
@@ -1,0 +1,35 @@
+#ifndef __KVS_SINK_RESOLUTION_H__
+#define __KVS_SINK_RESOLUTION_H__
+
+#include <string>
+
+// Pure region/credential precedence helpers, intentionally kept in their own dependency-free
+// translation unit (only <string>; no GStreamer, no logging, no file-scope statics). This lets the
+// unit tests compile this single .cpp into the test binary without pulling in KvsSinkUtil.cpp's
+// static initializers (e.g. the log4cplus LOGGER_TAG), which otherwise get constructed twice - once
+// in the test executable and once in the dlopened kvssink plugin - and crash at teardown.
+namespace kvs_sink_util {
+
+    // Resolves the effective AWS region. The lookup order is:
+    //   1. AWS_DEFAULT_REGION environment variable (unless ignore_env is true).
+    //   2. aws-region property.
+    //   3. us-west-2 default (carried by the aws-region property, which defaults to DEFAULT_REGION).
+    // When ignore_env is true, step 1 is skipped so the aws-region property always wins.
+    //
+    // The caller (kvssink) provides these values rather than this function reading them itself. This
+    // keeps the function pure (no getenv / no dependency on the GstKvsSink struct), so the full
+    // property/env/ignore matrix can be unit tested without mutating the process environment.
+    std::string resolveRegion(const std::string &property_region, const char *env_region, bool ignore_env);
+
+    // Returns whether a credential-related environment variable (e.g. AWS_ACCESS_KEY_ID) should be
+    // consulted. Returns false when ignore_env is true so the corresponding GStreamer property always
+    // wins, or when the environment variable is unset.
+    //
+    // As with resolveRegion, the caller (kvssink) provides these values rather than the function
+    // reading them itself, keeping it pure and unit testable. kvssink passes kvssink->ignore_credentials_env
+    // and a snapshot of getenv() for the relevant credential variable (nullptr if unset).
+    bool shouldUseCredentialsEnv(bool ignore_env, const char *env_value);
+
+}
+
+#endif //__KVS_SINK_RESOLUTION_H__

--- a/src/gstreamer/Util/KvsSinkResolution.h
+++ b/src/gstreamer/Util/KvsSinkResolution.h
@@ -10,6 +10,16 @@
 // in the test executable and once in the dlopened kvssink plugin - and crash at teardown.
 namespace kvs_sink_util {
 
+    // Returns whether an AWS environment variable should be consulted. Returns false when ignore_env
+    // is true so the corresponding GStreamer property always wins, or when the environment variable is
+    // unset. Used for both the region (AWS_DEFAULT_REGION) and credential (e.g. AWS_ACCESS_KEY_ID)
+    // env vars.
+    //
+    // The caller (kvssink) provides these values rather than the function reading them itself, keeping
+    // it pure and unit testable. kvssink passes the relevant ignore flag and a snapshot of getenv() for
+    // the variable (nullptr if unset).
+    bool shouldUseEnvVar(bool ignore_env, const char *env_value);
+
     // Resolves the effective AWS region. The lookup order is:
     //   1. AWS_DEFAULT_REGION environment variable (unless ignore_env is true).
     //   2. aws-region property.
@@ -20,15 +30,6 @@ namespace kvs_sink_util {
     // keeps the function pure (no getenv / no dependency on the GstKvsSink struct), so the full
     // property/env/ignore matrix can be unit tested without mutating the process environment.
     std::string resolveRegion(const std::string &property_region, const char *env_region, bool ignore_env);
-
-    // Returns whether a credential-related environment variable (e.g. AWS_ACCESS_KEY_ID) should be
-    // consulted. Returns false when ignore_env is true so the corresponding GStreamer property always
-    // wins, or when the environment variable is unset.
-    //
-    // As with resolveRegion, the caller (kvssink) provides these values rather than the function
-    // reading them itself, keeping it pure and unit testable. kvssink passes kvssink->ignore_credentials_env
-    // and a snapshot of getenv() for the relevant credential variable (nullptr if unset).
-    bool shouldUseCredentialsEnv(bool ignore_env, const char *env_value);
 
 }
 

--- a/src/gstreamer/Util/KvsSinkUtil.cpp
+++ b/src/gstreamer/Util/KvsSinkUtil.cpp
@@ -93,4 +93,19 @@ gboolean parseIotCredentialGstructure(GstStructure *g_struct, std::map<std::stri
 CleanUp:
     return ret;
 }
+
+// By default, the AWS_DEFAULT_REGION env var overrides the aws-region property. When ignore_env is
+// set, the env var is ignored and the aws-region property is always used.
+// The aws-region property has a default value of DEFAULT_AWS_REGION.
+std::string resolveRegion(const std::string &property_region, const char *env_region, bool ignore_env) {
+    if (!ignore_env && nullptr != env_region) {
+        return std::string(env_region);
+    }
+    return property_region;
+}
+
+bool shouldUseCredentialsEnv(bool ignore_env, const char *env_value) {
+    return !ignore_env && nullptr != env_value;
+}
+
 }

--- a/src/gstreamer/Util/KvsSinkUtil.cpp
+++ b/src/gstreamer/Util/KvsSinkUtil.cpp
@@ -93,19 +93,4 @@ gboolean parseIotCredentialGstructure(GstStructure *g_struct, std::map<std::stri
 CleanUp:
     return ret;
 }
-
-// By default, the AWS_DEFAULT_REGION env var overrides the aws-region property. When ignore_env is
-// set, the env var is ignored and the aws-region property is always used.
-// The aws-region property has a default value of DEFAULT_AWS_REGION.
-std::string resolveRegion(const std::string &property_region, const char *env_region, bool ignore_env) {
-    if (!ignore_env && nullptr != env_region) {
-        return std::string(env_region);
-    }
-    return property_region;
-}
-
-bool shouldUseCredentialsEnv(bool ignore_env, const char *env_value) {
-    return !ignore_env && nullptr != env_value;
-}
-
 }

--- a/src/gstreamer/Util/KvsSinkUtil.h
+++ b/src/gstreamer/Util/KvsSinkUtil.h
@@ -31,6 +31,26 @@ namespace kvs_sink_util{
     gboolean parseIotCredentialGstructure(GstStructure *g_struct,
                                              std::map<std::string, std::string> &iot_cert_params);
 
+    // Resolves the effective AWS region. The lookup order is:
+    //   1. AWS_DEFAULT_REGION environment variable (unless ignore_env is true).
+    //   2. aws-region property.
+    //   3. us-west-2 default (carried by the aws-region property, which defaults to DEFAULT_REGION).
+    // When ignore_env is true, step 1 is skipped so the aws-region property always wins.
+    //
+    // The caller (kvssink) provides these values rather than this function reading them itself. This
+    // keeps the function pure (no getenv / no dependency on the GstKvsSink struct), so the full
+    // property/env/ignore matrix can be unit tested without mutating the process environment.
+    std::string resolveRegion(const std::string &property_region, const char *env_region, bool ignore_env);
+
+    // Returns whether a credential-related environment variable (e.g. AWS_ACCESS_KEY_ID) should be
+    // consulted. Returns false when ignore_env is true so the corresponding GStreamer property always
+    // wins, or when the environment variable is unset.
+    //
+    // As with resolveRegion, the caller (kvssink) provides these values rather than the function
+    // reading them itself, keeping it pure and unit testable. kvssink passes kvssink->ignore_credentials_env
+    // and a snapshot of getenv() for the relevant credential variable (nullptr if unset).
+    bool shouldUseCredentialsEnv(bool ignore_env, const char *env_value);
+
 }
 
 #endif //__KVS_SINK_UTIL_H__

--- a/src/gstreamer/Util/KvsSinkUtil.h
+++ b/src/gstreamer/Util/KvsSinkUtil.h
@@ -7,6 +7,7 @@
 #include <set>
 #include <Logger.h>
 #include <chrono>
+#include "KvsSinkResolution.h"
 
 #define IOT_GET_CREDENTIAL_ENDPOINT "endpoint"
 #define CERTIFICATE_PATH "cert-path"
@@ -31,25 +32,6 @@ namespace kvs_sink_util{
     gboolean parseIotCredentialGstructure(GstStructure *g_struct,
                                              std::map<std::string, std::string> &iot_cert_params);
 
-    // Resolves the effective AWS region. The lookup order is:
-    //   1. AWS_DEFAULT_REGION environment variable (unless ignore_env is true).
-    //   2. aws-region property.
-    //   3. us-west-2 default (carried by the aws-region property, which defaults to DEFAULT_REGION).
-    // When ignore_env is true, step 1 is skipped so the aws-region property always wins.
-    //
-    // The caller (kvssink) provides these values rather than this function reading them itself. This
-    // keeps the function pure (no getenv / no dependency on the GstKvsSink struct), so the full
-    // property/env/ignore matrix can be unit tested without mutating the process environment.
-    std::string resolveRegion(const std::string &property_region, const char *env_region, bool ignore_env);
-
-    // Returns whether a credential-related environment variable (e.g. AWS_ACCESS_KEY_ID) should be
-    // consulted. Returns false when ignore_env is true so the corresponding GStreamer property always
-    // wins, or when the environment variable is unset.
-    //
-    // As with resolveRegion, the caller (kvssink) provides these values rather than the function
-    // reading them itself, keeping it pure and unit testable. kvssink passes kvssink->ignore_credentials_env
-    // and a snapshot of getenv() for the relevant credential variable (nullptr if unset).
-    bool shouldUseCredentialsEnv(bool ignore_env, const char *env_value);
 
 }
 

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -106,6 +106,8 @@ GST_DEBUG_CATEGORY_STATIC (gst_kvs_sink_debug);
 #define DEFAULT_SECRET_KEY "secret_key"
 #define DEFAULT_SESSION_TOKEN "session_token"
 #define DEFAULT_REGION "us-west-2"
+#define DEFAULT_IGNORE_REGION_ENV FALSE
+#define DEFAULT_IGNORE_CREDENTIALS_ENV FALSE
 #define DEFAULT_ROTATION_PERIOD_SECONDS 3600
 #define DEFAULT_LOG_FILE_PATH "../kvs_log_configuration"
 #define DEFAULT_STORAGE_SIZE_MB 128
@@ -171,6 +173,8 @@ enum {
     PROP_SECRET_KEY,
     PROP_SESSION_TOKEN,
     PROP_AWS_REGION,
+    PROP_IGNORE_REGION_ENV,
+    PROP_IGNORE_CREDENTIALS_ENV,
     PROP_ROTATION_PERIOD,
     PROP_LOG_CONFIG_PATH,
     PROP_STORAGE_SIZE,
@@ -275,10 +279,6 @@ void kinesis_video_producer_init(GstKvsSink *kvssink)
 
     kvssink->data->kvs_sink = kvssink;
 
-    char const *access_key;
-    char const *secret_key;
-    char const *session_token;
-    char const *default_region;
     char const *control_plane_uri;
     string access_key_str;
     string secret_key_str;
@@ -286,6 +286,13 @@ void kinesis_video_producer_init(GstKvsSink *kvssink)
     string region_str;
     string control_plane_uri_str = "";
     bool credential_is_static = true;
+
+    // Snapshot the AWS environment variables once, up front. Resolution below reads only these
+    // cached values so the env cannot appear to change between reads within this function.
+    char const *access_key_env = getenv(ACCESS_KEY_ENV_VAR);
+    char const *secret_key_env = getenv(SECRET_KEY_ENV_VAR);
+    char const *session_token_env = getenv(SESSION_TOKEN_ENV_VAR);
+    char const *default_region_env = getenv(DEFAULT_REGION_ENV_VAR);
 
     // This needs to happen after we've read in ALL of the properties
     if (!kvssink->disable_buffer_clipping) {
@@ -296,14 +303,16 @@ void kinesis_video_producer_init(GstKvsSink *kvssink)
     kvssink->data->kvs_sink = kvssink;
 
     if (0 == strcmp(kvssink->access_key, DEFAULT_ACCESS_KEY)) { // if no static credential is available in plugin property.
-        if (nullptr == (access_key = getenv(ACCESS_KEY_ENV_VAR))
-            || nullptr == (secret_key = getenv(SECRET_KEY_ENV_VAR))) { // if no static credential is available in env var.
+        // When ignore-credentials-env is set, the AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY env vars are
+        // never consulted, so kvssink always respects the access-key / secret-key properties (which are unset here).
+        if (!kvs_sink_util::shouldUseCredentialsEnv(kvssink->ignore_credentials_env, access_key_env)
+            || !kvs_sink_util::shouldUseCredentialsEnv(kvssink->ignore_credentials_env, secret_key_env)) { // if no static credential is available in env var.
             credential_is_static = false; // No static credential available.
             access_key_str = "";
             secret_key_str = "";
         } else {
-            access_key_str = string(access_key);
-            secret_key_str = string(secret_key);
+            access_key_str = string(access_key_env);
+            secret_key_str = string(secret_key_env);
         }
 
     } else {
@@ -314,19 +323,26 @@ void kinesis_video_producer_init(GstKvsSink *kvssink)
     // Handle session token separately, since this is optional with long term credentials
     if (0 == strcmp(kvssink->session_token, DEFAULT_SESSION_TOKEN)) {
         session_token_str = "";
-        if (nullptr != (session_token = getenv(SESSION_TOKEN_ENV_VAR))) {
+        // When ignore-credentials-env is set, the AWS_SESSION_TOKEN env var is never consulted.
+        if (kvs_sink_util::shouldUseCredentialsEnv(kvssink->ignore_credentials_env, session_token_env)) {
             LOG_INFO("Setting session token from env for " << kvssink->stream_name);
-            session_token_str = string(session_token);
+            session_token_str = string(session_token_env);
         }
     } else {
         LOG_INFO("Setting session token from config for " << kvssink->stream_name);
         session_token_str = string(kvssink->session_token);
     }
 
-    if (nullptr == (default_region = getenv(DEFAULT_REGION_ENV_VAR))) {
-        region_str = string(kvssink->aws_region);
-    } else {
-        region_str = string(default_region); // Use env var if both property and env var are available.
+    // Region resolution: by default the AWS_DEFAULT_REGION env var overrides the aws-region property.
+    // When ignore-region-env is set, the env var is ignored and the aws-region property is always used.
+    region_str = kvs_sink_util::resolveRegion(kvssink->aws_region, default_region_env, kvssink->ignore_region_env);
+    // Warn when the env var is silently overriding an explicitly-set aws-region property, since this
+    // can point streams at an unexpected region (see ignore-region-env to opt out of this override).
+    if (!kvssink->ignore_region_env && nullptr != default_region_env
+        && 0 != strcmp(kvssink->aws_region, DEFAULT_REGION) && region_str != kvssink->aws_region) {
+        LOG_WARN("The " << DEFAULT_REGION_ENV_VAR << " environment variable (" << region_str
+                 << ") is overriding the aws-region property (" << kvssink->aws_region << ") for "
+                 << kvssink->stream_name << ". Set ignore-region-env=true to always use the aws-region property.");
     }
 
     unique_ptr<CredentialProvider> credential_provider;
@@ -636,6 +652,18 @@ gst_kvs_sink_class_init(GstKvsSinkClass *klass) {
                                      g_param_spec_string ("aws-region", "AWS Region",
                                                           "AWS Region", DEFAULT_REGION, (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 
+    g_object_class_install_property (gobject_class, PROP_IGNORE_REGION_ENV,
+                                     g_param_spec_boolean ("ignore-region-env", "Ignore region environment variable",
+                                                           "If true, ignore the AWS_DEFAULT_REGION environment variable and always use the aws-region property. "
+                                                           "By default (false), the AWS_DEFAULT_REGION environment variable takes precedence over the aws-region property.", DEFAULT_IGNORE_REGION_ENV,
+                                                           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+    g_object_class_install_property (gobject_class, PROP_IGNORE_CREDENTIALS_ENV,
+                                     g_param_spec_boolean ("ignore-credentials-env", "Ignore credentials environment variables",
+                                                           "If true, ignore the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_SESSION_TOKEN environment variables and always use the access-key, secret-key, and session-token properties. "
+                                                           "By default (false), these environment variables take precedence over the corresponding properties.", DEFAULT_IGNORE_CREDENTIALS_ENV,
+                                                           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
     g_object_class_install_property (gobject_class, PROP_ROTATION_PERIOD,
                                      g_param_spec_uint ("rotation-period", "Rotation Period",
                                                         "Rotation Period. Unit: seconds", 0, G_MAXUINT, DEFAULT_ROTATION_PERIOD_SECONDS, (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
@@ -761,6 +789,8 @@ gst_kvs_sink_init(GstKvsSink *kvssink) {
     kvssink->secret_key = g_strdup (DEFAULT_SECRET_KEY);
     kvssink->session_token = g_strdup(DEFAULT_SESSION_TOKEN);
     kvssink->aws_region = g_strdup (DEFAULT_REGION);
+    kvssink->ignore_region_env = DEFAULT_IGNORE_REGION_ENV;
+    kvssink->ignore_credentials_env = DEFAULT_IGNORE_CREDENTIALS_ENV;
     kvssink->rotation_period = DEFAULT_ROTATION_PERIOD_SECONDS;
     kvssink->log_config_path = g_strdup (DEFAULT_LOG_FILE_PATH);
     kvssink->storage_size = DEFAULT_STORAGE_SIZE_MB;
@@ -912,6 +942,12 @@ gst_kvs_sink_set_property(GObject *object, guint prop_id,
             g_free(kvssink->aws_region);
             kvssink->aws_region = g_strdup (g_value_get_string (value));
             break;
+        case PROP_IGNORE_REGION_ENV:
+            kvssink->ignore_region_env = g_value_get_boolean (value);
+            break;
+        case PROP_IGNORE_CREDENTIALS_ENV:
+            kvssink->ignore_credentials_env = g_value_get_boolean (value);
+            break;
         case PROP_ROTATION_PERIOD:
             kvssink->rotation_period = g_value_get_uint (value);
             break;
@@ -1059,6 +1095,12 @@ gst_kvs_sink_get_property(GObject *object, guint prop_id, GValue *value,
             break;
         case PROP_AWS_REGION:
             g_value_set_string (value, kvssink->aws_region);
+            break;
+        case PROP_IGNORE_REGION_ENV:
+            g_value_set_boolean (value, kvssink->ignore_region_env);
+            break;
+        case PROP_IGNORE_CREDENTIALS_ENV:
+            g_value_set_boolean (value, kvssink->ignore_credentials_env);
             break;
         case PROP_ROTATION_PERIOD:
             g_value_set_uint (value, kvssink->rotation_period);

--- a/src/gstreamer/gstkvssink.cpp
+++ b/src/gstreamer/gstkvssink.cpp
@@ -305,8 +305,8 @@ void kinesis_video_producer_init(GstKvsSink *kvssink)
     if (0 == strcmp(kvssink->access_key, DEFAULT_ACCESS_KEY)) { // if no static credential is available in plugin property.
         // When ignore-credentials-env is set, the AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY env vars are
         // never consulted, so kvssink always respects the access-key / secret-key properties (which are unset here).
-        if (!kvs_sink_util::shouldUseCredentialsEnv(kvssink->ignore_credentials_env, access_key_env)
-            || !kvs_sink_util::shouldUseCredentialsEnv(kvssink->ignore_credentials_env, secret_key_env)) { // if no static credential is available in env var.
+        if (!kvs_sink_util::shouldUseEnvVar(kvssink->ignore_credentials_env, access_key_env)
+            || !kvs_sink_util::shouldUseEnvVar(kvssink->ignore_credentials_env, secret_key_env)) { // if no static credential is available in env var.
             credential_is_static = false; // No static credential available.
             access_key_str = "";
             secret_key_str = "";
@@ -324,7 +324,7 @@ void kinesis_video_producer_init(GstKvsSink *kvssink)
     if (0 == strcmp(kvssink->session_token, DEFAULT_SESSION_TOKEN)) {
         session_token_str = "";
         // When ignore-credentials-env is set, the AWS_SESSION_TOKEN env var is never consulted.
-        if (kvs_sink_util::shouldUseCredentialsEnv(kvssink->ignore_credentials_env, session_token_env)) {
+        if (kvs_sink_util::shouldUseEnvVar(kvssink->ignore_credentials_env, session_token_env)) {
             LOG_INFO("Setting session token from env for " << kvssink->stream_name);
             session_token_str = string(session_token_env);
         }

--- a/src/gstreamer/gstkvssink.h
+++ b/src/gstreamer/gstkvssink.h
@@ -122,6 +122,8 @@ struct _GstKvsSink {
     gchar                       *secret_key;
     gchar                       *session_token;
     gchar                       *aws_region;
+    gboolean                    ignore_region_env;
+    gboolean                    ignore_credentials_env;
     guint                       rotation_period;
     gchar                       *log_config_path;
     guint                       storage_size;

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -26,6 +26,9 @@ if(BUILD_GSTREAMER_PLUGIN AND NOT WIN32)
   pkg_check_modules(GST_CHECK REQUIRED gstreamer-check-1.0)
 
   file(GLOB GST_PLUGIN_TEST_SOURCES gstreamer/*.cpp)
+  # Compile in the plugin util sources so pure helpers (e.g. region/credential resolution) can be
+  # unit tested directly, rather than only through the runtime-loaded kvssink plugin.
+  list(APPEND GST_PLUGIN_TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../src/gstreamer/Util/KvsSinkUtil.cpp")
   SET(GST_KVS_PLUGIN_TEST_NAME gstkvsplugintest)
 
   include_directories("../src/gstreamer")

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -26,9 +26,11 @@ if(BUILD_GSTREAMER_PLUGIN AND NOT WIN32)
   pkg_check_modules(GST_CHECK REQUIRED gstreamer-check-1.0)
 
   file(GLOB GST_PLUGIN_TEST_SOURCES gstreamer/*.cpp)
-  # Compile in the plugin util sources so pure helpers (e.g. region/credential resolution) can be
-  # unit tested directly, rather than only through the runtime-loaded kvssink plugin.
-  list(APPEND GST_PLUGIN_TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../src/gstreamer/Util/KvsSinkUtil.cpp")
+  # Compile in the pure region/credential resolution helpers so they can be unit tested directly,
+  # rather than only through the runtime-loaded kvssink plugin. This is a dependency-free translation
+  # unit (no logging / no static initializers), so linking it into the test binary does not duplicate
+  # the plugin's static state (which would crash forked test children at teardown).
+  list(APPEND GST_PLUGIN_TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../src/gstreamer/Util/KvsSinkResolution.cpp")
   SET(GST_KVS_PLUGIN_TEST_NAME gstkvsplugintest)
 
   include_directories("../src/gstreamer")

--- a/tst/gstreamer/gstkvstest.cpp
+++ b/tst/gstreamer/gstkvstest.cpp
@@ -327,7 +327,7 @@ GST_START_TEST(check_region_env_override_resolution)
     }
 GST_END_TEST;
 
-// Exercises the credential env precedence logic directly via the pure shouldUseCredentialsEnv helper.
+// Exercises the credential env precedence logic directly via the pure shouldUseEnvVar helper.
 // Each row is one scenario; env_value == nullptr models an unset credential env var (e.g.
 // AWS_ACCESS_KEY_ID), and a non-null value models it being present. A true result means the env var
 // is consulted; false means the corresponding property wins.
@@ -353,14 +353,14 @@ GST_START_TEST(check_credentials_env_override_resolution)
 
         for (const CredentialCase &c : cases) {
             const char *env_display = c.env_value ? c.env_value : "(unset)";
-            cout << "shouldUseCredentialsEnv case: " << c.description
+            cout << "shouldUseEnvVar case: " << c.description
                  << " [ignore_env=" << (c.ignore_env ? "true" : "false")
                  << ", env=" << env_display
                  << ", expect_use_env=" << (c.expect_use_env ? "true" : "false") << "]" << endl;
 
-            bool use_env = kvs_sink_util::shouldUseCredentialsEnv(c.ignore_env, c.env_value);
+            bool use_env = kvs_sink_util::shouldUseEnvVar(c.ignore_env, c.env_value);
             fail_unless(use_env == c.expect_use_env,
-                        "shouldUseCredentialsEnv failed for case \"%s\": ignore_env=%s, env=%s -> expected %s but got %s",
+                        "shouldUseEnvVar failed for case \"%s\": ignore_env=%s, env=%s -> expected %s but got %s",
                         c.description, c.ignore_env ? "true" : "false", env_display,
                         c.expect_use_env ? "true" : "false", use_env ? "true" : "false");
         }

--- a/tst/gstreamer/gstkvstest.cpp
+++ b/tst/gstreamer/gstkvstest.cpp
@@ -1,5 +1,5 @@
 #include "gstkvssink.h" //import this first, or will cause build error on Mac
-#include "Util/KvsSinkUtil.h"
+#include "Util/KvsSinkResolution.h"
 #include <gst/check/gstcheck.h>
 #include <string>
 

--- a/tst/gstreamer/gstkvstest.cpp
+++ b/tst/gstreamer/gstkvstest.cpp
@@ -1,4 +1,5 @@
 #include "gstkvssink.h" //import this first, or will cause build error on Mac
+#include "Util/KvsSinkUtil.h"
 #include <gst/check/gstcheck.h>
 #include <string>
 
@@ -276,6 +277,96 @@ GST_START_TEST(check_properties_are_passed_correctly)
     }
 GST_END_TEST;
 
+// Exercises the region precedence logic directly via the pure resolveRegion helper, so the full
+// property/env/ignore-flag matrix is verified deterministically without mutating the process
+// environment (not portable) or making network calls. Each row is one scenario; env_region == nullptr
+// models an unset AWS_DEFAULT_REGION, and a non-null value models the env var being present.
+//
+// The aws-region property carries the us-west-2 default (DEFAULT_REGION), so a case where the env var
+// is unset and the property is left at that default is what produces the documented "defaults to
+// us-west-2" behavior (region lookup step 3).
+GST_START_TEST(check_region_env_override_resolution)
+    {
+        struct RegionCase {
+            const char *description;
+            const char *property_region; // value of the aws-region property
+            const char *env_region;      // snapshot of AWS_DEFAULT_REGION (nullptr == unset)
+            bool ignore_env;             // value of the ignore-region-env property
+            const char *expected;        // region resolveRegion should return
+        };
+
+        const RegionCase cases[] = {
+            // env set + property set, default flag -> env wins
+            {"env overrides property by default",        "us-east-1", "us-west-1", false, "us-west-1"},
+            // property set, env unset, default flag     -> property used
+            {"property used when env unset",             "us-east-1", nullptr,     false, "us-east-1"},
+            // neither explicitly set (property at us-west-2 default), env unset -> us-west-2 fallback
+            {"falls back to us-west-2 when neither set",  "us-west-2", nullptr,     false, "us-west-2"},
+            // env set + property set, ignore flag       -> property wins despite env
+            {"ignore flag makes property win over env",  "us-east-1", "us-west-1", true,  "us-east-1"},
+            // property set, env unset, ignore flag      -> property used
+            {"ignore flag with env unset uses property", "us-east-1", nullptr,     true,  "us-east-1"},
+            // neither explicitly set, ignore flag       -> us-west-2 fallback still holds
+            {"ignore flag preserves us-west-2 fallback", "us-west-2", nullptr,     true,  "us-west-2"},
+        };
+
+        for (const RegionCase &c : cases) {
+            const char *env_display = c.env_region ? c.env_region : "(unset)";
+            cout << "resolveRegion case: " << c.description
+                 << " [property=" << c.property_region
+                 << ", env=" << env_display
+                 << ", ignore_env=" << (c.ignore_env ? "true" : "false")
+                 << ", expected=" << c.expected << "]" << endl;
+
+            string resolved = kvs_sink_util::resolveRegion(c.property_region, c.env_region, c.ignore_env);
+            fail_unless(resolved == c.expected,
+                        "resolveRegion failed for case \"%s\": property=%s, env=%s, ignore_env=%s -> expected \"%s\" but got \"%s\"",
+                        c.description, c.property_region, env_display,
+                        c.ignore_env ? "true" : "false", c.expected, resolved.c_str());
+        }
+    }
+GST_END_TEST;
+
+// Exercises the credential env precedence logic directly via the pure shouldUseCredentialsEnv helper.
+// Each row is one scenario; env_value == nullptr models an unset credential env var (e.g.
+// AWS_ACCESS_KEY_ID), and a non-null value models it being present. A true result means the env var
+// is consulted; false means the corresponding property wins.
+GST_START_TEST(check_credentials_env_override_resolution)
+    {
+        struct CredentialCase {
+            const char *description;
+            bool ignore_env;         // value of the ignore-credentials-env property
+            const char *env_value;   // snapshot of the credential env var (nullptr == unset)
+            bool expect_use_env;     // whether the env var should be consulted
+        };
+
+        const CredentialCase cases[] = {
+            // env set, default flag  -> env is consulted (existing behavior)
+            {"env used when present by default", false, "AKIDEXAMPLE", true},
+            // env unset, default flag -> nothing to consult, property/other providers used
+            {"env ignored when unset",           false, nullptr,       false},
+            // env set, ignore flag   -> env never consulted, property wins
+            {"ignore flag skips present env",    true,  "AKIDEXAMPLE", false},
+            // env unset, ignore flag -> still not consulted
+            {"ignore flag with env unset",       true,  nullptr,       false},
+        };
+
+        for (const CredentialCase &c : cases) {
+            const char *env_display = c.env_value ? c.env_value : "(unset)";
+            cout << "shouldUseCredentialsEnv case: " << c.description
+                 << " [ignore_env=" << (c.ignore_env ? "true" : "false")
+                 << ", env=" << env_display
+                 << ", expect_use_env=" << (c.expect_use_env ? "true" : "false") << "]" << endl;
+
+            bool use_env = kvs_sink_util::shouldUseCredentialsEnv(c.ignore_env, c.env_value);
+            fail_unless(use_env == c.expect_use_env,
+                        "shouldUseCredentialsEnv failed for case \"%s\": ignore_env=%s, env=%s -> expected %s but got %s",
+                        c.description, c.ignore_env ? "true" : "false", env_display,
+                        c.expect_use_env ? "true" : "false", use_env ? "true" : "false");
+        }
+    }
+GST_END_TEST;
+
 GST_START_TEST(check_playing_to_paused_and_back_to_playing)
     {
         GstElement *pElement =
@@ -340,6 +431,13 @@ Suite *gst_kinesisvideoproducer_suite(void) {
     accessKey = accessKey ? accessKey : "";
     secretKey = secretKey ? secretKey : "";
     sessionToken = sessionToken ? sessionToken : "";
+
+    // Resolution-logic tests. These exercise the pure precedence helpers only; they don't contact
+    // AWS, so they run regardless of whether AWS credentials are present in the environment.
+    TCase *tc_resolution = tcase_create("EnvOverrideResolution");
+    tcase_add_test(tc_resolution, check_region_env_override_resolution);
+    tcase_add_test(tc_resolution, check_credentials_env_override_resolution);
+    suite_add_tcase(s, tc_resolution);
 
     // Check if required environment variables are set
     // Note: Session token can be empty if permanent credentials are used


### PR DESCRIPTION
*Issue #, if available:*
- N/A (internal incident: cross-region kvssink region resolution)

*What was changed?*
- Added two opt-in boolean `kvssink` GStreamer properties, both defaulting to `false`:
  - `ignore-region-env` — ignore `AWS_DEFAULT_REGION` and always use the `aws-region` property.
  - `ignore-credentials-env` — ignore `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` and always use the `access-key` / `secret-key` / `session-token` properties.
- Added a warning log when `AWS_DEFAULT_REGION` overrides an explicitly-set `aws-region`.
- Documented both properties and the env-var precedence / region lookup order in the README section.

*Why was it changed?*
- `AWS_DEFAULT_REGION` environment variable can override the `aws-region` property. This is documented behavior (env wins by default), not an SDK defect, but consumers had no way to pin region/credentials to the pipeline configuration. These properties let a pipeline opt into ignoring the env fallback so production configuration can't be changed by earlier elements in the resolution chain.

*How was it changed?*
- Added the two properties (struct fields, enum, install, set/get, defaults) in `gstkvssink`.
- Snapshotted the AWS env vars once, up front, so resolution reads a single consistent view rather than calling `getenv` repeatedly.
- Extracted the precedence decision into pure helpers `resolveRegion` / `shouldUseCredentialsEnv` in `KvsSinkUtil` so it can be unit tested directly; defaults preserve existing env-wins behavior.

*What testing was done for the changes?*
- Added table-driven unit tests (`gstkvsplugintest`, `EnvOverrideResolution` suite) covering the full region lookup matrix — env-overrides-property, property-when-env-unset, the `us-west-2` fallback when neither is set, and all `ignore-region-env` variants — plus the credential env/ignore matrix and a property round-trip test. These run without AWS credentials.
- Run the new suites from the `build` directory (built with `-DBUILD_GSTREAMER_PLUGIN=ON -DBUILD_TEST=ON`):
  ```bash
  CK_FORK=no GST_PLUGIN_PATH=$(pwd) \
    GST_CHECKS="check_region_env_override_resolution,check_credentials_env_override_resolution,check_ignore_env_properties" \
    ./tst/gstkvsplugintest
  ```
  Result: `Checks: 3, Failures: 0, Errors: 0`.
- Confirmed a clean full `make -j` build, and that `gst-inspect-1.0 kvssink` now lists both new properties:
  ```
  ignore-credentials-env: If true, ignore the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_SESSION_TOKEN environment variables and always use the access-key, secret-key, and session-token properties. By default (false), these environment variables take precedence over the corresponding properties.
                        flags: readable, writable
                        Boolean. Default: false

  ignore-region-env   : If true, ignore the AWS_DEFAULT_REGION environment variable and always use the aws-region property. By default (false), the AWS_DEFAULT_REGION environment variable takes precedence over the aws-region property.
                        flags: readable, writable
                        Boolean. Default: false
  ```
- Confirmed the override warning fires when `AWS_DEFAULT_REGION` overrides an explicitly-set `aws-region` (e.g. `aws-region=us-east-1` with `AWS_DEFAULT_REGION=us-west-1`):
  ```
  export AWS_DEFAULT_REGION=us-west-1
  gst-launch-1.0 videotestsrc num-buffers=1 \
    ! x264enc ! h264parse \
    ! kvssink stream-name="my-stream" aws-region="us-east-1"
  ```

  ```
  [WARN ] [22-07-2026 05:57:43:726.052 UTC] The AWS_DEFAULT_REGION environment variable (us-west-1) is overriding the aws-region property (us-east-1) for my-stream. Set ignore-region-env=true to always use the aws-region property.
  ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
